### PR TITLE
Release: BNB Smart Chain support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,21 @@
 # WalletConnect Cloud project ID — https://cloud.walletconnect.com/
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 
-# LemonChain mainnet: only the Loans contract is needed.
-# CollateralManager, LiquidityPool, and SwapManager are discovered on-chain:
+# Per-chain Loans addresses. Only the chains listed in
+# NEXT_PUBLIC_SUPPORTED_CHAINS need a value here. The other protocol
+# contracts (CollateralManager, LiquidityPool, SwapManager) are discovered
+# on-chain at runtime:
 #   CollateralManager = Loans.collateralManager()
 #   LiquidityPool     = Loans.liquidityPool()
 #   SwapManager       = LiquidityPool.swapManager()
 NEXT_PUBLIC_LEMON_LOANS_ADDRESS=
-
-# Citron testnet (only required when 1005 is included in NEXT_PUBLIC_SUPPORTED_CHAINS)
 NEXT_PUBLIC_CITRON_LOANS_ADDRESS=
+NEXT_PUBLIC_BSC_LOANS_ADDRESS=
 
-# Comma-separated list of chain ids to expose in the wallet network list and
-# the header chain switcher. Order matters — the first entry is the default.
-# Known ids: 1006 = LemonChain mainnet, 1005 = LemonChain testnet (Citron)
+# Comma-separated list of chain ids to expose in the wallet network list.
+# Order matters — the first entry is the default.
+# Known ids:
+#   1006 = LemonChain mainnet
+#   1005 = LemonChain testnet (Citron)
+#   56   = BNB Smart Chain mainnet
 NEXT_PUBLIC_SUPPORTED_CHAINS=1006

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ All variables must be prefixed `NEXT_PUBLIC_` to be available in the browser.
 | Variable | Required | Description |
 |---|---|---|
 | `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` | Yes | WalletConnect Cloud project ID |
-| `NEXT_PUBLIC_LEMON_LOANS_ADDRESS` | Yes | Loans contract address on LemonChain mainnet |
-| `NEXT_PUBLIC_CITRON_LOANS_ADDRESS` | Testnet only | Loans contract address on Citron testnet |
-| `NEXT_PUBLIC_SUPPORTED_CHAINS` | No | Comma-separated chain ids (e.g. `1006,1005`). First entry is the default. Defaults to LemonChain mainnet (`1006`) when unset. Surfaces in the wallet network list and the header chain switcher dropdown. |
+| `NEXT_PUBLIC_LEMON_LOANS_ADDRESS` | When 1006 is in supported chains | Loans contract address on LemonChain mainnet |
+| `NEXT_PUBLIC_CITRON_LOANS_ADDRESS` | When 1005 is in supported chains | Loans contract address on Citron testnet |
+| `NEXT_PUBLIC_BSC_LOANS_ADDRESS` | When 56 is in supported chains | Loans contract address on BNB Smart Chain mainnet |
+| `NEXT_PUBLIC_SUPPORTED_CHAINS` | No | Comma-separated chain ids (e.g. `1006,56`). First entry is the default. Defaults to LemonChain mainnet (`1006`) when unset. Known ids: `1006` LemonChain mainnet, `1005` Citron testnet, `56` BNB Smart Chain mainnet. |
 
 Only the Loans contract address is required per chain. The rest of the protocol contracts (`CollateralManager`, `LiquidityPool`, `SwapManager`) are discovered on-chain at app load via `Loans.collateralManager()`, `Loans.liquidityPool()`, and `LiquidityPool.swapManager()`.
 
@@ -45,7 +46,8 @@ For Cloudflare Pages deployments, secrets must be set via the Wrangler CLI rathe
 ```bash
 npx wrangler pages secret put NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID --project-name=loans-dapp
 npx wrangler pages secret put NEXT_PUBLIC_LEMON_LOANS_ADDRESS --project-name=loans-dapp
-# And, for testnet builds, NEXT_PUBLIC_CITRON_LOANS_ADDRESS
+npx wrangler pages secret put NEXT_PUBLIC_BSC_LOANS_ADDRESS --project-name=loans-dapp
+# Plus NEXT_PUBLIC_CITRON_LOANS_ADDRESS for builds that include the Citron testnet.
 ```
 
 Non-sensitive public variables can alternatively be set in `wrangler.toml` under `[vars]`.

--- a/docs/mainnet-setup.md
+++ b/docs/mainnet-setup.md
@@ -26,15 +26,17 @@ Only the Loans contract address is required per chain. The rest of the protocol 
 - `LiquidityPool` ← `Loans.liquidityPool()`
 - `SwapManager` ← `LiquidityPool.swapManager()`
 
-Add the following to `.env` (or Cloudflare Pages secrets — see README):
+Add the following to `.env` (or Cloudflare Pages secrets — see README). Provide a Loans address for every chain id you list in `NEXT_PUBLIC_SUPPORTED_CHAINS`:
 
 ```
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=...
-NEXT_PUBLIC_LEMON_LOANS_ADDRESS=0x...
-NEXT_PUBLIC_CITRON_LOANS_ADDRESS=0x...            # testnet only
+NEXT_PUBLIC_SUPPORTED_CHAINS=1006,56               # comma-separated chain ids; first is default
+NEXT_PUBLIC_LEMON_LOANS_ADDRESS=0x...              # required when 1006 is listed
+NEXT_PUBLIC_BSC_LOANS_ADDRESS=0x...                # required when 56 is listed
+NEXT_PUBLIC_CITRON_LOANS_ADDRESS=0x...             # required when 1005 is listed (testnet)
 ```
 
-Then rebuild so `wagmi generate` picks up the new Loans address:
+Then rebuild so `wagmi generate` picks up the new Loans address(es):
 
 ```bash
 npm run build

--- a/src/config/wagmi.ts
+++ b/src/config/wagmi.ts
@@ -7,6 +7,7 @@ import {
 } from '@rainbow-me/rainbowkit/wallets'
 import { createConfig, http } from 'wagmi'
 import { type Chain } from 'viem'
+import { bsc } from 'viem/chains'
 
 const citron = {
   id: 1005,
@@ -52,7 +53,8 @@ const lemon = {
 // chain id. Add new chains here as deployments expand.
 const SUPPORTED_CHAIN_REGISTRY: Record<number, Chain> = {
   [lemon.id]: lemon,
-  [citron.id]: citron
+  [citron.id]: citron,
+  [bsc.id]: bsc
 }
 
 // Resolve the active chain set from NEXT_PUBLIC_SUPPORTED_CHAINS, a

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -21,6 +21,7 @@ import CollateralManagerAbi from './src/abis/CollateralManager.json'
 const CHAINS = {
   LEMON: 1006,
   CITRON: 1005,
+  BSC: 56,
 } as const
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as `0x${string}`
@@ -28,6 +29,7 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as `0x${string
 const LOANS_ADDRESSES = {
   [CHAINS.LEMON]: (process.env.NEXT_PUBLIC_LEMON_LOANS_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
   [CHAINS.CITRON]: (process.env.NEXT_PUBLIC_CITRON_LOANS_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
+  [CHAINS.BSC]: (process.env.NEXT_PUBLIC_BSC_LOANS_ADDRESS || ZERO_ADDRESS) as `0x${string}`,
 } as const
 
 export default defineConfig({


### PR DESCRIPTION
Promotes the BNB Smart Chain integration (PR #19) from `develop` to `main`.

## Summary

Adds BSC mainnet (chain id 56) to the supported chain registry so the dapp can target the BNB Smart Chain deployment of the Loans contract alongside LemonChain.

- `src/config/wagmi.ts` registers `bsc` from `viem/chains` under `SUPPORTED_CHAIN_REGISTRY[56]`.
- `wagmi.config.ts` adds `NEXT_PUBLIC_BSC_LOANS_ADDRESS` to the codegen-baked Loans address map.
- `.env.example`, `README.md`, and `docs/mainnet-setup.md` document the new chain id and env var.

## To enable BSC in production

Set the following Cloudflare Pages secrets (via `wrangler pages secret put`) before the next deploy:

```
NEXT_PUBLIC_BSC_LOANS_ADDRESS=0x...        # BSC Loans contract address
NEXT_PUBLIC_SUPPORTED_CHAINS=1006,56        # include 56 alongside LemonChain mainnet
```

The other protocol contracts (`CollateralManager`, `LiquidityPool`, `SwapManager`) are still discovered on-chain at runtime, so no extra per-chain env vars are needed.

## Test plan

- [ ] Deploy with the BSC Loans address baked in — RainbowKit's network picker shows BSC alongside LemonChain.
- [ ] Switch wallet to BSC — `Loans.collateralManager()` / `Loans.liquidityPool()` resolve the BSC-side contracts; loan calculator and active-loans tab render against the BSC deployment.
- [ ] LemonChain-only configurations (without `56` in `NEXT_PUBLIC_SUPPORTED_CHAINS`) continue to work — BSC does not appear in the wallet picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)