### PR TITLE
Release: collateral selector + price banner fixes

### DIFF
--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -46,9 +46,12 @@ export function LoanParameters({
   setSelectedCollateral,
   isDashboard = false
 }: LoanParametersProps) {
-  // Always show the selector — the user must pick, even if only one token is configured.
-  const hasCollateralOptions = supportedCollateralTokens.length > 0
-  const needsCollateralChoice = hasCollateralOptions && !selectedCollateral
+  // Show the selector only when there's more than one collateral token to choose
+  // between. With a single configured token the user is auto-selected into it
+  // (handled by useCollateralManager) and the rest of the form is usable
+  // immediately.
+  const hasMultipleCollateral = supportedCollateralTokens.length > 1
+  const needsCollateralChoice = hasMultipleCollateral && !selectedCollateral
   // Use pre-calculated duration range from the hook
   const minDuration = durationRange.min
   const maxDuration = durationRange.max
@@ -96,8 +99,8 @@ export function LoanParameters({
         </CardTitle>
       </CardHeader>
       <CardContent className='space-y-6'>
-        {/* Collateral Token Selector — always required; the user must pick before the rest of the form is usable */}
-        {hasCollateralOptions && (
+        {/* Collateral Token Selector — only shown when more than one is configured */}
+        {hasMultipleCollateral && (
           <div>
             <label
               className={`block text-sm font-medium ${!isDashboard ? 'text-gray-300' : ''} mb-2`}
@@ -169,31 +172,10 @@ export function LoanParameters({
                   setLoanAmount(numValue)
                 }
               }}
-              onBlur={(e) => {
-                const value = e.target.value
-                const minAmount = loanConfig?.minLoanAmount
-                  ? Number(
-                      formatUnits(
-                        loanConfig.minLoanAmount,
-                        tokenConfig?.loanToken.decimals || 18
-                      )
-                    )
-                  : 1000
-                if (value === '' || Number(value) < minAmount) {
-                  setLoanAmount(minAmount)
-                }
-              }}
-              min={
-                loanConfig?.minLoanAmount
-                  ? formatUnits(
-                      loanConfig.minLoanAmount,
-                      tokenConfig?.loanToken.decimals || 18
-                    )
-                  : '1000'
-              }
+              min={minLoanAmount > 0 ? minLoanAmount : undefined}
               max={maxLoanAmount}
-              className={`pl-8 text-lg ${!isDashboard ? 'bg-white/10 border-white/20 text-white placeholder:text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed' : 'disabled:opacity-50 disabled:cursor-not-allowed'} ${isBelowMinimum ? 'border-red-500 ring-1 ring-red-500' : ''}`}
-              placeholder='10000'
+              className={`pl-8 text-lg ${!isDashboard ? 'bg-white/10 border-white/20 text-white placeholder:text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed' : 'placeholder:text-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed'} ${isBelowMinimum ? 'border-red-500 ring-1 ring-red-500' : ''}`}
+              placeholder={minLoanAmount > 0 ? String(minLoanAmount) : ''}
             />
           </div>
           {hasNoLiquidity ? (

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -3,12 +3,9 @@
 import { Button } from '../ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { Plus } from 'lucide-react'
-import { formatTokenAmount } from '../../utils/decimals'
-import { formatUnits } from 'viem'
 import { useState } from 'react'
 import { DisclaimerModal } from '../common/DisclaimerModal'
 import { LoanConfirmationModal } from '../common/LoanConfirmationModal'
-import { loanConfigQueryOptions } from '@/src/hooks/query/loanQueries'
 
 interface LoanSummaryProps {
   calculation: any
@@ -53,7 +50,10 @@ export function LoanSummary({
   isDashboard = false,
   selectedLtvOption
 }: LoanSummaryProps) {
-  const collateral = collateralSymbol || tokenConfig?.nativeToken.symbol
+  // Don't fall back to tokenConfig.nativeToken.symbol — that's the chain's
+  // gas token (tLEMX, BNB, …), unrelated to the actual collateral the user is
+  // posting. Use a neutral label until selectedCollateral resolves.
+  const collateral = collateralSymbol ?? 'Collateral'
   const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false)
 
   const handleDisclaimerContinue = () => {

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -144,22 +144,9 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   // Get initial loan config and options - moved up to avoid initialization error
   const initialHookData: UseLoansReturn = useLoans()
 
-  // Set initial values from contract config
+  // Set initial values from contract config (loanAmount stays at 0 so the
+  // input shows the placeholder — the user has to type the desired amount).
   useEffect(() => {
-    if (
-      initialHookData.loanConfig &&
-      initialHookData.loanConfig.minLoanAmount &&
-      loanAmount === 0
-    ) {
-      setLoanAmount(
-        Number(
-          formatUnits(
-            initialHookData.loanConfig.minLoanAmount,
-            tokenConfig?.loanToken.decimals || 18
-          )
-        )
-      )
-    }
     // Snap LTV to the first option for the selected collateral — on first load (ltv===0)
     // and when the user switches collateral tokens and the current LTV isn't in the new set.
     if (perAssetConfig.ltvOptions.length > 0 && tokenConfig) {

--- a/src/components/dashboard/PriceDataBanner.tsx
+++ b/src/components/dashboard/PriceDataBanner.tsx
@@ -55,14 +55,14 @@ function PriceDataBannerError({ error }: { error: Error }) {
 }
 
 export function PriceDataBanner() {
-  const { 
-    spotPrice, 
-    monthlyAverage, 
-    lmlnPrice, 
-    tokenSymbol, 
-    feeTokenSymbol, 
-    isLoading, 
-    error 
+  const {
+    spotPrice,
+    monthlyAverage,
+    feeTokenPrice,
+    collateralSymbol,
+    feeTokenSymbol,
+    isLoading,
+    error
   } = usePricing()
 
   if (isLoading) return <PriceDataBannerSkeleton />
@@ -86,26 +86,26 @@ export function PriceDataBanner() {
         <div className='flex items-center gap-8'>
           <div className='text-center'>
             <p className='text-xs text-gray-600 dark:text-gray-400'>
-              {tokenSymbol} Price
+              {collateralSymbol ?? 'Collateral'} Price
             </p>
             <p className='text-base font-bold text-gray-900 dark:text-gray-100'>
-              ${spotPrice}
+              ${spotPrice ?? '—'}
             </p>
           </div>
           <div className='text-center'>
             <p className='text-xs text-gray-600 dark:text-gray-400'>
-              {tokenSymbol} Monthly Avg
+              {collateralSymbol ?? 'Collateral'} Monthly Avg
             </p>
             <p className='text-base font-bold text-gray-900 dark:text-gray-100'>
-              ${monthlyAverage}
+              ${monthlyAverage ?? '—'}
             </p>
           </div>
           <div className='text-center'>
             <p className='text-xs text-gray-600 dark:text-gray-400'>
-              {feeTokenSymbol} Price
+              {feeTokenSymbol ?? 'Fee'} Price
             </p>
             <p className='text-base font-bold text-gray-900 dark:text-gray-100'>
-              ${lmlnPrice || '0.0000'}
+              ${feeTokenPrice ?? '—'}
             </p>
           </div>
         </div>

--- a/src/hooks/pricing/usePriceDataFeed.ts
+++ b/src/hooks/pricing/usePriceDataFeed.ts
@@ -5,7 +5,6 @@ import {
   useReadPriceDataFeedGetDailyAveragesHistory,
   useReadPriceDataFeedDecimals,
   useReadLoansPriceDataFeed,
-  useReadLoansNativeGasToken,
   useReadLoansOriginationFeeToken
 } from '@/src/generated'
 
@@ -33,8 +32,18 @@ export interface UsePriceDataFeedReturn {
   refetch: () => Promise<void>
 }
 
-export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
-  // Get contract addresses from Loans contract
+/**
+ * Reads price data for a single collateral token plus the origination fee token.
+ *
+ * The collateral token is passed in by the caller (typically the first asset
+ * registered on the CollateralManager). We deliberately do NOT use
+ * Loans.nativeGasToken here — that's the chain's gas token (e.g. WBNB on BSC)
+ * which the price feed isn't required to track. The price banner cares about
+ * the actual collateral the user posts, which lives on CollateralManager.
+ */
+export const usePriceDataFeed = (
+  collateralTokenAddress: `0x${string}` | undefined
+): UsePriceDataFeedReturn => {
   const {
     data: priceDataFeedAddress,
     isLoading: isPriceDataFeedAddressLoading,
@@ -43,20 +52,12 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
   } = useReadLoansPriceDataFeed()
 
   const {
-    data: collateralTokenAddress,
-    isLoading: isCollateralTokenAddressLoading,
-    error: collateralTokenAddressError,
-    refetch: refetchCollateralTokenAddress
-  } = useReadLoansNativeGasToken()
-
-  const {
     data: originationFeeTokenAddress,
     isLoading: isOriginationFeeTokenAddressLoading,
     error: originationFeeTokenAddressError,
     refetch: refetchOriginationFeeTokenAddress
   } = useReadLoansOriginationFeeToken()
 
-  // Get spot price from PriceDataFeed contract
   const {
     data: spotPrice,
     isLoading: isSpotPriceLoading,
@@ -70,7 +71,6 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
     }
   })
 
-  // Get 30-day average price from PriceDataFeed contract
   const {
     data: monthlyAverage,
     isLoading: isMonthlyAverageLoading,
@@ -84,12 +84,13 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
     }
   })
 
-  // Get LMLN price using getDailyAveragesHistory (last 1 day)
+  // Origination-fee-token price via getDailyAveragesHistory (last 1 day).
+  // Returns DailyAverageEntry[]: [{ averagePrice, timestamp, dataPoints, confidence }]
   const {
-    data: lmlnPriceData,
-    isLoading: isLmlnPriceLoading,
-    error: lmlnPriceError,
-    refetch: refetchLmlnPrice
+    data: feeTokenPriceHistory,
+    isLoading: isFeeTokenPriceLoading,
+    error: feeTokenPriceError,
+    refetch: refetchFeeTokenPrice
   } = useReadPriceDataFeedGetDailyAveragesHistory({
     address: priceDataFeedAddress,
     args: originationFeeTokenAddress ? [originationFeeTokenAddress, 1] : undefined,
@@ -97,12 +98,8 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
       enabled: !!(priceDataFeedAddress && originationFeeTokenAddress)
     }
   })
+  const originationFeeTokenPrice = feeTokenPriceHistory?.[0]?.averagePrice
 
-  // Extract the averagePrice from the DailyAverageEntry struct
-  // getDailyAveragesHistory returns: [{ averagePrice, timestamp, dataPoints, confidence }]
-  const originationFeeTokenPrice = lmlnPriceData?.[0]?.averagePrice
-
-  // Get decimals from PriceDataFeed contract
   const {
     data: decimals,
     isLoading: isDecimalsLoading,
@@ -115,70 +112,53 @@ export const usePriceDataFeed = (): UsePriceDataFeedReturn => {
     }
   })
 
-  // Combined loading states
   const isLoadingAddresses =
-    isPriceDataFeedAddressLoading || 
-    isCollateralTokenAddressLoading || 
-    isOriginationFeeTokenAddressLoading
+    isPriceDataFeedAddressLoading || isOriginationFeeTokenAddressLoading
   const isLoadingPrices =
-    isSpotPriceLoading || 
-    isMonthlyAverageLoading || 
-    isDecimalsLoading || 
-    isLmlnPriceLoading
+    isSpotPriceLoading ||
+    isMonthlyAverageLoading ||
+    isDecimalsLoading ||
+    isFeeTokenPriceLoading
   const isLoading = isLoadingAddresses || isLoadingPrices
 
-  // Combined error state
   const error =
     priceDataFeedAddressError ||
-    collateralTokenAddressError ||
     originationFeeTokenAddressError ||
     spotPriceError ||
     monthlyAverageError ||
     decimalsError ||
-    lmlnPriceError
+    feeTokenPriceError
 
-  // Refetch all data
   const refetch = useCallback(async () => {
     await Promise.all([
       refetchPriceDataFeedAddress(),
-      refetchCollateralTokenAddress(),
       refetchOriginationFeeTokenAddress(),
       refetchSpotPrice(),
       refetchMonthlyAverage(),
-      refetchLmlnPrice(),
+      refetchFeeTokenPrice(),
       refetchDecimals()
     ])
   }, [
     refetchPriceDataFeedAddress,
-    refetchCollateralTokenAddress,
     refetchOriginationFeeTokenAddress,
     refetchSpotPrice,
     refetchMonthlyAverage,
-    refetchLmlnPrice,
+    refetchFeeTokenPrice,
     refetchDecimals
   ])
 
   return {
-    // Contract addresses
     priceDataFeedAddress,
     collateralTokenAddress,
     originationFeeTokenAddress,
-
-    // Price data
     spotPrice,
     monthlyAverage,
     originationFeeTokenPrice,
     decimals,
-
-    // Loading states
     isLoading,
     isLoadingAddresses,
     isLoadingPrices,
-
-    // Error state
     error,
-
-    // Utility functions
     refetch
   }
 }

--- a/src/hooks/useCollateralManager.ts
+++ b/src/hooks/useCollateralManager.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useReadContract } from 'wagmi'
 import {
   useReadCollateralManagerGetSupportedAssets,
@@ -110,8 +110,14 @@ export function useCollateralManager(): UseCollateralManagerReturn {
   const { infos: supportedCollateralTokens, isLoading: metaLoading, error: metaError } =
     useCollateralAssets(cmAddress, allowedAddresses)
 
-  // No auto-selection — the user must always explicitly pick a collateral token
-  // before the loan calculator is usable. This is enforced in the LoanParameters UI.
+  // Auto-select when only one collateral token is configured — the selector UI
+  // is hidden in that case (LoanParameters checks supportedCollateralTokens.length).
+  // When two or more are configured the user must pick explicitly.
+  useEffect(() => {
+    if (supportedCollateralTokens.length === 1 && !selectedCollateral) {
+      setSelectedCollateral(supportedCollateralTokens[0])
+    }
+  }, [supportedCollateralTokens, selectedCollateral])
 
   const getCollateralByAddress = useMemo(
     () => (addr: string | undefined) => {

--- a/src/hooks/usePricing.ts
+++ b/src/hooks/usePricing.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import { usePriceDataFeed } from './pricing/usePriceDataFeed'
+import { useCollateralManager } from './useCollateralManager'
 import { useContractTokenConfiguration } from './useContractTokenConfiguration'
 import { formatTokenAmount, formatDisplayValue } from '@/src/utils/decimals'
-import type { UsePriceDataFeedReturn } from './pricing/usePriceDataFeed'
 
 // Re-export specialized hooks
 export { usePriceDataFeed } from './pricing/usePriceDataFeed'
@@ -12,12 +12,12 @@ export interface PriceData {
   // Raw values (bigint from contract)
   spotPriceRaw: bigint | undefined
   monthlyAverageRaw: bigint | undefined
-  lmlnPriceRaw: bigint | undefined
+  feeTokenPriceRaw: bigint | undefined
 
   // Formatted values (human-readable strings)
   spotPrice: string | undefined
   monthlyAverage: string | undefined
-  lmlnPrice: string | undefined
+  feeTokenPrice: string | undefined
 
   // Contract addresses
   priceDataFeedAddress: `0x${string}` | undefined
@@ -25,9 +25,8 @@ export interface PriceData {
   originationFeeTokenAddress: `0x${string}` | undefined
 
   // Token information
-  tokenSymbol: string | undefined
+  collateralSymbol: string | undefined
   feeTokenSymbol: string | undefined
-  tokenDecimals: number | undefined
 
   // States
   isLoading: boolean
@@ -37,31 +36,43 @@ export interface PriceData {
   refetch: () => Promise<void>
 }
 
+/**
+ * Aggregated pricing data for the dashboard banner.
+ *
+ * The collateral token surfaced for spot/monthly average is the first asset
+ * registered on the CollateralManager. The fee token (LMLN) is read from
+ * Loans.originationFeeToken().
+ */
 export const usePricing = (): PriceData => {
-  // Use focused hooks for specific concerns
-  const priceDataFeed = usePriceDataFeed()
+  const {
+    supportedCollateralTokens,
+    isLoading: collateralLoading,
+    error: collateralError
+  } = useCollateralManager()
   const {
     tokenConfig,
     isLoading: isTokenConfigLoading,
     error: tokenConfigError
   } = useContractTokenConfiguration()
 
-  // Combined loading and error states
-  const isLoading = priceDataFeed.isLoading || isTokenConfigLoading
-  const error = priceDataFeed.error || tokenConfigError
+  // Surface the first configured collateral token. The dashboard banner is
+  // a single-row summary; for multi-collateral deployments it gives a
+  // representative price (the calculator picks per-loan).
+  const collateral = supportedCollateralTokens[0]
+  const priceDataFeed = usePriceDataFeed(collateral?.address)
 
-  // Get token decimals for price formatting
+  const isLoading =
+    collateralLoading || priceDataFeed.isLoading || isTokenConfigLoading
+  const error = collateralError || priceDataFeed.error || tokenConfigError
+
   const priceDecimals = priceDataFeed.decimals
     ? Number(priceDataFeed.decimals)
     : undefined
-  const tokenSymbol = tokenConfig?.nativeToken.symbol
+  const collateralSymbol = collateral?.symbol
   const feeTokenSymbol = tokenConfig?.feeToken.symbol
-  const tokenDecimals = tokenConfig?.nativeToken.decimals
 
-  // Format price values
   const spotPrice = useMemo(() => {
-    if (!priceDataFeed.spotPrice || priceDecimals === undefined)
-      return undefined
+    if (!priceDataFeed.spotPrice || priceDecimals === undefined) return undefined
     const rawPrice = formatTokenAmount(priceDataFeed.spotPrice, priceDecimals)
     return formatDisplayValue(rawPrice, 2, 2)
   }, [priceDataFeed.spotPrice, priceDecimals])
@@ -76,42 +87,35 @@ export const usePricing = (): PriceData => {
     return formatDisplayValue(rawPrice, 2, 2)
   }, [priceDataFeed.monthlyAverage, priceDecimals])
 
-  const lmlnPrice = useMemo(() => {
+  const feeTokenPrice = useMemo(() => {
     if (!priceDataFeed.originationFeeTokenPrice || priceDecimals === undefined)
       return undefined
     const rawPrice = formatTokenAmount(
       priceDataFeed.originationFeeTokenPrice,
       priceDecimals
     )
-    return formatDisplayValue(rawPrice, 4, 4) // More decimals for LMLN since it's lower value
+    return formatDisplayValue(rawPrice, 4, 4) // smaller-value token → more decimals
   }, [priceDataFeed.originationFeeTokenPrice, priceDecimals])
 
   return {
-    // Raw values from usePriceDataFeed
     spotPriceRaw: priceDataFeed.spotPrice,
     monthlyAverageRaw: priceDataFeed.monthlyAverage,
-    lmlnPriceRaw: priceDataFeed.originationFeeTokenPrice,
+    feeTokenPriceRaw: priceDataFeed.originationFeeTokenPrice,
 
-    // Formatted values
     spotPrice,
     monthlyAverage,
-    lmlnPrice,
+    feeTokenPrice,
 
-    // Contract addresses from usePriceDataFeed
     priceDataFeedAddress: priceDataFeed.priceDataFeedAddress,
     collateralTokenAddress: priceDataFeed.collateralTokenAddress,
     originationFeeTokenAddress: priceDataFeed.originationFeeTokenAddress,
 
-    // Token information from useContractTokenConfiguration
-    tokenSymbol,
+    collateralSymbol,
     feeTokenSymbol,
-    tokenDecimals,
 
-    // Combined states
     isLoading,
     error,
 
-    // Utility from usePriceDataFeed
     refetch: priceDataFeed.refetch
   }
 }


### PR DESCRIPTION
Promotes the post-BSC fixes (PR #21 + the LoanSummary tLEMX fallback fix) from `develop` to `main`.

## Summary

- **`fac45f5` — auto-select single collateral + min-loan placeholder.** When exactly one collateral token is configured on the CollateralManager, the calculator hides the selector and auto-picks that token. The "How much do you need?" input no longer pre-fills with the contract minimum — it shows the minimum as a gray placeholder and the user types the real amount.
- **`d622564` — price banner reads the collateral token, not native gas.** `usePriceDataFeed` now takes a collateral address as an argument and `usePricing` composes it from `useCollateralManager`. On BSC this stops the banner from trying to price WBNB (which has no fresh feed) and prices the actual CollateralManager-registered token instead. Banner falls back to `—` when a price isn't available rather than `$0.0000` / `$undefined`.
- **`139fe8e` — Loan Summary stops falling back to the chain gas token.** The `collateral` label was `collateralSymbol || tokenConfig?.nativeToken.symbol`, which briefly displayed `tLEMX Collateral` / `BNB Collateral` on first paint. Switched to a neutral `'Collateral'` placeholder until the actual symbol resolves. Also dropped three unused imports flagged by the IDE.

## Test plan

- [ ] Single-collateral chain (LemonChain mainnet today): the calculator does **not** render the collateral selector — the form is usable immediately and the only configured token is auto-selected.
- [ ] Loan Summary's collateral row reads `LEMX Collateral` (or whatever the registered asset is), never `tLEMX Collateral` or `BNB Collateral`.
- [ ] "How much do you need?" starts empty with the contract minimum showing as gray placeholder.
- [ ] PriceDataBanner labels its spot/monthly columns with the actual collateral symbol (the asset on CollateralManager) — not the chain's gas token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)