### PR TITLE
Release: mobile header + price banner + empty-input polish

### DIFF
--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -241,11 +241,16 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
 
     // Check if we have calculation data from contract
     if (!loanOperations.calculationData) {
+      // No calculation yet just because the user hasn't typed a loan amount
+      // — show a neutral "—" instead of an alarming error string.
+      const noInput = !loanAmount
       return {
         ...base,
         priceError: loanOperations.isSimulating
           ? 'Calculating collateral...'
-          : 'Contract calculation not available'
+          : noInput
+            ? '—'
+            : 'Contract calculation not available'
       }
     }
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,22 +9,23 @@ export default function Header() {
 
   return (
     <div className='sticky top-0 z-50 flex items-center justify-center w-full border-b border-border/40 bg-background'>
-      <header className='flex items-center justify-between p-4 min-w-full max-w-screen-xl'>
-        <div className='flex items-center space-x-3'>
-          <Link href='/' className='flex items-center space-x-3'>
+      <header className='flex items-center justify-between gap-3 p-3 sm:p-4 min-w-full max-w-screen-xl'>
+        <div className='flex items-center min-w-0 gap-2 sm:gap-3'>
+          <Link href='/' className='flex items-center gap-2 sm:gap-3 shrink-0'>
             <Image
               src='/images/lemloans-logo.png'
               alt='LemLoans Logo'
               width={40}
               height={40}
-              className='h-auto'
+              className='h-8 w-8 sm:h-10 sm:w-10'
               priority
             />
-            <h1 className='text-2xl font-bold text-gray-900 dark:text-gray-100'>
+            {/* Wordmark hidden on small screens to prevent overlap with nav + wallet button */}
+            <h1 className='hidden sm:block text-2xl font-bold text-gray-900 dark:text-gray-100'>
               LemLoans
             </h1>
           </Link>
-          <nav className='flex items-center space-x-4 ml-6'>
+          <nav className='flex items-center gap-3 sm:gap-4 sm:ml-6 shrink-0'>
             <Link
               href='/'
               className={`text-sm font-medium transition-colors ${
@@ -47,7 +48,21 @@ export default function Header() {
             </Link>
           </nav>
         </div>
-        <ConnectButton />
+        {/* Compact RainbowKit button on small screens — drop balance, use a shorter label
+            and the icon-only chain status so the wallet pill doesn't blow out the header. */}
+        <div className='shrink-0'>
+          <div className='hidden sm:block'>
+            <ConnectButton />
+          </div>
+          <div className='block sm:hidden'>
+            <ConnectButton
+              label='Connect'
+              showBalance={false}
+              accountStatus='avatar'
+              chainStatus='icon'
+            />
+          </div>
+        </div>
       </header>
     </div>
   )

--- a/src/components/dashboard/PriceDataBanner.tsx
+++ b/src/components/dashboard/PriceDataBanner.tsx
@@ -70,10 +70,13 @@ export function PriceDataBanner() {
 
   return (
     <Card>
-      <CardContent className='flex items-center justify-between p-4 pr-8'>
+      {/* On mobile: title row stacks above a 3-column price grid so the
+          values get equal share of the width and don't get cut off. On
+          sm+ the original side-by-side layout returns. */}
+      <CardContent className='flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:pr-8'>
         <div className='flex items-center gap-3'>
-          <BarChart className='h-5 w-5 text-blue-600 dark:text-blue-400' />
-          <div>
+          <BarChart className='h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400' />
+          <div className='min-w-0'>
             <h3 className='text-sm font-semibold text-gray-900 dark:text-gray-100'>
               Token Price Data
             </h3>
@@ -83,7 +86,7 @@ export function PriceDataBanner() {
           </div>
         </div>
 
-        <div className='flex items-center gap-8'>
+        <div className='grid grid-cols-3 gap-3 sm:flex sm:items-center sm:gap-8'>
           <div className='text-center'>
             <p className='text-xs text-gray-600 dark:text-gray-400'>
               {collateralSymbol ?? 'Collateral'} Price


### PR DESCRIPTION
Promotes three follow-up fixes from `develop` to `main`.

## Summary

- **`7b91374` — mobile header layout.** Logo + nav + wallet button were overlapping on phones. Wordmark hides below the `sm` breakpoint (logo only), the RainbowKit pill switches to a compact variant on mobile (`label="Connect"`, no balance, avatar-only account state, icon-only chain), and shrink-0 wrappers stop the wallet button from wrapping onto the nav.
- **`6e80908` — price banner mobile layout.** The three price cells were squeezed into a horizontal flex row that clipped LMLN on narrow widths. The card now stacks vertically on mobile (title row above a 3-column equal-share grid) and keeps the original side-by-side layout on `sm+`.
- **`e515c7a` — neutral placeholder when no loan amount.** Empty loan-amount input was rendering "Contract calculation not available" in the Loan Summary, which read like an error. Replaced with a single "—" while the input is empty; real calculation failures (input present, no data) still surface the original message.

## Test plan

- [ ] On a phone-width viewport, the header shows the logo, two nav links, and a compact "Connect" pill on a single row with no overlap.
- [ ] PriceDataBanner stacks (title row over 3-column price grid) on mobile and stays inline on tablet/desktop. LMLN price column is fully visible at all widths.
- [ ] Loan Summary collateral row reads `LEMX Collateral · —` (or the active collateral) when the loan-amount input is empty. Typing a value still triggers the calculation states ("Calculating collateral..." / numeric result) as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)