### PR TITLE
feat: multi-collateral selector + dynamic protocol addresses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,15 @@
 # WalletConnect Cloud project ID — https://cloud.walletconnect.com/
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 
-# LemonChain mainnet contract addresses
+# LemonChain mainnet: only the Loans contract is needed.
+# CollateralManager, LiquidityPool, and SwapManager are discovered on-chain:
+#   CollateralManager = Loans.collateralManager()
+#   LiquidityPool     = Loans.liquidityPool()
+#   SwapManager       = LiquidityPool.swapManager()
 NEXT_PUBLIC_LEMON_LOANS_ADDRESS=
-NEXT_PUBLIC_LEMON_LIQUIDITY_POOL_ADDRESS=
 
-# Citron testnet contract addresses (required when NEXT_PUBLIC_INCLUDE_TESTNET=true)
+# Citron testnet (required when NEXT_PUBLIC_INCLUDE_TESTNET=true)
 NEXT_PUBLIC_CITRON_LOANS_ADDRESS=
-NEXT_PUBLIC_CITRON_LIQUIDITY_POOL_ADDRESS=
-NEXT_PUBLIC_CITRON_SWAP_MANAGER_ADDRESS=
 
 # Set to "true" to include Citron testnet in the wallet network list
 NEXT_PUBLIC_INCLUDE_TESTNET=false

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ All variables must be prefixed `NEXT_PUBLIC_` to be available in the browser.
 |---|---|---|
 | `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` | Yes | WalletConnect Cloud project ID |
 | `NEXT_PUBLIC_LEMON_LOANS_ADDRESS` | Yes | Loans contract address on LemonChain mainnet |
-| `NEXT_PUBLIC_LEMON_LIQUIDITY_POOL_ADDRESS` | Yes | LiquidityPool contract address on LemonChain mainnet |
 | `NEXT_PUBLIC_CITRON_LOANS_ADDRESS` | Testnet only | Loans contract address on Citron testnet |
-| `NEXT_PUBLIC_CITRON_LIQUIDITY_POOL_ADDRESS` | Testnet only | LiquidityPool contract address on Citron testnet |
-| `NEXT_PUBLIC_CITRON_SWAP_MANAGER_ADDRESS` | Testnet only | SwapManager contract address on Citron testnet |
 | `NEXT_PUBLIC_INCLUDE_TESTNET` | No | Set to `true` to include Citron testnet in the wallet network list |
+
+Only the Loans contract address is required per chain. The rest of the protocol contracts (`CollateralManager`, `LiquidityPool`, `SwapManager`) are discovered on-chain at app load via `Loans.collateralManager()`, `Loans.liquidityPool()`, and `LiquidityPool.swapManager()`.
 
 Copy `.env.example` to `.env` and fill in the values. Never commit `.env` — it is gitignored.
 
@@ -46,8 +45,7 @@ For Cloudflare Pages deployments, secrets must be set via the Wrangler CLI rathe
 ```bash
 npx wrangler pages secret put NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID --project-name=loans-dapp
 npx wrangler pages secret put NEXT_PUBLIC_LEMON_LOANS_ADDRESS --project-name=loans-dapp
-npx wrangler pages secret put NEXT_PUBLIC_LEMON_LIQUIDITY_POOL_ADDRESS --project-name=loans-dapp
-# Repeat for remaining NEXT_PUBLIC_* variables
+# And, for testnet builds, NEXT_PUBLIC_CITRON_LOANS_ADDRESS
 ```
 
 Non-sensitive public variables can alternatively be set in `wrangler.toml` under `[vars]`.

--- a/docs/mainnet-setup.md
+++ b/docs/mainnet-setup.md
@@ -20,24 +20,27 @@ This matters most for reflection/SafeMoon-style tokens, which take fees by defau
 
 ## Step 1 — Set environment variables
 
-Add the deployed contract addresses and your WalletConnect project ID to `.env` (or Cloudflare Pages secrets — see README):
+Only the Loans contract address is required per chain. The rest of the protocol addresses are discovered on-chain at app load:
+
+- `CollateralManager` ← `Loans.collateralManager()`
+- `LiquidityPool` ← `Loans.liquidityPool()`
+- `SwapManager` ← `LiquidityPool.swapManager()`
+
+Add the following to `.env` (or Cloudflare Pages secrets — see README):
 
 ```
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=...
 NEXT_PUBLIC_LEMON_LOANS_ADDRESS=0x...
-NEXT_PUBLIC_LEMON_LIQUIDITY_POOL_ADDRESS=0x...
-NEXT_PUBLIC_LEMON_COLLATERAL_MANAGER_ADDRESS=0x...
 NEXT_PUBLIC_CITRON_LOANS_ADDRESS=0x...            # testnet only
-NEXT_PUBLIC_CITRON_LIQUIDITY_POOL_ADDRESS=0x...   # testnet only
-NEXT_PUBLIC_CITRON_COLLATERAL_MANAGER_ADDRESS=0x...# testnet only
-NEXT_PUBLIC_CITRON_SWAP_MANAGER_ADDRESS=0x...     # testnet only
 ```
 
-Then rebuild so `wagmi generate` picks up the new addresses:
+Then rebuild so `wagmi generate` picks up the new Loans address:
 
 ```bash
 npm run build
 ```
+
+> Make sure the on-chain wiring in Steps 3 and 9 is correct before deploying — if `Loans.collateralManager()` or `Loans.liquidityPool()` return the zero address the UI will not be able to read anything downstream.
 
 ---
 
@@ -342,7 +345,7 @@ Run through this before opening to users. Repeat the asset-specific rows for eve
 
 | # | Check | How to verify | Expected result |
 |---|---|---|---|
-| 1 | Environment variables set | `.env` / Cloudflare secrets | All `NEXT_PUBLIC_*` vars populated, including `*_COLLATERAL_MANAGER_ADDRESS` |
+| 1 | Environment variables set | `.env` / Cloudflare secrets | `NEXT_PUBLIC_*_LOANS_ADDRESS` populated; all other contract addresses come from on-chain reads |
 | 2 | Build passes | `npm run build` | No errors |
 | 3 | SwapManager wired | `LiquidityPool.swapManager()` | SwapManager address |
 | 4 | CollateralManager wired | Loans/CollateralManager reference each other, PriceHelper set | Successful `initiateLoan` |

--- a/docs/qa-checklist.md
+++ b/docs/qa-checklist.md
@@ -1,0 +1,99 @@
+# QA Checklist — CollateralManager branch
+
+Scoped to the ABI upgrades on `loans-collateral-manager`. Run through each section top-to-bottom on Citron testnet.
+
+## 0. Prep
+
+- [ ] `.env` has `NEXT_PUBLIC_CITRON_COLLATERAL_MANAGER_ADDRESS` set
+- [ ] `npm run build` passes
+- [ ] Fresh dev server — `.next` cleared, `npm run dev`, hard refresh the browser
+- [ ] Wallet connected on Citron, has LUSD (loan token), LMLN (fee), and WLEMX (collateral)
+
+## 1. CollateralManager reads
+
+- [ ] Loan calculator page loads with no red errors in the browser console
+- [ ] APR slider/display shows a sensible number (not 0%, not "...") — confirms `getAllInterestAprConfigs(WLEMX)` returned
+- [ ] LTV slider shows multiple options (20/30/40/…%) — confirms `getAllOriginationFees(WLEMX)` returned
+- [ ] "Collateral Required" in the summary shows **WLEMX** as the symbol (not LEMON/LEMX)
+
+## 2. Loan creation — fresh wallet flow
+
+Start with zero allowance on both LMLN and WLEMX.
+
+- [ ] Click Create Loan → confirmation modal opens
+- [ ] Approval checklist shows three steps; **only** step 1 is bold (steps 2 & 3 are greyed/struck-through)
+- [ ] Step 1 button reads **Approve WLEMX**; click it, confirm in wallet
+- [ ] After success, step 1 becomes struck-through and step 2 becomes bold
+- [ ] Step 2 button reads **Approve LMLN Fee**; click it, confirm in wallet
+- [ ] After success, step 2 becomes struck-through, button switches to **Confirm & Create Loan**
+- [ ] Click Create Loan, confirm in wallet — transaction does NOT revert with `BEP20: transfer amount + fees exceeds balance`
+- [ ] New loan appears in Active Loans with correct amount, duration, LTV
+
+## 3. Loan creation — edge cases
+
+- [ ] Mouse-wheel scrolling over the **How much do you need?** input does NOT change the value (input blurs)
+- [ ] Entering an amount below the minimum shows the red-bordered input and error text
+- [ ] Reopening the modal on a partially-approved loan (e.g. WLEMX approved but not LMLN) skips step 1 correctly
+- [ ] Cancelling wallet prompt on step 1 closes modal cleanly; no stuck loading state
+
+## 4. Active loan display
+
+Pick a brand-new loan created from step 2.
+
+- [ ] **Collateral** cell shows WLEMX (not LEMON/LEMX)
+- [ ] **Cycles Transpired** reads `0/N` on a brand-new loan, not `1/N`
+- [ ] Countdown label reads **Time Until Default** — NOT "Overdue" on creation
+- [ ] Countdown value is positive and counts down
+- [ ] Progress bar advances proportionally as cycle time passes
+
+## 5. Loan payment
+
+- [ ] Click **Make Payment** → dialog opens
+- [ ] "Pay minimum payment" amount displays as expected (may be $0.10 for tiny testnet loans — that's rounding, not a bug)
+- [ ] Approve LUSD for the payment amount, then Confirm Payment
+- [ ] Paid amount increments, remaining balance decrements
+- [ ] Progress bar advances
+- [ ] After paying all cycles + principal → status flips to **UNLOCKED** and **Withdraw Collateral** button appears
+
+## 6. Loan states past maturity
+
+Let a short-cycle loan sit until it passes its end date without being paid off.
+
+- [ ] **Cycles Transpired** caps at `N/N` (does not show `4/3`, `5/3`, etc.)
+- [ ] Countdown label switches to **Overdue** after the cycle-long warning buffer elapses
+- [ ] "Payment overdue" banner appears
+- [ ] Loan status still ACTIVE until contract default triggers
+
+## 7. Collateral withdrawal
+
+After a loan reaches UNLOCKED.
+
+- [ ] Click **Withdraw Collateral** → confirmation modal shows **WLEMX** symbol and correct amount
+- [ ] Confirm in wallet, tx succeeds
+- [ ] Loan moves out of Active Loans; WLEMX balance increases by the collateral amount
+
+## 8. Loan extension
+
+- [ ] Click **Extend Loan** on an active loan
+- [ ] Extension dialog shows the extension fee in **LMLN** with gross-up-friendly amount
+- [ ] If LMLN allowance insufficient → **Approve LMLN** button appears first
+- [ ] After approval, **Confirm Extension** works
+- [ ] New due date on the card reflects the extension
+
+## 9. Loan history
+
+- [ ] Completed/defaulted loans in history show **total paid** in the loan token symbol (LUSD), not LEMX
+- [ ] Collateral amounts on history cards show the correct collateral token symbol
+
+## 10. Regression sanity
+
+- [ ] Liquidity page still loads (deposits, withdrawals, earnings unchanged)
+- [ ] No console errors about missing `collateralTokenDecimals`, `collateralWithdrawn`, or `relockLiquidity`
+- [ ] Dashboard pricing display still renders (pricing hook still works)
+
+---
+
+**If anything above fails, capture:**
+- Loan ID (copy from the card)
+- Browser console output
+- Wallet transaction hash (if a tx was submitted)

--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -23,7 +23,7 @@ interface LoanParametersProps {
   availableLiquidity?: bigint
   supportedCollateralTokens: CollateralTokenInfo[]
   selectedCollateral: CollateralTokenInfo | undefined
-  setSelectedCollateral: (token: CollateralTokenInfo) => void
+  setSelectedCollateral: (token: CollateralTokenInfo | undefined) => void
   isDashboard?: boolean
 }
 
@@ -46,8 +46,9 @@ export function LoanParameters({
   setSelectedCollateral,
   isDashboard = false
 }: LoanParametersProps) {
-  const hasMultipleCollateral = supportedCollateralTokens.length > 1
-  const needsCollateralChoice = hasMultipleCollateral && !selectedCollateral
+  // Always show the selector — the user must pick, even if only one token is configured.
+  const hasCollateralOptions = supportedCollateralTokens.length > 0
+  const needsCollateralChoice = hasCollateralOptions && !selectedCollateral
   // Use pre-calculated duration range from the hook
   const minDuration = durationRange.min
   const maxDuration = durationRange.max
@@ -95,8 +96,8 @@ export function LoanParameters({
         </CardTitle>
       </CardHeader>
       <CardContent className='space-y-6'>
-        {/* Collateral Token Selector — only shown when more than one is configured */}
-        {hasMultipleCollateral && (
+        {/* Collateral Token Selector — always required; the user must pick before the rest of the form is usable */}
+        {hasCollateralOptions && (
           <div>
             <label
               className={`block text-sm font-medium ${!isDashboard ? 'text-gray-300' : ''} mb-2`}

--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { formatUnits } from 'viem'
 import { formatPercentage, formatDurationRange } from '../../utils/decimals'
 import { formatDuration } from '../../utils/format'
+import type { CollateralTokenInfo } from '../../hooks/useCollateralManager'
 
 interface LoanParametersProps {
   loanAmount: number
@@ -20,6 +21,9 @@ interface LoanParametersProps {
   durationRange: { min: number; max: number }
   configLoading: boolean
   availableLiquidity?: bigint
+  supportedCollateralTokens: CollateralTokenInfo[]
+  selectedCollateral: CollateralTokenInfo | undefined
+  setSelectedCollateral: (token: CollateralTokenInfo) => void
   isDashboard?: boolean
 }
 
@@ -37,8 +41,13 @@ export function LoanParameters({
   durationRange,
   configLoading,
   availableLiquidity,
+  supportedCollateralTokens,
+  selectedCollateral,
+  setSelectedCollateral,
   isDashboard = false
 }: LoanParametersProps) {
+  const hasMultipleCollateral = supportedCollateralTokens.length > 1
+  const needsCollateralChoice = hasMultipleCollateral && !selectedCollateral
   // Use pre-calculated duration range from the hook
   const minDuration = durationRange.min
   const maxDuration = durationRange.max
@@ -86,6 +95,49 @@ export function LoanParameters({
         </CardTitle>
       </CardHeader>
       <CardContent className='space-y-6'>
+        {/* Collateral Token Selector — only shown when more than one is configured */}
+        {hasMultipleCollateral && (
+          <div>
+            <label
+              className={`block text-sm font-medium ${!isDashboard ? 'text-gray-300' : ''} mb-2`}
+            >
+              🪙 Choose your collateral token
+            </label>
+            <div className='flex flex-wrap gap-2'>
+              {supportedCollateralTokens.map((token) => {
+                const isSelected =
+                  selectedCollateral?.address.toLowerCase() ===
+                  token.address.toLowerCase()
+                return (
+                  <button
+                    key={token.address}
+                    type='button'
+                    onClick={() => setSelectedCollateral(token)}
+                    className={`px-4 py-2 rounded-md text-sm font-medium border transition-colors ${
+                      isSelected
+                        ? !isDashboard
+                          ? 'bg-yellow-400 border-yellow-400 text-black'
+                          : 'bg-primary border-primary text-primary-foreground'
+                        : !isDashboard
+                          ? 'bg-white/10 border-white/20 text-white hover:bg-white/20'
+                          : 'bg-muted border-border text-foreground hover:bg-accent'
+                    }`}
+                  >
+                    {token.symbol}
+                  </button>
+                )
+              })}
+            </div>
+            {needsCollateralChoice && (
+              <p
+                className={`text-sm mt-2 ${!isDashboard ? 'text-yellow-300' : 'text-muted-foreground'}`}
+              >
+                Select a collateral token to see APR and LTV options.
+              </p>
+            )}
+          </div>
+        )}
+
         {/* Loan Amount Input */}
         <div>
           <label
@@ -181,9 +233,11 @@ export function LoanParameters({
             <div
               className={`text-sm ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'}`}
             >
-              {configLoading
-                ? 'Loading durations...'
-                : 'No durations available'}
+              {needsCollateralChoice
+                ? 'Select a collateral token first.'
+                : configLoading
+                  ? 'Loading durations...'
+                  : 'No durations available'}
             </div>
           ) : (
             <>
@@ -221,9 +275,11 @@ export function LoanParameters({
             <div
               className={`text-sm ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'}`}
             >
-              {configLoading
-                ? 'Loading LTV options...'
-                : 'No LTV options available'}
+              {needsCollateralChoice
+                ? 'Select a collateral token first.'
+                : configLoading
+                  ? 'Loading LTV options...'
+                  : 'No LTV options available'}
             </div>
           ) : (
             <>

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -420,20 +420,13 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
             'Your loan has been created and will appear in your active loans!'
         })
 
-        // Reset inputs to defaults
-        if (initialHookData.loanConfig?.minLoanAmount && tokenConfig) {
-          setLoanAmount(
-            Number(formatUnits(initialHookData.loanConfig.minLoanAmount, tokenConfig.loanToken.decimals))
-          )
-        }
-        if (initialHookData.durationRange.min > 0) {
-          setDuration(initialHookData.durationRange.min)
-        }
-        if (perAssetConfig.ltvOptions.length > 0 && tokenConfig) {
-          setLtv(
-            Number(formatPercentage(perAssetConfig.ltvOptions[0].ltv, tokenConfig.ltvDecimals))
-          )
-        }
+        // Full reset \u2014 force the user to re-pick collateral and re-enter loan terms
+        // if they want another loan. Loan amount and duration repopulate to
+        // contract defaults via the init effect; LTV stays 0 until a collateral is picked.
+        setSelectedCollateral(undefined)
+        setLoanAmount(0)
+        setDuration(0)
+        setLtv(0)
       }
     } catch (error) {
       const contractError = error as ContractError

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -121,8 +121,12 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   const { toast } = useToast()
 
   // Collateral manager — auto-selects when only one token is configured.
-  // When multi-collateral ships, pull setSelectedCollateral + supportedCollateralTokens here.
-  const { selectedCollateral } = useCollateralManager()
+  // When multiple are configured, the user must pick via the selector in LoanParameters.
+  const {
+    selectedCollateral,
+    setSelectedCollateral,
+    supportedCollateralTokens
+  } = useCollateralManager()
 
   // Per-asset config (ltvOptions, interestAprConfigs depend on selected collateral)
   const perAssetConfig = useLoanConfig(selectedCollateral?.address)
@@ -158,14 +162,15 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         )
       )
     }
-    if (perAssetConfig.ltvOptions.length > 0 && ltv === 0 && tokenConfig) {
-      const ltvPercentage = Number(
-        formatPercentage(
-          perAssetConfig.ltvOptions[0].ltv,
-          tokenConfig.ltvDecimals
-        )
+    // Snap LTV to the first option for the selected collateral — on first load (ltv===0)
+    // and when the user switches collateral tokens and the current LTV isn't in the new set.
+    if (perAssetConfig.ltvOptions.length > 0 && tokenConfig) {
+      const availableLtvs = perAssetConfig.ltvOptions.map((opt) =>
+        Number(formatPercentage(opt.ltv, tokenConfig.ltvDecimals))
       )
-      setLtv(ltvPercentage)
+      if (ltv === 0 || !availableLtvs.includes(ltv)) {
+        setLtv(availableLtvs[0])
+      }
     }
     if (initialHookData.durationRange.min > 0 && duration === 0) {
       setDuration(initialHookData.durationRange.min)
@@ -478,6 +483,9 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         durationRange={initialHookData.durationRange}
         configLoading={initialHookData.isLoading || perAssetConfig.isLoading}
         availableLiquidity={loanOperations.availableLiquidity}
+        supportedCollateralTokens={supportedCollateralTokens}
+        selectedCollateral={selectedCollateral}
+        setSelectedCollateral={setSelectedCollateral}
         isDashboard={isDashboard}
       />
 

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -6,10 +6,8 @@ import { formatUnits, parseUnits } from 'viem'
 import { useContractTokenConfiguration } from '../../hooks/useContractTokenConfiguration'
 import { useToast } from '../../hooks/use-toast'
 import {
-  parsePercentage,
   formatPercentage,
-  formatTokenAmount,
-  formatDurationRange
+  formatTokenAmount
 } from '../../utils/decimals'
 import { formatDuration } from '../../utils/format'
 import { LoanParameters } from '../calculator/LoanParameters'
@@ -120,8 +118,8 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   const { tokenConfig } = useContractTokenConfiguration()
   const { toast } = useToast()
 
-  // Collateral manager — auto-selects when only one token is configured.
-  // When multiple are configured, the user must pick via the selector in LoanParameters.
+  // Collateral manager — the user always picks explicitly via the selector in LoanParameters,
+  // even when only one token is configured. No auto-selection.
   const {
     selectedCollateral,
     setSelectedCollateral,

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -28,8 +28,7 @@ import {
 } from '@/src/utils/errorHandling'
 import type { UseLiquidityPoolReturn } from '@/src/hooks/liquidity/useLiquidityPool'
 import type { LockDurationTier } from '@/src/types/liquidity'
-import { liquidityPoolAbi, liquidityPoolAddress } from '@/src/generated'
-import { useChainId } from 'wagmi'
+import { liquidityPoolAbi } from '@/src/generated'
 
 function formatLockDuration(duration: bigint): string {
   const s = Number(duration)
@@ -70,9 +69,6 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
   const [selectedTierIndex, setSelectedTierIndex] = useState<number | null>(null)
   const { toast } = useToast()
   const { address } = useAccount()
-  const chainId = useChainId()
-
-  const lpAddress = liquidityPoolAddress[chainId as keyof typeof liquidityPoolAddress]
 
   const {
     stableTokenAddress,
@@ -83,6 +79,9 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
     refetch,
   } = liquidityPool
 
+  // Alias kept for clarity at the read-call sites below
+  const lpAddress = liquidityPoolContractAddress
+
   const stableDecimals = stableTokenDecimals ?? 18
 
   // Read supported assets from the pool
@@ -90,6 +89,7 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
     address: lpAddress,
     abi: liquidityPoolAbi as unknown as any[],
     functionName: 'getSupportedAssets',
+    query: { enabled: !!lpAddress },
   })
   const allAssets = useMemo((): `0x${string}`[] => {
     if (!supportedAssetsRaw) return []

--- a/src/hooks/liquidity/useLiquidityData.ts
+++ b/src/hooks/liquidity/useLiquidityData.ts
@@ -1,15 +1,14 @@
 import { useMemo, useCallback } from 'react'
-import { useAccount, useChainId, useReadContract, usePublicClient } from 'wagmi'
+import { useAccount, useReadContract, usePublicClient } from 'wagmi'
 import { erc20Abi, parseAbiItem } from 'viem'
 import { useQuery } from '@tanstack/react-query'
 import {
-  useReadLiquidityPoolStableToken,
-  liquidityPoolAddress,
   liquidityPoolAbi,
   useReadLoansGetLiquidityStatus,
   useReadLoansTotalLoansIssued,
   useReadLoansCumulativeLoanValue,
 } from '@/src/generated'
+import { useProtocolAddresses } from '@/src/hooks/useProtocolAddresses'
 import {
   parseUserStatus,
   parsePoolStatus,
@@ -81,18 +80,24 @@ const DEPOSITED_EVENT = parseAbiItem(
 
 export function useLiquidityData(): UseLiquidityDataReturn {
   const { address } = useAccount()
-  const chainId = useChainId()
   const publicClient = usePublicClient()
 
-  const liquidityPoolContractAddress =
-    liquidityPoolAddress[chainId as keyof typeof liquidityPoolAddress]
+  // LiquidityPool address is resolved on-chain via Loans.liquidityPool()
+  const { liquidityPool: liquidityPoolContractAddress } = useProtocolAddresses()
 
-  // Get stable token address from LiquidityPool
+  // Get stable token address from LiquidityPool — use useReadContract directly
+  // because the generated hook hits TS deep-instantiation limits when address is overridden.
   const {
-    data: stableTokenAddress,
+    data: stableTokenAddressRaw,
     isLoading: stableTokenLoading,
     error: stableTokenError,
-  } = useReadLiquidityPoolStableToken()
+  } = useReadContract({
+    address: liquidityPoolContractAddress,
+    abi: liquidityPoolAbi as unknown as any[],
+    functionName: 'stableToken',
+    query: { enabled: !!liquidityPoolContractAddress },
+  })
+  const stableTokenAddress = stableTokenAddressRaw as `0x${string}` | undefined
 
   // Get stable token metadata
   const { data: stableTokenSymbol } = useReadContract({

--- a/src/hooks/liquidity/useLiquidityOperations.ts
+++ b/src/hooks/liquidity/useLiquidityOperations.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useAccount, useChainId, usePublicClient, useWriteContract } from 'wagmi'
+import { useAccount, useChainId, usePublicClient, useReadContract, useWriteContract } from 'wagmi'
 import { useQueryClient } from '@tanstack/react-query'
 import { erc20Abi } from 'viem'
 import {
@@ -12,14 +12,12 @@ import {
   useWriteLiquidityPoolClaimWithdrawal,
   useWriteLiquidityPoolFundWithdrawalQueue,
   useWriteLiquidityPoolProcessSwaps,
-  useReadLiquidityPoolDepositFeeUsd,
-  useReadLiquidityPoolWithdrawFeeUsd,
   useReadLoansGetNativeFee,
   loansAddress,
   loansAbi,
-  liquidityPoolAddress,
   liquidityPoolAbi,
 } from '@/src/generated'
+import { useProtocolAddresses } from '@/src/hooks/useProtocolAddresses'
 
 export interface UseLiquidityOperationsReturn {
   deposit: (token: `0x${string}`, amount: bigint, lockDuration: bigint, nonEarning: boolean) => Promise<`0x${string}` | undefined>
@@ -44,9 +42,25 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
   const publicClient = usePublicClient()
   const queryClient = useQueryClient()
 
-  // Native fee reads
-  const { data: depositFeeUSD } = useReadLiquidityPoolDepositFeeUsd()
-  const { data: withdrawFeeUSD } = useReadLiquidityPoolWithdrawFeeUsd()
+  // LiquidityPool address resolved from Loans.liquidityPool()
+  const { liquidityPool: lpAddress } = useProtocolAddresses()
+
+  // Native fee reads — use useReadContract directly to avoid TS deep-instantiation
+  // errors when overriding address on the generated LP hooks.
+  const { data: depositFeeUSDRaw } = useReadContract({
+    address: lpAddress,
+    abi: liquidityPoolAbi as unknown as any[],
+    functionName: 'depositFeeUSD',
+    query: { enabled: !!lpAddress },
+  })
+  const { data: withdrawFeeUSDRaw } = useReadContract({
+    address: lpAddress,
+    abi: liquidityPoolAbi as unknown as any[],
+    functionName: 'withdrawFeeUSD',
+    query: { enabled: !!lpAddress },
+  })
+  const depositFeeUSD = depositFeeUSDRaw as bigint | undefined
+  const withdrawFeeUSD = withdrawFeeUSDRaw as bigint | undefined
 
   // Get native fee conversion: pass USD amount, get native wei amount
   // @ts-ignore - wagmi deep type instantiation
@@ -130,17 +144,17 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
   const deposit = useCallback(
     async (token: `0x${string}`, amount: bigint, lockDuration: bigint, nonEarning: boolean) => {
       if (!address) throw new Error('Wallet not connected')
+      if (!lpAddress) throw new Error('LiquidityPool address not resolved')
 
       // Always resolve the native fee fresh from chain to avoid stale hook state.
       // The deposit() function on LiquidityPool is payable and requires TLEMX fee.
       let nativeFee = depositNativeFee ?? 0n
       if (publicClient) {
         try {
-          const lpAddr = liquidityPoolAddress[chainId as keyof typeof liquidityPoolAddress]
           const loansAddr = loansAddress[chainId as keyof typeof loansAddress]
-          if (lpAddr && loansAddr) {
+          if (loansAddr) {
             const feeUSD = await publicClient.readContract({
-              address: lpAddr,
+              address: lpAddress,
               abi: liquidityPoolAbi,
               functionName: 'depositFeeUSD',
             }) as bigint
@@ -161,24 +175,22 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
       let gasEstimate: bigint | undefined
       if (publicClient) {
         try {
-          const lpAddr = liquidityPoolAddress[chainId as keyof typeof liquidityPoolAddress]
-          if (lpAddr) {
-            const estimated = await publicClient.estimateContractGas({
-              address: lpAddr,
-              abi: liquidityPoolAbi,
-              functionName: 'deposit',
-              args: [token, amount, lockDuration, nonEarning],
-              value: nativeFee,
-              account: address,
-            })
-            gasEstimate = (estimated * 120n) / 100n // 20% buffer
-          }
+          const estimated = await publicClient.estimateContractGas({
+            address: lpAddress,
+            abi: liquidityPoolAbi,
+            functionName: 'deposit',
+            args: [token, amount, lockDuration, nonEarning],
+            value: nativeFee,
+            account: address,
+          })
+          gasEstimate = (estimated * 120n) / 100n // 20% buffer
         } catch {
           // gas estimation failed — send without gas override and let wallet decide
         }
       }
 
       const txHash = await depositFn({
+        address: lpAddress,
         args: [token, amount, lockDuration, nonEarning],
         value: nativeFee,
         ...(gasEstimate !== undefined ? { gas: gasEstimate } : {}),
@@ -186,33 +198,38 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, chainId, depositFn, depositNativeFee, publicClient, waitAndInvalidate]
+    [address, chainId, lpAddress, depositFn, depositNativeFee, publicClient, waitAndInvalidate]
   )
 
   const requestWithdrawal = useCallback(
     async (amount: bigint) => {
       if (!address) throw new Error('Wallet not connected')
-      const txHash = await requestWithdrawalFn({ args: [amount] })
+      if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+      const txHash = await requestWithdrawalFn({ address: lpAddress, args: [amount] })
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, requestWithdrawalFn, waitAndInvalidate]
+    [address, lpAddress, requestWithdrawalFn, waitAndInvalidate]
   )
 
   const claimEarnings = useCallback(async () => {
     if (!address) throw new Error('Wallet not connected')
+    if (!lpAddress) throw new Error('LiquidityPool address not resolved')
     const txHash = await claimEarningsFn({
+      address: lpAddress,
       value: withdrawNativeFee ?? 0n,
       gas: 300_000n,
     })
     await waitAndInvalidate(txHash)
     return txHash
-  }, [address, claimEarningsFn, withdrawNativeFee, waitAndInvalidate])
+  }, [address, lpAddress, claimEarningsFn, withdrawNativeFee, waitAndInvalidate])
 
   const compoundEarnings = useCallback(
     async (lockDuration: bigint) => {
       if (!address) throw new Error('Wallet not connected')
+      if (!lpAddress) throw new Error('LiquidityPool address not resolved')
       const txHash = await compoundEarningsFn({
+        address: lpAddress,
         args: [lockDuration],
         value: depositNativeFee ?? 0n,
         gas: 500_000n,
@@ -220,29 +237,33 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, compoundEarningsFn, depositNativeFee, waitAndInvalidate]
+    [address, lpAddress, compoundEarningsFn, depositNativeFee, waitAndInvalidate]
   )
 
   const pullEarnings = useCallback(async () => {
-    const txHash = await pullEarningsFn({})
+    if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+    const txHash = await pullEarningsFn({ address: lpAddress })
     await waitAndInvalidate(txHash)
     return txHash
-  }, [pullEarningsFn, waitAndInvalidate])
+  }, [lpAddress, pullEarningsFn, waitAndInvalidate])
 
   const transferAccount = useCallback(
     async (to: `0x${string}`) => {
       if (!address) throw new Error('Wallet not connected')
-      const txHash = await transferAccountFn({ args: [to] })
+      if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+      const txHash = await transferAccountFn({ address: lpAddress, args: [to] })
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, transferAccountFn, waitAndInvalidate]
+    [address, lpAddress, transferAccountFn, waitAndInvalidate]
   )
 
   const claimWithdrawal = useCallback(
     async (requestId: bigint) => {
       if (!address) throw new Error('Wallet not connected')
+      if (!lpAddress) throw new Error('LiquidityPool address not resolved')
       const txHash = await claimWithdrawalFn({
+        address: lpAddress,
         args: [requestId],
         value: withdrawNativeFee ?? 0n,
         gas: 300_000n,
@@ -250,22 +271,24 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, claimWithdrawalFn, withdrawNativeFee, waitAndInvalidate]
+    [address, lpAddress, claimWithdrawalFn, withdrawNativeFee, waitAndInvalidate]
   )
 
   const fundWithdrawalQueue = useCallback(async () => {
-    const txHash = await fundWithdrawalQueueFn({})
+    if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+    const txHash = await fundWithdrawalQueueFn({ address: lpAddress })
     await waitAndInvalidate(txHash)
     return txHash
-  }, [fundWithdrawalQueueFn, waitAndInvalidate])
+  }, [lpAddress, fundWithdrawalQueueFn, waitAndInvalidate])
 
   const processSwaps = useCallback(
     async (token: `0x${string}`) => {
-      const txHash = await processSwapsFn({ args: [token] })
+      if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+      const txHash = await processSwapsFn({ address: lpAddress, args: [token] })
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [processSwapsFn, waitAndInvalidate]
+    [lpAddress, processSwapsFn, waitAndInvalidate]
   )
 
   const approveToken = useCallback(

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -15,13 +15,13 @@ import {
   loansAbi,
   useWriteLoansWithdrawCollateral,
   useWriteLoansExtendLoan,
-  readLoansLoanStatus,
-  collateralManagerAddress
+  readLoansLoanStatus
 } from '@/src/generated'
 import { useReadContract, useWriteContract, usePublicClient } from 'wagmi'
 import { config } from '@/src/config/wagmi'
 import { erc20Abi } from 'viem'
 import { useContractTokenConfiguration } from '../useContractTokenConfiguration'
+import { useProtocolAddresses } from '../useProtocolAddresses'
 import { loanKeys } from '../query/loanQueries'
 
 export interface LoanRequest {
@@ -104,9 +104,8 @@ export const useLoanOperations = (
   const loansContractAddress =
     loansAddress[chainId as keyof typeof loansAddress]
 
-  // Get collateral manager address for current chain
-  const cmAddress =
-    collateralManagerAddress[chainId as keyof typeof collateralManagerAddress]
+  // Collateral manager address is resolved on-chain from Loans.collateralManager()
+  const { collateralManager: cmAddress } = useProtocolAddresses()
 
   // Get contract token and decimal configuration
   const {

--- a/src/hooks/useCollateralManager.ts
+++ b/src/hooks/useCollateralManager.ts
@@ -1,11 +1,11 @@
 import { useState, useMemo, useEffect } from 'react'
-import { useReadContract, useChainId } from 'wagmi'
+import { useReadContract } from 'wagmi'
 import {
   useReadCollateralManagerGetSupportedAssets,
-  useReadCollateralManagerGetAssetConfig,
-  collateralManagerAddress
+  useReadCollateralManagerGetAssetConfig
 } from '../generated'
 import erc20Abi from '../abis/ERC20.json'
+import { useProtocolAddresses } from './useProtocolAddresses'
 
 export interface CollateralTokenInfo {
   address: `0x${string}`
@@ -25,12 +25,14 @@ export interface UseCollateralManagerReturn {
 
 // Internal hook to load a single asset's metadata
 function useCollateralAsset(
+  cmAddress: `0x${string}` | undefined,
   tokenAddress: `0x${string}` | undefined
 ): { info: CollateralTokenInfo | undefined; isLoading: boolean; error: Error | null } {
   const { data: config, isLoading: configLoading, error: configError } =
     useReadCollateralManagerGetAssetConfig({
+      address: cmAddress,
       args: tokenAddress ? [tokenAddress] : undefined,
-      query: { enabled: !!tokenAddress }
+      query: { enabled: !!cmAddress && !!tokenAddress }
     })
 
   const { data: symbol, isLoading: symbolLoading, error: symbolError } =
@@ -60,15 +62,18 @@ function useCollateralAsset(
 // Wrap the per-asset hook so we can call it for a known set of addresses.
 // React hooks must run in the same order every render, so we use fixed slots.
 // We load up to 8 assets; add more slots here if collateral options grow past 8.
-function useCollateralAssets(addresses: readonly `0x${string}`[]) {
-  const a0 = useCollateralAsset(addresses[0])
-  const a1 = useCollateralAsset(addresses[1])
-  const a2 = useCollateralAsset(addresses[2])
-  const a3 = useCollateralAsset(addresses[3])
-  const a4 = useCollateralAsset(addresses[4])
-  const a5 = useCollateralAsset(addresses[5])
-  const a6 = useCollateralAsset(addresses[6])
-  const a7 = useCollateralAsset(addresses[7])
+function useCollateralAssets(
+  cmAddress: `0x${string}` | undefined,
+  addresses: readonly `0x${string}`[]
+) {
+  const a0 = useCollateralAsset(cmAddress, addresses[0])
+  const a1 = useCollateralAsset(cmAddress, addresses[1])
+  const a2 = useCollateralAsset(cmAddress, addresses[2])
+  const a3 = useCollateralAsset(cmAddress, addresses[3])
+  const a4 = useCollateralAsset(cmAddress, addresses[4])
+  const a5 = useCollateralAsset(cmAddress, addresses[5])
+  const a6 = useCollateralAsset(cmAddress, addresses[6])
+  const a7 = useCollateralAsset(cmAddress, addresses[7])
 
   return useMemo(() => {
     const slots = [a0, a1, a2, a3, a4, a5, a6, a7].slice(0, addresses.length)
@@ -81,21 +86,20 @@ function useCollateralAssets(addresses: readonly `0x${string}`[]) {
 }
 
 export function useCollateralManager(): UseCollateralManagerReturn {
-  const chainId = useChainId()
+  const { collateralManager: cmAddress } = useProtocolAddresses()
   const [selectedCollateral, setSelectedCollateral] = useState<
     CollateralTokenInfo | undefined
   >(undefined)
-
-  const cmAddress =
-    collateralManagerAddress[chainId as keyof typeof collateralManagerAddress]
 
   const {
     data: supportedAssetAddresses,
     isLoading: assetsLoading,
     error: assetsError
-  } = useReadCollateralManagerGetSupportedAssets()
+  } = useReadCollateralManagerGetSupportedAssets({
+    address: cmAddress,
+    query: { enabled: !!cmAddress }
+  })
 
-  // Filter to only allowed assets
   const allowedAddresses = useMemo(
     () =>
       (supportedAssetAddresses ?? []).filter(
@@ -105,7 +109,7 @@ export function useCollateralManager(): UseCollateralManagerReturn {
   )
 
   const { infos: supportedCollateralTokens, isLoading: metaLoading, error: metaError } =
-    useCollateralAssets(allowedAddresses)
+    useCollateralAssets(cmAddress, allowedAddresses)
 
   // Auto-select when exactly one token is configured
   useEffect(() => {

--- a/src/hooks/useCollateralManager.ts
+++ b/src/hooks/useCollateralManager.ts
@@ -58,21 +58,26 @@ function useCollateralAsset(
 }
 
 // Wrap the per-asset hook so we can call it for a known set of addresses.
-// We load up to 4 assets; add more entries if collateral options grow.
+// React hooks must run in the same order every render, so we use fixed slots.
+// We load up to 8 assets; add more slots here if collateral options grow past 8.
 function useCollateralAssets(addresses: readonly `0x${string}`[]) {
   const a0 = useCollateralAsset(addresses[0])
   const a1 = useCollateralAsset(addresses[1])
   const a2 = useCollateralAsset(addresses[2])
   const a3 = useCollateralAsset(addresses[3])
+  const a4 = useCollateralAsset(addresses[4])
+  const a5 = useCollateralAsset(addresses[5])
+  const a6 = useCollateralAsset(addresses[6])
+  const a7 = useCollateralAsset(addresses[7])
 
   return useMemo(() => {
-    const slots = [a0, a1, a2, a3].slice(0, addresses.length)
+    const slots = [a0, a1, a2, a3, a4, a5, a6, a7].slice(0, addresses.length)
     return {
       infos: slots.map((s) => s.info).filter((i): i is CollateralTokenInfo => !!i),
       isLoading: slots.some((s) => s.isLoading),
       error: slots.find((s) => s.error)?.error ?? null
     }
-  }, [a0, a1, a2, a3, addresses.length])
+  }, [a0, a1, a2, a3, a4, a5, a6, a7, addresses.length])
 }
 
 export function useCollateralManager(): UseCollateralManagerReturn {

--- a/src/hooks/useCollateralManager.ts
+++ b/src/hooks/useCollateralManager.ts
@@ -17,7 +17,6 @@ export interface UseCollateralManagerReturn {
   supportedCollateralTokens: CollateralTokenInfo[]
   selectedCollateral: CollateralTokenInfo | undefined
   setSelectedCollateral: (token: CollateralTokenInfo | undefined) => void
-  collateralManagerAddress: `0x${string}` | undefined
   getCollateralByAddress: (addr: string) => CollateralTokenInfo | undefined
   isLoading: boolean
   error: Error | null
@@ -126,7 +125,6 @@ export function useCollateralManager(): UseCollateralManagerReturn {
     supportedCollateralTokens,
     selectedCollateral,
     setSelectedCollateral,
-    collateralManagerAddress: cmAddress,
     getCollateralByAddress,
     isLoading: assetsLoading || metaLoading,
     error: assetsError ?? metaError ?? null

--- a/src/hooks/useCollateralManager.ts
+++ b/src/hooks/useCollateralManager.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { useReadContract } from 'wagmi'
 import {
   useReadCollateralManagerGetSupportedAssets,
@@ -16,7 +16,7 @@ export interface CollateralTokenInfo {
 export interface UseCollateralManagerReturn {
   supportedCollateralTokens: CollateralTokenInfo[]
   selectedCollateral: CollateralTokenInfo | undefined
-  setSelectedCollateral: (token: CollateralTokenInfo) => void
+  setSelectedCollateral: (token: CollateralTokenInfo | undefined) => void
   collateralManagerAddress: `0x${string}` | undefined
   getCollateralByAddress: (addr: string) => CollateralTokenInfo | undefined
   isLoading: boolean
@@ -111,12 +111,8 @@ export function useCollateralManager(): UseCollateralManagerReturn {
   const { infos: supportedCollateralTokens, isLoading: metaLoading, error: metaError } =
     useCollateralAssets(cmAddress, allowedAddresses)
 
-  // Auto-select when exactly one token is configured
-  useEffect(() => {
-    if (supportedCollateralTokens.length === 1 && !selectedCollateral) {
-      setSelectedCollateral(supportedCollateralTokens[0])
-    }
-  }, [supportedCollateralTokens, selectedCollateral])
+  // No auto-selection — the user must always explicitly pick a collateral token
+  // before the loan calculator is usable. This is enforced in the LoanParameters UI.
 
   const getCollateralByAddress = useMemo(
     () => (addr: string) =>

--- a/src/hooks/useProtocolAddresses.ts
+++ b/src/hooks/useProtocolAddresses.ts
@@ -1,0 +1,59 @@
+import {
+  useReadLoansCollateralManager,
+  useReadLoansLiquidityPool,
+  liquidityPoolAbi,
+  loansAddress
+} from '@/src/generated'
+import { useChainId, useReadContract } from 'wagmi'
+
+/**
+ * Resolves all protocol contract addresses from a single Loans address in env.
+ *
+ * Only NEXT_PUBLIC_*_LOANS_ADDRESS is required. The remaining addresses are
+ * discovered on-chain:
+ *   CollateralManager  = Loans.collateralManager()
+ *   LiquidityPool      = Loans.liquidityPool()
+ *   SwapManager        = LiquidityPool.swapManager()
+ *
+ * All addresses are undefined while their underlying read is pending, so
+ * consumers must gate dependent reads/writes on the address being defined.
+ */
+export function useProtocolAddresses() {
+  const chainId = useChainId()
+  const loans = loansAddress[chainId as keyof typeof loansAddress] as
+    | `0x${string}`
+    | undefined
+
+  const {
+    data: collateralManager,
+    isLoading: cmLoading,
+    error: cmError
+  } = useReadLoansCollateralManager()
+
+  const {
+    data: liquidityPool,
+    isLoading: lpLoading,
+    error: lpError
+  } = useReadLoansLiquidityPool()
+
+  // Use useReadContract directly — the generated hook hits TS deep-instantiation limits.
+  const {
+    data: swapManager,
+    isLoading: smLoading,
+    error: smError
+  } = useReadContract({
+    address: liquidityPool as `0x${string}` | undefined,
+    abi: liquidityPoolAbi,
+    functionName: 'swapManager',
+    query: { enabled: !!liquidityPool }
+  })
+
+  return {
+    loans,
+    collateralManager: collateralManager as `0x${string}` | undefined,
+    liquidityPool: liquidityPool as `0x${string}` | undefined,
+    swapManager: swapManager as `0x${string}` | undefined,
+    isLoading: cmLoading || lpLoading || smLoading,
+    error: cmError ?? lpError ?? smError ?? null
+  }
+}

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -13,7 +13,11 @@ import LiquidityPoolAbi from './src/abis/LiquidityPool.json'
 import PriceHelperAbi from './src/abis/PriceHelper.json'
 import CollateralManagerAbi from './src/abis/CollateralManager.json'
 
-// Chain configuration following wagmi best practices
+// Only the Loans address is sourced from env. Every other protocol contract
+// address is discovered on-chain at runtime via useProtocolAddresses():
+//   CollateralManager  = Loans.collateralManager()
+//   LiquidityPool      = Loans.liquidityPool()
+//   SwapManager        = LiquidityPool.swapManager()
 const CHAINS = {
   LEMON: 1006,
   CITRON: 1005,
@@ -21,18 +25,9 @@ const CHAINS = {
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as `0x${string}`
 
-// Contract addresses by chain (following wagmi patterns)
-const ADDRESSES = {
-  [CHAINS.LEMON]: {
-    loans: (process.env.NEXT_PUBLIC_LEMON_LOANS_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
-    liquidityPool: (process.env.NEXT_PUBLIC_LEMON_LIQUIDITY_POOL_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
-    collateralManager: (process.env.NEXT_PUBLIC_LEMON_COLLATERAL_MANAGER_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
-  },
-  [CHAINS.CITRON]: {
-    loans: (process.env.NEXT_PUBLIC_CITRON_LOANS_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
-    liquidityPool: (process.env.NEXT_PUBLIC_CITRON_LIQUIDITY_POOL_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
-    collateralManager: (process.env.NEXT_PUBLIC_CITRON_COLLATERAL_MANAGER_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
-  },
+const LOANS_ADDRESSES = {
+  [CHAINS.LEMON]: (process.env.NEXT_PUBLIC_LEMON_LOANS_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
+  [CHAINS.CITRON]: (process.env.NEXT_PUBLIC_CITRON_LOANS_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
 } as const
 
 export default defineConfig({
@@ -41,36 +36,27 @@ export default defineConfig({
     {
       name: 'Loans',
       abi: LoansAbi as Abi,
-      address: {
-        [CHAINS.CITRON]: ADDRESSES[CHAINS.CITRON].loans,
-        [CHAINS.LEMON]: ADDRESSES[CHAINS.LEMON].loans,
-      }
+      address: LOANS_ADDRESSES,
     },
     {
       name: 'PriceDataFeed',
       abi: PriceDataFeedAbi as Abi,
-      // Address will be dynamically obtained from Loans contract
+      // Address resolved at runtime from Loans.priceDataFeed()
     },
     {
       name: 'PriceHelper',
       abi: PriceHelperAbi as Abi,
-      // Address will be dynamically obtained from LiquidityPool contract via priceHelper()
+      // Address resolved at runtime from LiquidityPool.priceHelper()
     },
     {
       name: 'LiquidityPool',
       abi: LiquidityPoolAbi as Abi,
-      address: {
-        [CHAINS.CITRON]: ADDRESSES[CHAINS.CITRON].liquidityPool,
-        [CHAINS.LEMON]: ADDRESSES[CHAINS.LEMON].liquidityPool,
-      }
+      // Address resolved at runtime from Loans.liquidityPool()
     },
     {
       name: 'CollateralManager',
       abi: CollateralManagerAbi as Abi,
-      address: {
-        [CHAINS.CITRON]: ADDRESSES[CHAINS.CITRON].collateralManager,
-        [CHAINS.LEMON]: ADDRESSES[CHAINS.LEMON].collateralManager,
-      }
+      // Address resolved at runtime from Loans.collateralManager()
     },
   ],
   plugins: [


### PR DESCRIPTION
Follow-up PR to #14, continuing on the same `loans-collateral-manager` branch. #14 was merged; these four new commits build on that work.

## Summary

- **Collateral token selector.** A segmented button group now renders at the top of the Loan Parameters card listing every CollateralManager-supported asset. The user must explicitly pick one before the rest of the form becomes usable — no auto-selection, even when only one token is configured.
- **Per-asset APR + LTV options.** When a collateral is selected, the duration and LTV sliders repopulate from that token's own `getAllInterestAprConfigs` / `getAllOriginationFees` on the Loans contract. Switching tokens snaps the LTV to the new token's first valid option so the form never leaves an invalid state.
- **Dynamic protocol-address resolution.** Only `NEXT_PUBLIC_*_LOANS_ADDRESS` is required in env. A new `useProtocolAddresses` hook reads `CollateralManager` from `Loans.collateralManager()`, `LiquidityPool` from `Loans.liquidityPool()`, and `SwapManager` from `LiquidityPool.swapManager()`. `wagmi.config.ts` drops the static chainId→address maps for those three contracts so every call site is forced to pass the runtime-resolved address.
- **Post-create reset.** After a successful `initiateLoan`, Calculator clears `selectedCollateral`, `loanAmount`, `duration`, and `ltv`, so starting another loan requires a fresh collateral pick.
- **Cleanup.** Dropped the unused `collateralManagerAddress` return field on `useCollateralManager`, removed two unused imports in Calculator, and added `docs/qa-checklist.md` covering the full branch.

## Test plan

- [ ] `.env` with only `NEXT_PUBLIC_*_LOANS_ADDRESS` set — app loads, calculator loads, no errors in console.
- [ ] Liquidity page still loads, deposits and withdrawals work.
- [ ] Loan calculator: collateral selector appears at the top; APR and LTV sliders show "Select a collateral token first." until the user clicks a token.
- [ ] With two or more assets configured in CollateralManager: both surface as buttons; switching between them updates APR tiers and LTV options.
- [ ] Create loan end-to-end (approve collateral → approve LMLN → create). Confirmation-modal checklist advances one step at a time.
- [ ] After a successful loan creation: selector is cleared, form returns to "Select a collateral token first." state.
- [ ] Run through `docs/qa-checklist.md` on Citron testnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)