### PR TITLE
Fix share display, action modals, and deposit history

### DIFF
--- a/src/__tests__/liquidity-logic.test.ts
+++ b/src/__tests__/liquidity-logic.test.ts
@@ -258,31 +258,31 @@ describe('LiquidityPerformance logic', () => {
   describe('pool ownership calculation', () => {
     it('calculates correct ownership percentage', () => {
       const userShares = 100n
-      const totalShares = 1000n
+      const liquidityShares = 1000n
 
-      const poolOwnership = (Number(userShares) / Number(totalShares)) * 100
+      const poolOwnership = (Number(userShares) / Number(liquidityShares)) * 100
       expect(poolOwnership).toBe(10)
     })
 
     it('returns 0 when pool has no shares', () => {
-      const totalShares = 0n
-      const poolOwnership = totalShares === 0n ? 0 : 50
+      const liquidityShares = 0n
+      const poolOwnership = liquidityShares === 0n ? 0 : 50
       expect(poolOwnership).toBe(0)
     })
 
     it('returns 100% for sole depositor', () => {
       const userShares = 500n
-      const totalShares = 500n
+      const liquidityShares = 500n
 
-      const poolOwnership = (Number(userShares) / Number(totalShares)) * 100
+      const poolOwnership = (Number(userShares) / Number(liquidityShares)) * 100
       expect(poolOwnership).toBe(100)
     })
 
     it('handles fractional ownership', () => {
       const userShares = 1n
-      const totalShares = 3n
+      const liquidityShares = 3n
 
-      const poolOwnership = (Number(userShares) / Number(totalShares)) * 100
+      const poolOwnership = (Number(userShares) / Number(liquidityShares)) * 100
       expect(poolOwnership).toBeCloseTo(33.33, 1)
     })
   })
@@ -411,25 +411,26 @@ describe('LiquidityPerformance logic', () => {
   describe('hasPosition logic', () => {
     it('returns true when user has principal', () => {
       const userStatus = parseUserStatus([0n, 0n, 1000n, 0n, 0n, 0n, 0n])
-      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.totalShares > 0n
+      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.liquidityShares > 0n
       expect(hasPosition).toBe(true)
     })
 
     it('returns true when user has shares but no principal', () => {
       const userStatus = parseUserStatus([100n, 0n, 0n, 0n, 0n, 0n, 0n])
-      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.totalShares > 0n
+      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.liquidityShares > 0n
       expect(hasPosition).toBe(true)
     })
 
     it('returns false when user has neither', () => {
       const userStatus = parseUserStatus([0n, 0n, 0n, 0n, 0n, 0n, 0n])
-      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.totalShares > 0n
+      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.liquidityShares > 0n
       expect(hasPosition).toBe(false)
     })
 
     it('returns true when user only has non-earning shares', () => {
-      const userStatus = parseUserStatus([0n, 100n, 0n, 0n, 0n, 0n, 0n])
-      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.totalShares > 0n || userStatus.totalNonEarningShares > 0n
+      // liquidityShares=100 (total), interestShares=0 (earning), so non-earning=100
+      const userStatus = parseUserStatus([100n, 0n, 0n, 0n, 0n, 0n, 0n])
+      const hasPosition = userStatus.totalPrincipal > 0n || userStatus.liquidityShares > 0n
 
       expect(hasPosition).toBe(true)
     })

--- a/src/__tests__/liquidity-types.test.ts
+++ b/src/__tests__/liquidity-types.test.ts
@@ -15,8 +15,8 @@ describe('liquidity type parsers', () => {
       const raw = [100n, 20n, 500n, 200n, 300n, 50n, 25n] as const
       const result = parseUserStatus(raw)
 
-      expect(result.totalShares).toBe(100n)
-      expect(result.totalNonEarningShares).toBe(20n)
+      expect(result.liquidityShares).toBe(100n)
+      expect(result.interestShares).toBe(20n)
       expect(result.totalPrincipal).toBe(500n)
       expect(result.unlockedPrincipal).toBe(200n)
       expect(result.lockedPrincipal).toBe(300n)
@@ -28,7 +28,7 @@ describe('liquidity type parsers', () => {
       const raw = [0n, 0n, 0n, 0n, 0n, 0n, 0n] as const
       const result = parseUserStatus(raw)
 
-      expect(result.totalShares).toBe(0n)
+      expect(result.liquidityShares).toBe(0n)
       expect(result.totalPrincipal).toBe(0n)
       expect(result.pendingEarnings).toBe(0n)
     })
@@ -38,7 +38,7 @@ describe('liquidity type parsers', () => {
       const raw = [oneThousandTokens, 0n, oneThousandTokens, oneThousandTokens, 0n, 0n, 0n] as const
       const result = parseUserStatus(raw)
 
-      expect(result.totalShares).toBe(oneThousandTokens)
+      expect(result.liquidityShares).toBe(oneThousandTokens)
       expect(result.totalPrincipal).toBe(oneThousandTokens)
     })
 
@@ -49,8 +49,8 @@ describe('liquidity type parsers', () => {
       // Verify structure matches interface
       const keys = Object.keys(result)
       expect(keys).toEqual([
-        'totalShares',
-        'totalNonEarningShares',
+        'liquidityShares',
+        'interestShares',
         'totalPrincipal',
         'unlockedPrincipal',
         'lockedPrincipal',
@@ -63,11 +63,12 @@ describe('liquidity type parsers', () => {
       const raw = [1000n, 200n, 0n, 0n, 0n, 0n, 0n] as const
       const result = parseUserStatus(raw)
 
-      // totalShares should NOT include non-earning
-      expect(result.totalShares).toBe(1000n)
-      expect(result.totalNonEarningShares).toBe(200n)
+      // liquidityShares = total shares (earning + non-earning)
+      expect(result.liquidityShares).toBe(1000n)
+      // interestShares = earning shares only
+      expect(result.interestShares).toBe(200n)
       // These are separate values from contract
-      expect(result.totalShares).not.toBe(result.totalNonEarningShares)
+      expect(result.liquidityShares).not.toBe(result.interestShares)
     })
   })
 
@@ -77,9 +78,9 @@ describe('liquidity type parsers', () => {
       const result = parsePoolStatus(raw)
 
       expect(result.totalPoolValue).toBe(10000n)
-      expect(result.totalShares).toBe(5000n)
-      expect(result.totalNonEarningShares).toBe(500n)
-      expect(result.accumulatedEarningsPerShare).toBe(1000000n)
+      expect(result.totalLiquidityShares).toBe(5000n)
+      expect(result.totalInterestShares).toBe(500n)
+      expect(result.accumulatedEarningsPerInterestShare).toBe(1000000n)
       expect(result.lastEarningsWithdrawal).toBe(1700000000n)
       expect(result.availableEarningsInLoans).toBe(200n)
       expect(result.nextEarningsWithdrawalTime).toBe(1700003600n)
@@ -90,7 +91,7 @@ describe('liquidity type parsers', () => {
       const result = parsePoolStatus(raw)
 
       expect(result.totalPoolValue).toBe(0n)
-      expect(result.totalShares).toBe(0n)
+      expect(result.totalLiquidityShares).toBe(0n)
     })
 
     it('returns correct types for all fields', () => {
@@ -100,9 +101,9 @@ describe('liquidity type parsers', () => {
       const keys = Object.keys(result)
       expect(keys).toEqual([
         'totalPoolValue',
-        'totalShares',
-        'totalNonEarningShares',
-        'accumulatedEarningsPerShare',
+        'totalLiquidityShares',
+        'totalInterestShares',
+        'accumulatedEarningsPerInterestShare',
         'lastEarningsWithdrawal',
         'availableEarningsInLoans',
         'nextEarningsWithdrawalTime',

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -121,13 +121,14 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
   const [transferEarningsModal, setTransferEarningsModal] = useState<TransferModal>(emptyModal)
   const [transferSharesModal, setTransferSharesModal] = useState<TransferModal>(emptyModal)
   const [transferNonEarningSharesModal, setTransferNonEarningSharesModal] = useState<TransferModal>(emptyModal)
+  const [confirmModal, setConfirmModal] = useState<{ open: boolean; title: string; description: string; actionName: string; action: () => Promise<unknown>; successMsg: string }>({ open: false, title: '', description: '', actionName: '', action: async () => {}, successMsg: '' })
 
   const {
     userStatus,
     poolStatus,
     feeConfig,
     liquidityStatus,
-    lockEntries,
+    depositEntries,
     hasPosition,
     totalLoansIssued,
     cumulativeLoanValue,
@@ -149,8 +150,8 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
 
   // Computed values
   const poolOwnership = useMemo(() => {
-    if (!userStatus || !poolStatus || poolStatus.totalShares === 0n) return 0
-    return (Number(userStatus.totalShares) / Number(poolStatus.totalShares)) * 100
+    if (!userStatus || !poolStatus || poolStatus.totalLiquidityShares === 0n) return 0
+    return (Number(userStatus.liquidityShares) / Number(poolStatus.totalLiquidityShares)) * 100
   }, [userStatus, poolStatus])
 
   const lifetimeEarnings = useMemo(() => {
@@ -187,9 +188,9 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     return formatRelativeTime(poolStatus.nextEarningsWithdrawalTime)
   }, [poolStatus])
 
-  const sortedLockEntries = useMemo(() => {
-    return [...lockEntries].sort((a, b) => Number(a.unlockTime - b.unlockTime))
-  }, [lockEntries])
+  const sortedDepositEntries = useMemo(() => {
+    return [...depositEntries].sort((a, b) => Number(a.unlockTime - b.unlockTime))
+  }, [depositEntries])
 
   // Action handlers
   const handleAction = async (
@@ -238,7 +239,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
         />
         <StatItem
           label='Pool Non-Earning Shares'
-          value={poolStatus ? formatCurrency(poolStatus.totalNonEarningShares, decimals, symbol) : 'Loading...'}
+          value={poolStatus ? formatCurrency(poolStatus.totalLiquidityShares - poolStatus.totalInterestShares, decimals, symbol) : 'Loading...'}
         />
         {liquidityStatus && liquidityStatus.principalForfeited > 0n && (
           <StatItem
@@ -277,7 +278,14 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
             size='sm'
             variant='outline'
             onClick={() =>
-              handleAction('Distribute', () => pullEarnings(), 'Earnings distributed to the pool.')
+              setConfirmModal({
+                open: true,
+                title: 'Distribute Earnings',
+                description: 'This will pull earned interest from the Loans contract into the liquidity pool, making it available for all depositors to claim. Anyone can trigger this action.',
+                actionName: 'Distribute',
+                action: () => pullEarnings(),
+                successMsg: 'Earnings distributed to the pool.',
+              })
             }
             disabled={isProcessing !== null}
           >
@@ -357,14 +365,14 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
             />
             <StatItem
               label='Earning Shares'
-              value={userStatus ? formatCurrency(userStatus.totalShares, decimals, symbol) : '0'}
+              value={userStatus ? formatCurrency(userStatus.interestShares, decimals, symbol) : '0'}
             />
             <StatItem
               label='Non-Earning Shares'
-              value={userStatus ? formatCurrency(userStatus.totalNonEarningShares, decimals, symbol) : '0'}
+              value={userStatus ? formatCurrency(userStatus.liquidityShares - userStatus.interestShares, decimals, symbol) : '0'}
             />
           </div>
-          {userStatus && userStatus.totalShares > 0n && (
+          {userStatus && userStatus.interestShares > 0n && (
             <div className='flex items-start gap-4 pt-2'>
               <Button
                 size='sm'
@@ -381,7 +389,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
               </p>
             </div>
           )}
-          {userStatus && userStatus.totalNonEarningShares > 0n && (
+          {userStatus && (userStatus.liquidityShares - userStatus.interestShares) > 0n && (
             <div className='flex items-start gap-4 pt-2'>
               <Button
                 size='sm'
@@ -442,7 +450,14 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
                   variant='outline'
                   className='shrink-0'
                   onClick={() =>
-                    handleAction('Claim', () => claimEarnings(), 'Earnings claimed successfully.')
+                    setConfirmModal({
+                      open: true,
+                      title: 'Claim Earnings',
+                      description: `Your pending earnings of ${formatCurrency(userStatus.pendingEarnings, decimals, symbol)} will be transferred directly to your wallet.${earningsFeePct ? ` A ${earningsFeePct}% fee will be deducted.` : ''}`,
+                      actionName: 'Claim',
+                      action: () => claimEarnings(),
+                      successMsg: 'Earnings claimed successfully.',
+                    })
                   }
                   disabled={isProcessing !== null}
                 >
@@ -462,7 +477,14 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
                   variant='outline'
                   className='shrink-0'
                   onClick={() =>
-                    handleAction('Compound', () => compoundEarnings(lockDuration ?? 0n), 'Earnings compounded into new shares.')
+                    setConfirmModal({
+                      open: true,
+                      title: 'Compound Earnings',
+                      description: `Your pending earnings of ${formatCurrency(userStatus.pendingEarnings, decimals, symbol)} will be deposited back into the pool as new shares. The compounded amount will be subject to a new ${lockDurationLabel} lock period.`,
+                      actionName: 'Compound',
+                      action: () => compoundEarnings(lockDuration ?? 0n),
+                      successMsg: 'Earnings compounded into new shares.',
+                    })
                   }
                   disabled={isProcessing !== null}
                 >
@@ -507,25 +529,27 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
 
         <div className='border-t' />
 
-        {/* 5. Lock Schedule */}
+        {/* 5. Deposit History */}
         <div className='space-y-3'>
           <h3 className='text-sm font-semibold flex items-center gap-2'>
-            <Clock className='h-4 w-4' /> Lock Schedule
+            <Clock className='h-4 w-4' /> Deposit History
           </h3>
-          {sortedLockEntries.length > 0 ? (
+          {sortedDepositEntries.length > 0 ? (
             <div className='space-y-2'>
-              <div className='grid grid-cols-3 text-xs font-medium text-muted-foreground pb-1 border-b'>
+              <div className='grid grid-cols-4 text-xs font-medium text-muted-foreground pb-1 border-b'>
                 <span>Deposit Amount</span>
+                <span>Lock Duration</span>
                 <span>Unlock Date</span>
                 <span>Status</span>
               </div>
-              {sortedLockEntries.map((entry, index) => {
+              {sortedDepositEntries.map((entry, index) => {
                 const now = BigInt(Math.floor(Date.now() / 1000))
                 const isUnlocked = entry.unlockTime <= now
 
                 return (
-                  <div key={index} className='grid grid-cols-3 items-center text-sm py-2 border-b border-border/50'>
-                    <span>{formatCurrency(entry.amount, decimals, symbol)}</span>
+                  <div key={index} className='grid grid-cols-4 items-center text-sm py-2 border-b border-border/50'>
+                    <span>{formatCurrency(entry.stableTokenValue, decimals, symbol)}</span>
+                    <span>{formatDuration(entry.lockDuration)}</span>
                     <span>{formatDate(entry.unlockTime)}</span>
                     <div>
                       {isUnlocked ? (
@@ -543,7 +567,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
               })}
             </div>
           ) : (
-            <p className='text-sm text-muted-foreground'>No lock entries found.</p>
+            <p className='text-sm text-muted-foreground'>No deposit entries found.</p>
           )}
 
         </div>
@@ -685,7 +709,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
                   onClick={() =>
                     setTransferSharesModal((m) => ({
                       ...m,
-                      amount: formatTokenAmount(userStatus.totalShares, decimals),
+                      amount: formatTokenAmount(userStatus.interestShares, decimals),
                     }))
                   }
                 >
@@ -695,7 +719,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
             </div>
             {userStatus && (
               <p className='text-xs text-muted-foreground'>
-                Available: {formatCurrency(userStatus.totalShares, decimals, symbol)}
+                Available: {formatCurrency(userStatus.interestShares, decimals, symbol)}
               </p>
             )}
           </div>
@@ -726,6 +750,40 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
               <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Transferring...</>
             ) : (
               'Confirm Transfer'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    {/* Confirmation Modal */}
+    <Dialog
+      open={confirmModal.open}
+      onOpenChange={(open) => !open && setConfirmModal((m) => ({ ...m, open: false }))}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{confirmModal.title}</DialogTitle>
+        </DialogHeader>
+        <div className='py-2'>
+          <p className='text-sm text-muted-foreground'>{confirmModal.description}</p>
+        </div>
+        <DialogFooter>
+          <Button variant='outline' onClick={() => setConfirmModal((m) => ({ ...m, open: false }))}>
+            Cancel
+          </Button>
+          <Button
+            disabled={isProcessing !== null}
+            onClick={async () => {
+              const { actionName, action, successMsg } = confirmModal
+              setConfirmModal((m) => ({ ...m, open: false }))
+              await handleAction(actionName, action, successMsg)
+            }}
+          >
+            {isProcessing === confirmModal.actionName ? (
+              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Processing...</>
+            ) : (
+              'Confirm'
             )}
           </Button>
         </DialogFooter>
@@ -776,7 +834,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
                   onClick={() =>
                     setTransferNonEarningSharesModal((m) => ({
                       ...m,
-                      amount: formatTokenAmount(userStatus.totalNonEarningShares, decimals),
+                      amount: formatTokenAmount(userStatus.liquidityShares - userStatus.interestShares, decimals),
                     }))
                   }
                 >
@@ -786,7 +844,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
             </div>
             {userStatus && (
               <p className='text-xs text-muted-foreground'>
-                Available: {formatCurrency(userStatus.totalNonEarningShares, decimals, symbol)}
+                Available: {formatCurrency(userStatus.liquidityShares - userStatus.interestShares, decimals, symbol)}
               </p>
             )}
           </div>

--- a/src/hooks/liquidity/useLiquidityData.ts
+++ b/src/hooks/liquidity/useLiquidityData.ts
@@ -19,6 +19,7 @@ import type {
   UserStatus,
   PoolStatus,
   LockEntry,
+  DepositEntry,
   FeeConfig,
   LiquidityStatus,
   WithdrawalRequest,
@@ -28,11 +29,17 @@ export interface UseLiquidityDataReturn {
   // User data
   userStatus: UserStatus | undefined
   lockEntries: LockEntry[]
+  depositEntries: DepositEntry[]
   hasPosition: boolean
 
   // Pool data
   poolStatus: PoolStatus | undefined
   feeConfig: FeeConfig | undefined
+
+  // Pool reads
+  currentUtilization: bigint | undefined
+  totalCommittedStableToken: bigint | undefined
+  acceptableLiquidityAmount: bigint | undefined
 
   // Loans contract data
   liquidityStatus: LiquidityStatus | undefined
@@ -213,6 +220,33 @@ export function useLiquidityData(): UseLiquidityDataReturn {
     query: { enabled: !!address, refetchInterval: 5000 },
   })
 
+  // Additional pool reads
+  const {
+    data: currentUtilizationRaw,
+  } = useReadContract({
+    address: liquidityPoolContractAddress,
+    abi: liquidityPoolAbi as unknown as any[],
+    functionName: 'getCurrentUtilization',
+    query: { refetchInterval: 10000 },
+  })
+
+  const {
+    data: totalCommittedStableTokenRaw,
+  } = useReadContract({
+    address: liquidityPoolContractAddress,
+    abi: liquidityPoolAbi as unknown as any[],
+    functionName: 'totalCommittedStableToken',
+  })
+
+  const {
+    data: acceptableLiquidityAmountRaw,
+  } = useReadContract({
+    address: liquidityPoolContractAddress,
+    abi: liquidityPoolAbi as unknown as any[],
+    functionName: 'getAcceptableLiquidityAmount',
+    query: { refetchInterval: 10000 },
+  })
+
   // Parse data
   const userStatus = useMemo(() => {
     if (!userStatusRaw) return undefined
@@ -246,6 +280,19 @@ export function useLiquidityData(): UseLiquidityDataReturn {
     }))
   }, [depositEntriesRaw])
 
+  const depositEntries = useMemo((): DepositEntry[] => {
+    if (!depositEntriesRaw) return []
+    return (depositEntriesRaw as any[]).map((entry: any) => ({
+      token: entry.token as `0x${string}`,
+      tokenAmount: entry.tokenAmount as bigint,
+      stableTokenValue: entry.stableTokenValue as bigint,
+      liquidityShares: entry.liquidityShares as bigint,
+      interestShares: entry.interestShares as bigint,
+      unlockTime: entry.unlockTime as bigint,
+      lockDuration: entry.lockDuration as bigint,
+    }))
+  }, [depositEntriesRaw])
+
   const withdrawalRequests = useMemo(() => {
     if (!withdrawalRequestsRaw) return { requestIds: [], requests: [] }
     const [ids, reqs] = withdrawalRequestsRaw as unknown as readonly [readonly bigint[], readonly {
@@ -271,7 +318,7 @@ export function useLiquidityData(): UseLiquidityDataReturn {
 
   const hasPosition = useMemo(() => {
     if (!userStatus) return false
-    return userStatus.totalPrincipal > 0n || userStatus.totalShares > 0n || userStatus.totalNonEarningShares > 0n
+    return userStatus.totalPrincipal > 0n || userStatus.liquidityShares > 0n
   }, [userStatus])
 
   // Combined states
@@ -312,9 +359,13 @@ export function useLiquidityData(): UseLiquidityDataReturn {
   return {
     userStatus,
     lockEntries,
+    depositEntries,
     hasPosition,
     poolStatus,
     feeConfig,
+    currentUtilization: currentUtilizationRaw as bigint | undefined,
+    totalCommittedStableToken: totalCommittedStableTokenRaw as bigint | undefined,
+    acceptableLiquidityAmount: acceptableLiquidityAmountRaw as bigint | undefined,
     liquidityStatus,
     totalLoansIssued,
     cumulativeLoanValue,

--- a/src/types/liquidity.ts
+++ b/src/types/liquidity.ts
@@ -1,8 +1,8 @@
 // Types matching LiquidityPool and Loans contract return values
 
 export interface UserStatus {
-  totalShares: bigint
-  totalNonEarningShares: bigint
+  liquidityShares: bigint    // data[0] - total shares (earning + non-earning)
+  interestShares: bigint     // data[1] - earning shares only
   totalPrincipal: bigint
   unlockedPrincipal: bigint
   lockedPrincipal: bigint
@@ -12,9 +12,9 @@ export interface UserStatus {
 
 export interface PoolStatus {
   totalPoolValue: bigint
-  totalShares: bigint
-  totalNonEarningShares: bigint
-  accumulatedEarningsPerShare: bigint
+  totalLiquidityShares: bigint    // data[1]
+  totalInterestShares: bigint     // data[2]
+  accumulatedEarningsPerInterestShare: bigint
   lastEarningsWithdrawal: bigint
   availableEarningsInLoans: bigint
   nextEarningsWithdrawalTime: bigint
@@ -23,6 +23,16 @@ export interface PoolStatus {
 export interface LockEntry {
   amount: bigint
   unlockTime: bigint
+}
+
+export interface DepositEntry {
+  token: `0x${string}`
+  tokenAmount: bigint
+  stableTokenValue: bigint
+  liquidityShares: bigint
+  interestShares: bigint
+  unlockTime: bigint
+  lockDuration: bigint
 }
 
 export interface WithdrawalRequest {
@@ -60,8 +70,8 @@ export interface LiquidityStatus {
 
 export function parseUserStatus(data: readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint]): UserStatus {
   return {
-    totalShares: data[0],
-    totalNonEarningShares: data[1],
+    liquidityShares: data[0],
+    interestShares: data[1],
     totalPrincipal: data[2],
     unlockedPrincipal: data[3],
     lockedPrincipal: data[4],
@@ -73,9 +83,9 @@ export function parseUserStatus(data: readonly [bigint, bigint, bigint, bigint, 
 export function parsePoolStatus(data: readonly [bigint, bigint, bigint, bigint, bigint, bigint, bigint]): PoolStatus {
   return {
     totalPoolValue: data[0],
-    totalShares: data[1],
-    totalNonEarningShares: data[2],
-    accumulatedEarningsPerShare: data[3],
+    totalLiquidityShares: data[1],
+    totalInterestShares: data[2],
+    accumulatedEarningsPerInterestShare: data[3],
     lastEarningsWithdrawal: data[4],
     availableEarningsInLoans: data[5],
     nextEarningsWithdrawalTime: data[6],


### PR DESCRIPTION
## Summary
- Fix Earning/Non-Earning shares display (was backwards)
- Add confirmation modals for Distribute, Claim, and Compound actions
- Rename Lock Schedule to Deposit History with full entry details
- Add pool utilization, committed stable token, and acceptable liquidity reads

## Test plan
- [x] TypeScript: 0 errors
- [x] Tests: 93/93 pass
- [ ] Manual: verify share counts match expected (earning vs non-earning)
- [ ] Manual: test Distribute/Claim/Compound modal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)