### PR TITLE
Fix: sticky header and floor available balance display

### DIFF
--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -162,7 +162,7 @@ export function LoanParameters({
               </span>
               <span>
                 {availableLiquidity !== undefined
-                  ? `$${Number(formatUnits(availableLiquidity, tokenConfig?.loanToken.decimals || 18)).toLocaleString(undefined, { maximumFractionDigits: 0 })} available`
+                  ? `$${Math.floor(Number(formatUnits(availableLiquidity, tokenConfig?.loanToken.decimals || 18))).toLocaleString()} available`
                   : 'Loading liquidity...'}
               </span>
             </div>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
   const pathname = usePathname()
 
   return (
-    <div className='flex items-center justify-center w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'>
+    <div className='sticky top-0 z-50 flex items-center justify-center w-full border-b border-border/40 bg-background'>
       <header className='flex items-center justify-between p-4 min-w-full max-w-screen-xl'>
         <div className='flex items-center space-x-3'>
           <Link href='/' className='flex items-center space-x-3'>


### PR DESCRIPTION
## Summary
- Make the site header sticky (`top-0`, `z-50`) with a solid background so it remains visible while scrolling
- Floor the available liquidity amount shown in the loan calculator so users can safely enter the displayed value without the loan being rejected

## Test plan
- [ ] Scroll down on Loans and Liquidity pages — header stays pinned at the top
- [ ] Confirm available balance shows a floored integer (no rounding up)
- [ ] Enter the exact displayed available amount and verify loan creation proceeds without a liquidity error

🤖 Generated with [Claude Code](https://claude.com/claude-code)