### PR TITLE
fix: loan tile stability, countdown correctness, thousands-separated collateral

### DIFF
--- a/src/components/common/LoanCompletionModal.tsx
+++ b/src/components/common/LoanCompletionModal.tsx
@@ -31,6 +31,11 @@ export function LoanCompletionModal({
   isWithdrawing,
   onConfirmWithdrawal
 }: LoanCompletionModalProps) {
+  // After a successful withdrawal the loan transitions to COMPLETED and is
+  // filtered out of activeLoans. The modal may re-render once with loan=undefined
+  // before the parent's closeWithdrawalModal runs, so don't crash on it.
+  if (!loan) return null
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className='sm:max-w-md'>

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -463,25 +463,22 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         const isOverdue = isLoanOverdue(loan)
         const isInGracePeriod = isLoanInGracePeriod(loan)
 
-        // Countdown target — uses only absolute timestamps from the loan struct
-        // so it does NOT reset when the component re-renders (e.g. opening the
-        // Make Payment dialog). Two phases:
-        //   1. Before loan end date: count down to createdAt + duration.
-        //   2. After loan end date (in grace window): count down to the actual
-        //      default time (loanEnd + balloonGrace) minus a one-cycle buffer
-        //      so the user sees urgency before the contract defaults them.
+        // Countdown target — always derived from the loan's absolute timestamps
+        // (createdAt + duration, plus loanConfig.balloonPaymentGraceDuration),
+        // so the value does not shift when the component re-renders.
+        //   1. Before loan end: count to createdAt + duration ("Time to Loan End")
+        //   2. After loan end:  count to loanEnd + grace − 1 day ("Time Until Default")
+        // The one-day buffer is a user-facing warning window so the countdown
+        // hits zero ahead of the contract's actual default.
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
         const loanEndMs = Number(loan.dueTimestamp) * 1000
         const graceDurationMs = loanConfig?.balloonPaymentGraceDuration
           ? Number(loanConfig.balloonPaymentGraceDuration) * 1000
           : 0
-        const cycleDurationMs = Number(loan.loanCycleDuration ?? 0n) * 1000
-        const warningBufferMs =
-          cycleDurationMs > 0 ? Math.min(ONE_DAY_MS, cycleDurationMs) : ONE_DAY_MS
-        const pastLoanEnd = isOverdue // isLoanOverdue is now "now >= loanEndMs"
+        const pastLoanEnd = isOverdue // isLoanOverdue === "now >= loanEndMs"
 
         const countdownTarget: Date = pastLoanEnd
-          ? new Date(loanEndMs + graceDurationMs - warningBufferMs)
+          ? new Date(loanEndMs + graceDurationMs - ONE_DAY_MS)
           : new Date(loanEndMs)
 
         const countdownLabel = pastLoanEnd ? 'Time Until Default' : 'Time to Loan End'

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -86,7 +86,6 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
   const {
     isLoanOverdue,
     isLoanInGracePeriod,
-    getDisplayDueDate,
     getPaymentProgress,
     minimumPayment,
     isPaymentRequired,
@@ -464,31 +463,29 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         const isOverdue = isLoanOverdue(loan)
         const isInGracePeriod = isLoanInGracePeriod(loan)
 
-        // Countdown target and label depend on payment state:
-        // 1. Grace period, before loan end: count to exact loan end (no buffer)
-        // 2. Grace period, after loan end:  count to end + balloonPaymentGraceDuration - 1 day
-        // 3. Normal (interest not fully paid): count to now + timeToDefault - 1 day
+        // Countdown target — uses only absolute timestamps from the loan struct
+        // so it does NOT reset when the component re-renders (e.g. opening the
+        // Make Payment dialog). Two phases:
+        //   1. Before loan end date: count down to createdAt + duration.
+        //   2. After loan end date (in grace window): count down to the actual
+        //      default time (loanEnd + balloonGrace) minus a one-cycle buffer
+        //      so the user sees urgency before the contract defaults them.
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
         const loanEndMs = Number(loan.dueTimestamp) * 1000
-        const now = Date.now()
-        const pastLoanEnd = isInGracePeriod && now >= loanEndMs
         const graceDurationMs = loanConfig?.balloonPaymentGraceDuration
           ? Number(loanConfig.balloonPaymentGraceDuration) * 1000
           : 0
+        const cycleDurationMs = Number(loan.loanCycleDuration ?? 0n) * 1000
+        const warningBufferMs =
+          cycleDurationMs > 0 ? Math.min(ONE_DAY_MS, cycleDurationMs) : ONE_DAY_MS
+        const pastLoanEnd = isOverdue // isLoanOverdue is now "now >= loanEndMs"
 
-        const countdownTarget: Date = isInGracePeriod && !pastLoanEnd
-          ? new Date(loanEndMs)
-          : pastLoanEnd
-            ? new Date(loanEndMs + graceDurationMs - ONE_DAY_MS)
-            : getDisplayDueDate(loan)
+        const countdownTarget: Date = pastLoanEnd
+          ? new Date(loanEndMs + graceDurationMs - warningBufferMs)
+          : new Date(loanEndMs)
 
-        const countdownLabel = isOverdue
-          ? 'Overdue'
-          : isInGracePeriod && !pastLoanEnd
-            ? 'Time to Loan End'
-            : 'Time Until Default'
-
-        const showCountdownTooltip = !isOverdue && !(isInGracePeriod && !pastLoanEnd)
+        const countdownLabel = pastLoanEnd ? 'Time Until Default' : 'Time to Loan End'
+        const showCountdownTooltip = pastLoanEnd
 
         return (
           <Card key={loan.id}>

--- a/src/components/error/Web3ErrorBoundary.tsx
+++ b/src/components/error/Web3ErrorBoundary.tsx
@@ -102,12 +102,14 @@ export class Web3ErrorBoundary extends Component<Props, State> {
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4'>
-            {process.env.NODE_ENV === 'development' && this.state.error && (
-              <details className='text-xs text-red-600'>
+            {this.state.error && (
+              <details className='text-xs text-red-600' open>
                 <summary className='cursor-pointer font-medium'>
                   Technical Details
                 </summary>
-                <pre className='mt-2 whitespace-pre-wrap bg-red-100 p-2 rounded'>
+                <pre className='mt-2 whitespace-pre-wrap bg-red-100 p-2 rounded max-h-64 overflow-auto'>
+                  {this.state.error.message}
+                  {'\n\n'}
                   {this.state.error.stack}
                 </pre>
               </details>

--- a/src/components/error/Web3ErrorBoundary.tsx
+++ b/src/components/error/Web3ErrorBoundary.tsx
@@ -102,7 +102,7 @@ export class Web3ErrorBoundary extends Component<Props, State> {
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4'>
-            {this.state.error && (
+            {process.env.NODE_ENV === 'development' && this.state.error && (
               <details className='text-xs text-red-600' open>
                 <summary className='cursor-pointer font-medium'>
                   Technical Details

--- a/src/hooks/loans/useLoanPayment.ts
+++ b/src/hooks/loans/useLoanPayment.ts
@@ -83,29 +83,15 @@ export const useLoanPayment = (
     return loan?.paymentAmount ?? 0n
   }, [loan?.paymentAmount])
 
-  // Countdown target: now + timeToDefault minus a buffer so users see urgency
-  // before the contract actually defaults them. The buffer is one loan cycle
-  // (capped at 1 day) so short-cycle testnet loans don't show as Overdue at
-  // creation time when timeToDefault is only a few cycles.
-  const getDisplayDueDate = useCallback((loanData: Loan): Date => {
-    const now = Date.now()
-    const ONE_DAY_MS = 24 * 60 * 60 * 1000
-    const cycleDurationMs = Number(loanData.loanCycleDuration ?? 0n) * 1000
-    const buffer = cycleDurationMs > 0 ? Math.min(ONE_DAY_MS, cycleDurationMs) : ONE_DAY_MS
-    return new Date(now + Number(loanData.timeToDefault) * 1000 - buffer)
+  // Overdue once the loan is past its end date. The contract still allows
+  // payments during the balloonPaymentGraceDuration window, but from the
+  // user's perspective the principal payment is late.
+  const isLoanOverdue = useCallback((loanData: Loan): boolean => {
+    if (loanData.status !== LOAN_STATUS.ACTIVE) {
+      return false
+    }
+    return Date.now() >= Number(loanData.dueTimestamp) * 1000
   }, [])
-
-  // Simple check if loan payment is overdue (for UI state only)
-  const isLoanOverdue = useCallback(
-    (loanData: Loan): boolean => {
-      if (loanData.status !== LOAN_STATUS.ACTIVE) {
-        return false
-      }
-      const displayDueDate = getDisplayDueDate(loanData)
-      return displayDueDate.getTime() < Date.now()
-    },
-    [getDisplayDueDate]
-  )
 
   // Grace period: all cycle payments are done and only the balloon (principal) remains.
   // Cannot use paidAmount >= interestAmount — once principal is paid, paidAmount dwarfs
@@ -146,7 +132,6 @@ export const useLoanPayment = (
     isValidAmount,
     isLoanOverdue,
     isLoanInGracePeriod,
-    getDisplayDueDate,
     getPaymentProgress,
     // New status-aware properties
     isPaymentRequired,

--- a/src/hooks/useCollateralManager.ts
+++ b/src/hooks/useCollateralManager.ts
@@ -114,10 +114,13 @@ export function useCollateralManager(): UseCollateralManagerReturn {
   // before the loan calculator is usable. This is enforced in the LoanParameters UI.
 
   const getCollateralByAddress = useMemo(
-    () => (addr: string) =>
-      supportedCollateralTokens.find(
-        (t) => t.address.toLowerCase() === addr.toLowerCase()
-      ),
+    () => (addr: string | undefined) => {
+      if (!addr) return undefined
+      const target = addr.toLowerCase()
+      return supportedCollateralTokens.find(
+        (t) => t.address.toLowerCase() === target
+      )
+    },
     [supportedCollateralTokens]
   )
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -12,7 +12,10 @@ export const formatAmountWithSymbol = (
   symbol: string,
   decimals = 18
 ): string => {
-  const formattedAmount = parseFloat(formatAmount(amount, decimals)).toFixed(2)
+  const formattedAmount = parseFloat(formatAmount(amount, decimals)).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })
   return `${formattedAmount} ${symbol}`
 }
 


### PR DESCRIPTION
Follow-up PR to #15. Continues on `loans-collateral-manager`.

## Summary

- **Countdown shows loan duration, not default-time.** Before the loan end date the countdown now targets `createdAt + duration` with the label "Time to Loan End" — so a 5-minute loan starts at 5:00 and counts down, instead of the 10:00 default-time runway it was showing.
- **Countdown no longer resets on UI interactions.** Target is derived entirely from absolute timestamps on the loan struct (`dueTimestamp` + `loanConfig.balloonPaymentGraceDuration`) with no `Date.now()` inside the render, so clicking Make Payment (or any other re-render) doesn't bump the displayed time.
- **1-day warning buffer restored** on the post-loan-end "Time Until Default" phase — matches the pre-existing develop behavior where the visible countdown hits zero a day before the contract's actual default.
- **Collateral amount renders with thousands separators.** `formatAmountWithSymbol` uses `toLocaleString('en-US')` so the loan-tile Collateral cell reads `5,656,748.50 LMLN` instead of `5656748.50 LMLN`.
- **Active Loans no longer crashes on collateral withdrawal.** `LoanCompletionModal` early-returns `null` when the loan is undefined (happens for one render tick after a successful withdrawal when the loan has transitioned to COMPLETED and been filtered out of activeLoans), and `getCollateralByAddress` no-ops on a missing address instead of throwing on `.toLowerCase()`.
- **Web3ErrorBoundary** shows the error message + stack trace (expanded, scrollable) in development so the next render crash is diagnosable on-screen without devtools; production still shows only the user-friendly fallback.

## Test plan

- [ ] Create a 5-minute loan on Citron — countdown starts at 5:00 and decrements cleanly.
- [ ] Click Make Payment and close without submitting — countdown keeps its position, doesn't jump.
- [ ] Let a short-cycle loan pass its end date — label flips to "Time Until Default" and the timer shows "Make Payment Now" during the grace window.
- [ ] Collateral amount with a large value shows thousands separators in the loan tile.
- [ ] Pay off a loan to UNLOCKED, click Withdraw Collateral, confirm — Active Loans tab does **not** show the "Something went wrong" error boundary after the withdrawal succeeds on-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)