### PR TITLE
fix: restore single-collateral auto-select + collateral-aware price banner

### DIFF
--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -46,9 +46,12 @@ export function LoanParameters({
   setSelectedCollateral,
   isDashboard = false
 }: LoanParametersProps) {
-  // Always show the selector — the user must pick, even if only one token is configured.
-  const hasCollateralOptions = supportedCollateralTokens.length > 0
-  const needsCollateralChoice = hasCollateralOptions && !selectedCollateral
+  // Show the selector only when there's more than one collateral token to choose
+  // between. With a single configured token the user is auto-selected into it
+  // (handled by useCollateralManager) and the rest of the form is usable
+  // immediately.
+  const hasMultipleCollateral = supportedCollateralTokens.length > 1
+  const needsCollateralChoice = hasMultipleCollateral && !selectedCollateral
   // Use pre-calculated duration range from the hook
   const minDuration = durationRange.min
   const maxDuration = durationRange.max
@@ -96,8 +99,8 @@ export function LoanParameters({
         </CardTitle>
       </CardHeader>
       <CardContent className='space-y-6'>
-        {/* Collateral Token Selector — always required; the user must pick before the rest of the form is usable */}
-        {hasCollateralOptions && (
+        {/* Collateral Token Selector — only shown when more than one is configured */}
+        {hasMultipleCollateral && (
           <div>
             <label
               className={`block text-sm font-medium ${!isDashboard ? 'text-gray-300' : ''} mb-2`}
@@ -169,31 +172,10 @@ export function LoanParameters({
                   setLoanAmount(numValue)
                 }
               }}
-              onBlur={(e) => {
-                const value = e.target.value
-                const minAmount = loanConfig?.minLoanAmount
-                  ? Number(
-                      formatUnits(
-                        loanConfig.minLoanAmount,
-                        tokenConfig?.loanToken.decimals || 18
-                      )
-                    )
-                  : 1000
-                if (value === '' || Number(value) < minAmount) {
-                  setLoanAmount(minAmount)
-                }
-              }}
-              min={
-                loanConfig?.minLoanAmount
-                  ? formatUnits(
-                      loanConfig.minLoanAmount,
-                      tokenConfig?.loanToken.decimals || 18
-                    )
-                  : '1000'
-              }
+              min={minLoanAmount > 0 ? minLoanAmount : undefined}
               max={maxLoanAmount}
-              className={`pl-8 text-lg ${!isDashboard ? 'bg-white/10 border-white/20 text-white placeholder:text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed' : 'disabled:opacity-50 disabled:cursor-not-allowed'} ${isBelowMinimum ? 'border-red-500 ring-1 ring-red-500' : ''}`}
-              placeholder='10000'
+              className={`pl-8 text-lg ${!isDashboard ? 'bg-white/10 border-white/20 text-white placeholder:text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed' : 'placeholder:text-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed'} ${isBelowMinimum ? 'border-red-500 ring-1 ring-red-500' : ''}`}
+              placeholder={minLoanAmount > 0 ? String(minLoanAmount) : ''}
             />
           </div>
           {hasNoLiquidity ? (

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -144,22 +144,9 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   // Get initial loan config and options - moved up to avoid initialization error
   const initialHookData: UseLoansReturn = useLoans()
 
-  // Set initial values from contract config
+  // Set initial values from contract config (loanAmount stays at 0 so the
+  // input shows the placeholder — the user has to type the desired amount).
   useEffect(() => {
-    if (
-      initialHookData.loanConfig &&
-      initialHookData.loanConfig.minLoanAmount &&
-      loanAmount === 0
-    ) {
-      setLoanAmount(
-        Number(
-          formatUnits(
-            initialHookData.loanConfig.minLoanAmount,
-            tokenConfig?.loanToken.decimals || 18
-          )
-        )
-      )
-    }
     // Snap LTV to the first option for the selected collateral — on first load (ltv===0)
     // and when the user switches collateral tokens and the current LTV isn't in the new set.
     if (perAssetConfig.ltvOptions.length > 0 && tokenConfig) {

--- a/src/components/dashboard/PriceDataBanner.tsx
+++ b/src/components/dashboard/PriceDataBanner.tsx
@@ -55,14 +55,14 @@ function PriceDataBannerError({ error }: { error: Error }) {
 }
 
 export function PriceDataBanner() {
-  const { 
-    spotPrice, 
-    monthlyAverage, 
-    lmlnPrice, 
-    tokenSymbol, 
-    feeTokenSymbol, 
-    isLoading, 
-    error 
+  const {
+    spotPrice,
+    monthlyAverage,
+    feeTokenPrice,
+    collateralSymbol,
+    feeTokenSymbol,
+    isLoading,
+    error
   } = usePricing()
 
   if (isLoading) return <PriceDataBannerSkeleton />
@@ -86,26 +86,26 @@ export function PriceDataBanner() {
         <div className='flex items-center gap-8'>
           <div className='text-center'>
             <p className='text-xs text-gray-600 dark:text-gray-400'>
-              {tokenSymbol} Price
+              {collateralSymbol ?? 'Collateral'} Price
             </p>
             <p className='text-base font-bold text-gray-900 dark:text-gray-100'>
-              ${spotPrice}
+              ${spotPrice ?? '—'}
             </p>
           </div>
           <div className='text-center'>
             <p className='text-xs text-gray-600 dark:text-gray-400'>
-              {tokenSymbol} Monthly Avg
+              {collateralSymbol ?? 'Collateral'} Monthly Avg
             </p>
             <p className='text-base font-bold text-gray-900 dark:text-gray-100'>
-              ${monthlyAverage}
+              ${monthlyAverage ?? '—'}
             </p>
           </div>
           <div className='text-center'>
             <p className='text-xs text-gray-600 dark:text-gray-400'>
-              {feeTokenSymbol} Price
+              {feeTokenSymbol ?? 'Fee'} Price
             </p>
             <p className='text-base font-bold text-gray-900 dark:text-gray-100'>
-              ${lmlnPrice || '0.0000'}
+              ${feeTokenPrice ?? '—'}
             </p>
           </div>
         </div>

--- a/src/hooks/pricing/usePriceDataFeed.ts
+++ b/src/hooks/pricing/usePriceDataFeed.ts
@@ -5,7 +5,6 @@ import {
   useReadPriceDataFeedGetDailyAveragesHistory,
   useReadPriceDataFeedDecimals,
   useReadLoansPriceDataFeed,
-  useReadLoansNativeGasToken,
   useReadLoansOriginationFeeToken
 } from '@/src/generated'
 
@@ -33,8 +32,18 @@ export interface UsePriceDataFeedReturn {
   refetch: () => Promise<void>
 }
 
-export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
-  // Get contract addresses from Loans contract
+/**
+ * Reads price data for a single collateral token plus the origination fee token.
+ *
+ * The collateral token is passed in by the caller (typically the first asset
+ * registered on the CollateralManager). We deliberately do NOT use
+ * Loans.nativeGasToken here — that's the chain's gas token (e.g. WBNB on BSC)
+ * which the price feed isn't required to track. The price banner cares about
+ * the actual collateral the user posts, which lives on CollateralManager.
+ */
+export const usePriceDataFeed = (
+  collateralTokenAddress: `0x${string}` | undefined
+): UsePriceDataFeedReturn => {
   const {
     data: priceDataFeedAddress,
     isLoading: isPriceDataFeedAddressLoading,
@@ -43,20 +52,12 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
   } = useReadLoansPriceDataFeed()
 
   const {
-    data: collateralTokenAddress,
-    isLoading: isCollateralTokenAddressLoading,
-    error: collateralTokenAddressError,
-    refetch: refetchCollateralTokenAddress
-  } = useReadLoansNativeGasToken()
-
-  const {
     data: originationFeeTokenAddress,
     isLoading: isOriginationFeeTokenAddressLoading,
     error: originationFeeTokenAddressError,
     refetch: refetchOriginationFeeTokenAddress
   } = useReadLoansOriginationFeeToken()
 
-  // Get spot price from PriceDataFeed contract
   const {
     data: spotPrice,
     isLoading: isSpotPriceLoading,
@@ -70,7 +71,6 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
     }
   })
 
-  // Get 30-day average price from PriceDataFeed contract
   const {
     data: monthlyAverage,
     isLoading: isMonthlyAverageLoading,
@@ -84,12 +84,13 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
     }
   })
 
-  // Get LMLN price using getDailyAveragesHistory (last 1 day)
+  // Origination-fee-token price via getDailyAveragesHistory (last 1 day).
+  // Returns DailyAverageEntry[]: [{ averagePrice, timestamp, dataPoints, confidence }]
   const {
-    data: lmlnPriceData,
-    isLoading: isLmlnPriceLoading,
-    error: lmlnPriceError,
-    refetch: refetchLmlnPrice
+    data: feeTokenPriceHistory,
+    isLoading: isFeeTokenPriceLoading,
+    error: feeTokenPriceError,
+    refetch: refetchFeeTokenPrice
   } = useReadPriceDataFeedGetDailyAveragesHistory({
     address: priceDataFeedAddress,
     args: originationFeeTokenAddress ? [originationFeeTokenAddress, 1] : undefined,
@@ -97,12 +98,8 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
       enabled: !!(priceDataFeedAddress && originationFeeTokenAddress)
     }
   })
+  const originationFeeTokenPrice = feeTokenPriceHistory?.[0]?.averagePrice
 
-  // Extract the averagePrice from the DailyAverageEntry struct
-  // getDailyAveragesHistory returns: [{ averagePrice, timestamp, dataPoints, confidence }]
-  const originationFeeTokenPrice = lmlnPriceData?.[0]?.averagePrice
-
-  // Get decimals from PriceDataFeed contract
   const {
     data: decimals,
     isLoading: isDecimalsLoading,
@@ -115,70 +112,53 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
     }
   })
 
-  // Combined loading states
   const isLoadingAddresses =
-    isPriceDataFeedAddressLoading || 
-    isCollateralTokenAddressLoading || 
-    isOriginationFeeTokenAddressLoading
+    isPriceDataFeedAddressLoading || isOriginationFeeTokenAddressLoading
   const isLoadingPrices =
-    isSpotPriceLoading || 
-    isMonthlyAverageLoading || 
-    isDecimalsLoading || 
-    isLmlnPriceLoading
+    isSpotPriceLoading ||
+    isMonthlyAverageLoading ||
+    isDecimalsLoading ||
+    isFeeTokenPriceLoading
   const isLoading = isLoadingAddresses || isLoadingPrices
 
-  // Combined error state
   const error =
     priceDataFeedAddressError ||
-    collateralTokenAddressError ||
     originationFeeTokenAddressError ||
     spotPriceError ||
     monthlyAverageError ||
     decimalsError ||
-    lmlnPriceError
+    feeTokenPriceError
 
-  // Refetch all data
   const refetch = useCallback(async () => {
     await Promise.all([
       refetchPriceDataFeedAddress(),
-      refetchCollateralTokenAddress(),
       refetchOriginationFeeTokenAddress(),
       refetchSpotPrice(),
       refetchMonthlyAverage(),
-      refetchLmlnPrice(),
+      refetchFeeTokenPrice(),
       refetchDecimals()
     ])
   }, [
     refetchPriceDataFeedAddress,
-    refetchCollateralTokenAddress,
     refetchOriginationFeeTokenAddress,
     refetchSpotPrice,
     refetchMonthlyAverage,
-    refetchLmlnPrice,
+    refetchFeeTokenPrice,
     refetchDecimals
   ])
 
   return {
-    // Contract addresses
     priceDataFeedAddress,
     collateralTokenAddress,
     originationFeeTokenAddress,
-
-    // Price data
     spotPrice,
     monthlyAverage,
     originationFeeTokenPrice,
     decimals,
-
-    // Loading states
     isLoading,
     isLoadingAddresses,
     isLoadingPrices,
-
-    // Error state
     error,
-
-    // Utility functions
     refetch
   }
 }

--- a/src/hooks/useCollateralManager.ts
+++ b/src/hooks/useCollateralManager.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useReadContract } from 'wagmi'
 import {
   useReadCollateralManagerGetSupportedAssets,
@@ -110,8 +110,14 @@ export function useCollateralManager(): UseCollateralManagerReturn {
   const { infos: supportedCollateralTokens, isLoading: metaLoading, error: metaError } =
     useCollateralAssets(cmAddress, allowedAddresses)
 
-  // No auto-selection — the user must always explicitly pick a collateral token
-  // before the loan calculator is usable. This is enforced in the LoanParameters UI.
+  // Auto-select when only one collateral token is configured — the selector UI
+  // is hidden in that case (LoanParameters checks supportedCollateralTokens.length).
+  // When two or more are configured the user must pick explicitly.
+  useEffect(() => {
+    if (supportedCollateralTokens.length === 1 && !selectedCollateral) {
+      setSelectedCollateral(supportedCollateralTokens[0])
+    }
+  }, [supportedCollateralTokens, selectedCollateral])
 
   const getCollateralByAddress = useMemo(
     () => (addr: string | undefined) => {

--- a/src/hooks/usePricing.ts
+++ b/src/hooks/usePricing.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import { usePriceDataFeed } from './pricing/usePriceDataFeed'
+import { useCollateralManager } from './useCollateralManager'
 import { useContractTokenConfiguration } from './useContractTokenConfiguration'
 import { formatTokenAmount, formatDisplayValue } from '@/src/utils/decimals'
-import type { UsePriceDataFeedReturn } from './pricing/usePriceDataFeed'
 
 // Re-export specialized hooks
 export { usePriceDataFeed } from './pricing/usePriceDataFeed'
@@ -12,12 +12,12 @@ export interface PriceData {
   // Raw values (bigint from contract)
   spotPriceRaw: bigint | undefined
   monthlyAverageRaw: bigint | undefined
-  lmlnPriceRaw: bigint | undefined
+  feeTokenPriceRaw: bigint | undefined
 
   // Formatted values (human-readable strings)
   spotPrice: string | undefined
   monthlyAverage: string | undefined
-  lmlnPrice: string | undefined
+  feeTokenPrice: string | undefined
 
   // Contract addresses
   priceDataFeedAddress: `0x${string}` | undefined
@@ -25,9 +25,8 @@ export interface PriceData {
   originationFeeTokenAddress: `0x${string}` | undefined
 
   // Token information
-  tokenSymbol: string | undefined
+  collateralSymbol: string | undefined
   feeTokenSymbol: string | undefined
-  tokenDecimals: number | undefined
 
   // States
   isLoading: boolean
@@ -37,31 +36,43 @@ export interface PriceData {
   refetch: () => Promise<void>
 }
 
+/**
+ * Aggregated pricing data for the dashboard banner.
+ *
+ * The collateral token surfaced for spot/monthly average is the first asset
+ * registered on the CollateralManager. The fee token (LMLN) is read from
+ * Loans.originationFeeToken().
+ */
 export const usePricing = (): PriceData => {
-  // Use focused hooks for specific concerns
-  const priceDataFeed = usePriceDataFeed()
+  const {
+    supportedCollateralTokens,
+    isLoading: collateralLoading,
+    error: collateralError
+  } = useCollateralManager()
   const {
     tokenConfig,
     isLoading: isTokenConfigLoading,
     error: tokenConfigError
   } = useContractTokenConfiguration()
 
-  // Combined loading and error states
-  const isLoading = priceDataFeed.isLoading || isTokenConfigLoading
-  const error = priceDataFeed.error || tokenConfigError
+  // Surface the first configured collateral token. The dashboard banner is
+  // a single-row summary; for multi-collateral deployments it gives a
+  // representative price (the calculator picks per-loan).
+  const collateral = supportedCollateralTokens[0]
+  const priceDataFeed = usePriceDataFeed(collateral?.address)
 
-  // Get token decimals for price formatting
+  const isLoading =
+    collateralLoading || priceDataFeed.isLoading || isTokenConfigLoading
+  const error = collateralError || priceDataFeed.error || tokenConfigError
+
   const priceDecimals = priceDataFeed.decimals
     ? Number(priceDataFeed.decimals)
     : undefined
-  const tokenSymbol = tokenConfig?.nativeToken.symbol
+  const collateralSymbol = collateral?.symbol
   const feeTokenSymbol = tokenConfig?.feeToken.symbol
-  const tokenDecimals = tokenConfig?.nativeToken.decimals
 
-  // Format price values
   const spotPrice = useMemo(() => {
-    if (!priceDataFeed.spotPrice || priceDecimals === undefined)
-      return undefined
+    if (!priceDataFeed.spotPrice || priceDecimals === undefined) return undefined
     const rawPrice = formatTokenAmount(priceDataFeed.spotPrice, priceDecimals)
     return formatDisplayValue(rawPrice, 2, 2)
   }, [priceDataFeed.spotPrice, priceDecimals])
@@ -76,42 +87,35 @@ export const usePricing = (): PriceData => {
     return formatDisplayValue(rawPrice, 2, 2)
   }, [priceDataFeed.monthlyAverage, priceDecimals])
 
-  const lmlnPrice = useMemo(() => {
+  const feeTokenPrice = useMemo(() => {
     if (!priceDataFeed.originationFeeTokenPrice || priceDecimals === undefined)
       return undefined
     const rawPrice = formatTokenAmount(
       priceDataFeed.originationFeeTokenPrice,
       priceDecimals
     )
-    return formatDisplayValue(rawPrice, 4, 4) // More decimals for LMLN since it's lower value
+    return formatDisplayValue(rawPrice, 4, 4) // smaller-value token → more decimals
   }, [priceDataFeed.originationFeeTokenPrice, priceDecimals])
 
   return {
-    // Raw values from usePriceDataFeed
     spotPriceRaw: priceDataFeed.spotPrice,
     monthlyAverageRaw: priceDataFeed.monthlyAverage,
-    lmlnPriceRaw: priceDataFeed.originationFeeTokenPrice,
+    feeTokenPriceRaw: priceDataFeed.originationFeeTokenPrice,
 
-    // Formatted values
     spotPrice,
     monthlyAverage,
-    lmlnPrice,
+    feeTokenPrice,
 
-    // Contract addresses from usePriceDataFeed
     priceDataFeedAddress: priceDataFeed.priceDataFeedAddress,
     collateralTokenAddress: priceDataFeed.collateralTokenAddress,
     originationFeeTokenAddress: priceDataFeed.originationFeeTokenAddress,
 
-    // Token information from useContractTokenConfiguration
-    tokenSymbol,
+    collateralSymbol,
     feeTokenSymbol,
-    tokenDecimals,
 
-    // Combined states
     isLoading,
     error,
 
-    // Utility from usePriceDataFeed
     refetch: priceDataFeed.refetch
   }
 }


### PR DESCRIPTION
PR #19 (BSC support) was merged before two follow-up commits on the `add-bnb-chain` branch could land — this PR cherry-picks them into develop so develop has every commit that was on `add-bnb-chain`.

## Cherry-picked commits

- **`fac45f5`** (originally `646df17`) — `fix: minimum-loan placeholder + auto-select single collateral token`
  - `useCollateralManager` auto-selects when exactly one collateral asset is configured. The selector UI is hidden in that case (LoanParameters checks `supportedCollateralTokens.length`). With two or more configured tokens the user still has to pick.
  - Loan-amount input no longer pre-fills with the contract minimum on first load. Placeholder now reads from `loanConfig.minLoanAmount`; native `min`/`max` attributes still enforce bounds.

- **`d622564`** (originally `b3f4bbf`) — `fix: price banner reads collateral token, not native gas token`
  - `usePriceDataFeed` takes the collateral token address as a parameter instead of reading `Loans.nativeGasToken()` internally. `usePricing` composes it from `useCollateralManager` (first registered asset). On BSC this stops the banner from trying to price WBNB (which has no fresh feed) and starts pricing the actual collateral.
  - Renamed `tokenSymbol` → `collateralSymbol` and `lmlnPrice` → `feeTokenPrice` so the data model matches what's displayed. Banner falls back to `—` when a price is unavailable instead of `$undefined` / `$0.0000`.

## Test plan

- [ ] On a single-collateral chain (LemonChain mainnet / testnet today): the calculator does **not** render the collateral selector — the form is usable immediately and the only configured token is auto-selected.
- [ ] On a deployment with two or more configured collateral assets, the selector still appears and the user must pick.
- [ ] The "How much do you need?" input starts empty with the contract minimum showing as gray placeholder; typing a value below the minimum surfaces the existing red-border state.
- [ ] PriceDataBanner labels the spot/monthly columns with the actual collateral symbol (e.g. WLEMX/LEMX) — not the chain's native gas token. On BSC, this resolves to the asset registered on CollateralManager rather than WBNB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)