### PR TITLE
Release: liquidity multiplier scale + loan calculator UX + payment fixes

### DIFF
--- a/docs/mainnet-setup.md
+++ b/docs/mainnet-setup.md
@@ -42,7 +42,7 @@ Then rebuild so `wagmi generate` picks up the new Loans address(es):
 npm run build
 ```
 
-> Make sure the on-chain wiring in Steps 3 and 9 is correct before deploying — if `Loans.collateralManager()` or `Loans.liquidityPool()` return the zero address the UI will not be able to read anything downstream.
+> Make sure the on-chain wiring in Steps 3 and 11 is correct before deploying — if `Loans.collateralManager()` or `Loans.liquidityPool()` return the zero address the UI cannot read anything downstream.
 
 ---
 
@@ -62,12 +62,22 @@ The pool cannot route non-stable deposits without this.
 
 ---
 
-## Step 3 — Wire the CollateralManager
+## Step 3 — Wire CollateralManager, LiquidityPool, and PriceHelper into Loans
 
-The CollateralManager holds collateral for active loans. Loans and CollateralManager reference each other directly, and CollateralManager uses PriceHelper to value non-stable collateral.
+The Loans contract holds references to the rest of the protocol. Set them all here so the on-chain `Loans.collateralManager()` / `Loans.liquidityPool()` getters return the right addresses (the dapp discovers everything else from those at runtime).
 
 ```solidity
 Loans.setCollateralManager(<CollateralManager address>)
+Loans.setLiquidityPool(<LiquidityPool address>)
+Loans.setPriceHelper(<PriceHelper address>)
+Loans.setPriceFeed(<PriceDataFeed address>)
+Loans.setOriginationFeeToken(<LMLN token address>)   // skip if already set during initialize()
+Loans.setNativeGasToken(<wrapped native token>)      // skip if already set during initialize()
+```
+
+The CollateralManager needs the same wiring so it can mint/release collateral and price it for liquidation:
+
+```solidity
 CollateralManager.setLoans(<Loans address>)
 CollateralManager.setPriceHelper(<PriceHelper address>)
 CollateralManager.setDefaultLiquidator(<DefaultLiquidator address>)
@@ -75,34 +85,49 @@ CollateralManager.setDefaultLiquidator(<DefaultLiquidator address>)
 
 **Verify:**
 ```solidity
-CollateralManager.setLoans     // read via storage or re-read via getter if exposed
-CollateralManager.setPriceHelper
-// Loans → CollateralManager wiring is validated implicitly when initiateLoan succeeds in step 11.
+Loans.collateralManager()   // → CollateralManager address
+Loans.liquidityPool()       // → LiquidityPool address
+Loans.priceHelper()         // → PriceHelper address
+Loans.priceDataFeed()       // → PriceDataFeed address
+// CollateralManager's references are not exposed via public getters — they
+// are validated implicitly when initiateLoan succeeds in the final smoke test.
 ```
 
-Without this, `initiateLoan` will revert when trying to hand collateral to the CollateralManager.
+Without this wiring, `initiateLoan` reverts when handing collateral to the CollateralManager or pricing it.
 
 ---
 
 ## Step 4 — Grant contract roles
 
-The Loans contract must have `MANAGER_ROLE` on the LiquidityPool so it can deposit collateral during loan creation. Without this, `initiateLoan` reverts with no error data.
+Each protocol contract uses OpenZeppelin's `AccessControl` with these role constants:
+
+- **Loans:** `DEFAULT_ADMIN_ROLE`, `MANAGER_ROLE`, `LENDER_ROLE`, `PRICE_SETTER_ROLE`, `UPGRADER_ROLE`
+- **LiquidityPool:** `DEFAULT_ADMIN_ROLE`, `MANAGER_ROLE`, `MINIMUM_BYPASS_ROLE`, `UPGRADER_ROLE`
+- **CollateralManager:** `DEFAULT_ADMIN_ROLE`, `MANAGER_ROLE`, `UPGRADER_ROLE`
+
+The minimum cross-contract grants needed for a working deployment:
 
 ```solidity
+// Loans must be able to deposit collateral / pull liquidity from the pool
 LiquidityPool.grantRole(MANAGER_ROLE, <Loans address>)
+
+// Loans must be able to lock/release collateral on the CollateralManager
+CollateralManager.grantRole(MANAGER_ROLE, <Loans address>)
+
+// LiquidityPool must be able to act as the lender on the Loans contract
+Loans.grantRole(LENDER_ROLE, <LiquidityPool address>)
+
+// Off-chain price keeper (the EOA / bot pushing prices to PriceDataFeed)
+Loans.grantRole(PRICE_SETTER_ROLE, <price keeper address>)
 ```
 
-The CollateralManager needs a role on the Loans contract so it can call back during liquidation, and Loans needs a role on the CollateralManager so it can lock/release collateral. Grant whichever roles the contracts' `onlyRole` modifiers require (check the source).
-
-```solidity
-CollateralManager.grantRole(LOANS_ROLE, <Loans address>)
-// plus any other roles the deployed contracts require between Loans ↔ CollateralManager
-```
+Read the deployed source for any project-specific roles (e.g. liquidator roles) before considering this step done.
 
 **Verify:**
 ```solidity
-LiquidityPool.hasRole(MANAGER_ROLE, <Loans address>)
-CollateralManager.hasRole(LOANS_ROLE, <Loans address>)
+LiquidityPool.hasRole(MANAGER_ROLE, <Loans>)
+CollateralManager.hasRole(MANAGER_ROLE, <Loans>)
+Loans.hasRole(LENDER_ROLE, <LiquidityPool>)
 // Expected: true for each
 ```
 
@@ -122,7 +147,53 @@ The price feed is configured independently of the LiquidityPool and CollateralMa
 
 ---
 
-## Step 6 — Configure collateral assets (CollateralManager)
+## Step 6 — Configure global Loans parameters
+
+These globals apply to every loan regardless of collateral and back the constants the dapp reads at app load (the loan calculator's min/max amount, slider bounds, and grace period).
+
+```solidity
+Loans.setLoanConfiguration(
+  <minLoanAmount>,                // raw stable-token wei
+  <minLoanDuration>,              // seconds
+  <maxLoanDuration>,              // seconds
+  <balloonPaymentGraceDuration>,  // seconds — grace after loan end before default
+  <loanCycleDuration>,            // seconds per cycle (drives interest cadence)
+  <aprYearDuration>               // seconds in a year (e.g. 31536000); APR scales by this
+)
+
+Loans.setMaxLoanAmount(<absolute ceiling, raw stable-token wei>)
+Loans.setWithdrawalReserve(<reserve amount, raw stable-token wei>)   // optional
+```
+
+**Verify:**
+```solidity
+Loans.loanConfig()        // → tuple matching the values you just set
+Loans.maxLoanAmount()     // → ceiling
+Loans.withdrawalReserve() // → reserve
+```
+
+If `loanConfig()` returns zeros, the dapp's calculator is unusable — `minLoanAmount` and `loanCycleDuration` drive the form defaults and the on-screen countdown.
+
+---
+
+## Step 7 — Configure origination-fee distribution
+
+```solidity
+Loans.setOriginationFeeReceiver(<receiver address>)        // required: where origination fees go
+Loans.setOriginationFeeSplit(<burnBps>, <donationBps>)     // optional: portions burnt / donated
+```
+
+`burnBps + donationBps` must be ≤ `10_000` (= 100%). Any remainder stays with the receiver.
+
+**Verify:**
+```solidity
+Loans.originationFeeReceiver()
+Loans.originationFeeSplit()
+```
+
+---
+
+## Step 8 — Configure collateral assets (CollateralManager)
 
 Each token that users can post as collateral must be registered on the CollateralManager. The config tuple is `(allowed, usesPriceFeed, stablePrice, decimals)`.
 
@@ -158,7 +229,7 @@ The UI reads `getSupportedAssets()` and auto-selects when exactly one collateral
 
 ---
 
-## Step 7 — Configure interest APR tiers per asset (Loans)
+## Step 9 — Configure interest APR tiers per asset (Loans)
 
 Each collateral asset must have at least one APR tier defined, keyed by duration range. The UI reads these to offer APR by loan duration.
 
@@ -188,7 +259,7 @@ Loans.removeInterestAprConfig(<collateral token address>, <index>)
 
 ---
 
-## Step 8 — Configure LTV / origination fee options per asset (Loans)
+## Step 10 — Configure LTV / origination fee options per asset (Loans)
 
 Each collateral asset must have at least one LTV option with its corresponding origination fee. The UI surfaces these as the LTV slider's discrete steps.
 
@@ -210,7 +281,7 @@ Loans.getAllOriginationFees(<collateral token address>)
 
 ---
 
-## Step 9 — Configure supported deposit assets (LiquidityPool)
+## Step 11 — Configure supported deposit assets (LiquidityPool)
 
 The `AssetStatus` enum:
 - `0` — Disabled
@@ -248,7 +319,7 @@ LiquidityPool.getAssetConfig(<token address>)
 
 ---
 
-## Step 10 — Add lock tiers
+## Step 12 — Add lock tiers
 
 Each user-depositable asset must have at least one lock tier before the deposit UI will show it.
 
@@ -270,7 +341,7 @@ LiquidityPool.getAssetLockTiers(<token address>)
 
 ---
 
-## Step 11 — Set the minimum deposit
+## Step 13 — Set the minimum deposit
 
 ```solidity
 LiquidityPool.setMinimumDeposit(<amount in raw stable token units>)
@@ -291,7 +362,7 @@ LiquidityPool.minimumDepositValue()
 
 ---
 
-## Step 12 — Configure native fees
+## Step 14 — Configure native fees
 
 The pool charges a small native token fee on `claimEarnings`, `compoundEarnings`, and `claimWithdrawal`. Set the amounts and the receiver address:
 
@@ -324,7 +395,7 @@ LiquidityPool.nativeFeeReceiver()
 
 ---
 
-## Step 13 — Set earnings frequency
+## Step 15 — Set earnings frequency
 
 Controls how often the pool allows earnings to be pulled from the Loans contract:
 
@@ -347,20 +418,22 @@ Run through this before opening to users. Repeat the asset-specific rows for eve
 
 | # | Check | How to verify | Expected result |
 |---|---|---|---|
-| 1 | Environment variables set | `.env` / Cloudflare secrets | `NEXT_PUBLIC_*_LOANS_ADDRESS` populated; all other contract addresses come from on-chain reads |
+| 1 | Environment variables set | `.env` / Cloudflare secrets | `NEXT_PUBLIC_*_LOANS_ADDRESS` populated for every chain id in `NEXT_PUBLIC_SUPPORTED_CHAINS`; nothing else needed (other addresses are read from chain) |
 | 2 | Build passes | `npm run build` | No errors |
 | 3 | SwapManager wired | `LiquidityPool.swapManager()` | SwapManager address |
-| 4 | CollateralManager wired | Loans/CollateralManager reference each other, PriceHelper set | Successful `initiateLoan` |
-| 5 | Loans has MANAGER_ROLE | `LiquidityPool.hasRole(MANAGER_ROLE, Loans)` | `true` |
-| 6 | Loans ↔ CollateralManager roles granted | `CollateralManager.hasRole(LOANS_ROLE, Loans)` | `true` |
-| 7 | Price feed live | `PriceDataFeed.getSpotPrice(token)` | Non-zero (non-stable assets only) |
-| 8 | Collateral asset configured | `CollateralManager.getAssetConfig(token)` | `allowed=true`, correct decimals |
-| 9 | APR tiers set | `Loans.getAllInterestAprConfigs(token)` | ≥ 1 tier |
-| 10 | LTV / fee options set | `Loans.getAllOriginationFees(token)` | Matching `(ltvs[], fees[])` arrays |
-| 11 | Deposit asset configured | `LiquidityPool.getAssetConfig(token).status` | `1` (Active) |
-| 12 | Lock tiers exist | `LiquidityPool.getAssetLockTiers(token)` | ≥ 1 enabled tier |
-| 13 | Minimum deposit set | `LiquidityPool.minimumDepositValue()` | Intended value in raw units |
-| 14 | Fee receiver set (pool + loans) | `LiquidityPool.nativeFeeReceiver()`, `Loans.nativeFeeReceiver()` | Correct address on both |
-| 15 | Earnings frequency set | `LiquidityPool.earningsFrequency()` | Intended interval (seconds) |
-| 16 | Token transfer fee | Check token contract | 0, or protocol contracts fee-exempt |
-| 17 | SwapManager swap ID | `SwapManager.assetSwapIds(token)` | Non-zero bytes32 (check after first deposit) |
+| 4 | Loans wired (CM, LP, PriceHelper, PriceFeed) | `Loans.collateralManager()`, `Loans.liquidityPool()`, `Loans.priceHelper()`, `Loans.priceDataFeed()` | All four return non-zero addresses |
+| 5 | Loans has `MANAGER_ROLE` on LP and CM | `LiquidityPool.hasRole(MANAGER_ROLE, Loans)`, `CollateralManager.hasRole(MANAGER_ROLE, Loans)` | `true` for both |
+| 6 | LiquidityPool has `LENDER_ROLE` on Loans | `Loans.hasRole(LENDER_ROLE, LiquidityPool)` | `true` |
+| 7 | Price feed live | `PriceDataFeed.getSpotPrice(token)` | Non-zero, recent timestamp (non-stable assets only) |
+| 8 | Loan globals set | `Loans.loanConfig()`, `Loans.maxLoanAmount()` | Matching the values you configured |
+| 9 | Origination-fee receiver set | `Loans.originationFeeReceiver()` | Non-zero address |
+| 10 | Collateral asset configured | `CollateralManager.getAssetConfig(token)` | `allowed=true`, correct decimals |
+| 11 | APR tiers set | `Loans.getAllInterestAprConfigs(token)` | ≥ 1 tier |
+| 12 | LTV / fee options set | `Loans.getAllOriginationFees(token)` | Matching `(ltvs[], fees[])` arrays |
+| 13 | Deposit asset configured | `LiquidityPool.getAssetConfig(token).status` | `1` (Active) — or `2` for collateral-only assets like LMLN |
+| 14 | Lock tiers exist | `LiquidityPool.getAssetLockTiers(token)` | ≥ 1 enabled tier |
+| 15 | Minimum deposit set | `LiquidityPool.minimumDepositValue()` | Intended value in raw units |
+| 16 | Native fees set (pool + loans) | `LiquidityPool.nativeFeeReceiver()`, `Loans.nativeFeeReceiver()` | Correct address on both |
+| 17 | Earnings frequency set | `LiquidityPool.earningsFrequency()` | Intended interval (seconds) |
+| 18 | Token transfer fee | Check token contract | 0, or protocol contracts fee-exempt |
+| 19 | SwapManager swap ID | `SwapManager.assetSwapIds(token)` (via explorer — proxy) | Non-zero bytes32 (check after first deposit) |

--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -183,25 +183,34 @@ export function LoanParameters({
               No liquidity available — loans are currently unavailable.
             </p>
           ) : (
-            <div
-              className={`flex justify-between text-sm ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'} mt-1`}
-            >
-              <span>
-                {tokenConfig?.loanToken.symbol || 'Token'} — $
-                {loanConfig?.minLoanAmount
-                  ? formatUnits(
-                      loanConfig.minLoanAmount,
-                      tokenConfig?.loanToken.decimals || 18
-                    )
-                  : '1000'}{' '}
-                min
-              </span>
-              <span>
-                {availableLiquidity !== undefined
-                  ? `$${Math.floor(Number(formatUnits(availableLiquidity, tokenConfig?.loanToken.decimals || 18))).toLocaleString()} available`
-                  : 'Loading liquidity...'}
-              </span>
-            </div>
+            <>
+              <div
+                className={`flex justify-between text-sm ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'} mt-1`}
+              >
+                <span>
+                  {tokenConfig?.loanToken.symbol || 'Token'} — $
+                  {loanConfig?.minLoanAmount
+                    ? Number(
+                        formatUnits(
+                          loanConfig.minLoanAmount,
+                          tokenConfig?.loanToken.decimals || 18
+                        )
+                      ).toLocaleString()
+                    : '1,000'}{' '}
+                  min
+                </span>
+                <span>
+                  {availableLiquidity !== undefined
+                    ? `$${Math.floor(Number(formatUnits(availableLiquidity, tokenConfig?.loanToken.decimals || 18))).toLocaleString()} available`
+                    : 'Loading liquidity...'}
+                </span>
+              </div>
+              {isBelowMinimum && (
+                <p className='text-sm text-red-500 mt-1'>
+                  Minimum loan is ${minLoanAmount.toLocaleString()} {tokenConfig?.loanToken.symbol || 'Token'}.
+                </p>
+              )}
+            </>
           )}
         </div>
 

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -52,8 +52,10 @@ export function LoanSummary({
 }: LoanSummaryProps) {
   // Don't fall back to tokenConfig.nativeToken.symbol — that's the chain's
   // gas token (tLEMX, BNB, …), unrelated to the actual collateral the user is
-  // posting. Use a neutral label until selectedCollateral resolves.
-  const collateral = collateralSymbol ?? 'Collateral'
+  // posting. Use a neutral label until selectedCollateral resolves, and avoid
+  // duplicating the word ("Collateral Collateral") when no symbol is known.
+  const collateralLabel = collateralSymbol ? `${collateralSymbol} Collateral` : 'Collateral'
+  const collateralUnit = collateralSymbol ?? ''
   const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false)
 
   const handleDisclaimerContinue = () => {
@@ -96,13 +98,13 @@ export function LoanSummary({
               <span
                 className={`${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'}`}
               >
-                {collateral} Collateral
+                {collateralLabel}
               </span>
               <span
                 className={`font-medium ${!isDashboard ? 'text-white' : ''}`}
               >
                 {calculation.lemonRequired > 0
-                  ? `${calculation.lemonRequired.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${collateral}`
+                  ? `${calculation.lemonRequired.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}${collateralUnit ? ` ${collateralUnit}` : ''}`
                   : calculation.priceError || 'Calculating...'}
               </span>
             </div>
@@ -122,9 +124,9 @@ export function LoanSummary({
                     '$0.00 USD'}
                 </span>
                 <div
-                  className={`text-xs ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'} mt-0.5`}
+                  className={`text-xs ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'} ${hasInsufficientLmln ? 'text-red-500' : ''} mt-0.5`}
                 >
-                  {calculation.originationFeeLmln?.toFixed(2) || '0'}{' '}
+                  {Number(calculation.originationFeeLmln ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}{' '}
                   {tokenConfig?.feeToken.symbol || 'LMLN'}
                 </div>
               </div>
@@ -166,7 +168,7 @@ export function LoanSummary({
               <span
                 className={`font-medium ${!isDashboard ? 'text-white' : ''}`}
               >
-                ${calculation.monthlyPayment.toFixed(2)}
+                ${calculation.monthlyPayment.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
               </span>
             </div>
 
@@ -222,6 +224,11 @@ export function LoanSummary({
             {hasInsufficientLiquidity && (
               <p className='text-sm text-destructive mb-3'>
                 Insufficient pool liquidity for this loan amount. Please try a smaller amount.
+              </p>
+            )}
+            {hasInsufficientLmln && !hasInsufficientLiquidity && (
+              <p className='text-sm text-destructive mb-3'>
+                Insufficient {tokenConfig?.feeToken.symbol || 'LMLN'} balance to cover the origination fee.
               </p>
             )}
             <Button

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -241,16 +241,15 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
 
     // Check if we have calculation data from contract
     if (!loanOperations.calculationData) {
-      // No calculation yet just because the user hasn't typed a loan amount
-      // — show a neutral "—" instead of an alarming error string.
-      const noInput = !loanAmount
+      // No data because the simulation can't run yet (no input or invalid input
+      // like below-minimum). Either way, show a neutral "—" instead of an
+      // alarming error string — the form surfaces actionable validation
+      // (red border + min-amount hint) elsewhere.
       return {
         ...base,
         priceError: loanOperations.isSimulating
           ? 'Calculating collateral...'
-          : noInput
-            ? '—'
-            : 'Contract calculation not available'
+          : '—'
       }
     }
 

--- a/src/components/common/LoanConfirmationModal.tsx
+++ b/src/components/common/LoanConfirmationModal.tsx
@@ -95,7 +95,7 @@ export function LoanConfirmationModal({
             <div className='flex justify-between'>
               <span className='font-medium'>Origination Fee:</span>
               <span>
-                {calculation.originationFeeLmln?.toFixed(2) || '0'}{' '}
+                {Number(calculation.originationFeeLmln ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}{' '}
                 {tokenConfig?.feeToken.symbol || 'Token'}
               </span>
             </div>

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -830,14 +830,19 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                         </div>
                         <div className='flex gap-2'>
                           {(() => {
-                            // Check if approval is needed
+                            // Check if approval is needed. The contract pulls
+                            // amount + protocol fee on makeLoanPayment, so the
+                            // allowance must cover the gross — otherwise this
+                            // button silently shows "Confirm Payment" and the
+                            // tx reverts with insufficient allowance.
                             const currentPaymentAmount = getPaymentAmount(loan)
                             const paymentWei =
                               currentPaymentAmount && tokenConfig?.loanToken.decimals
                                 ? parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
                                 : 0n
+                            const grossPaymentWei = paymentWei + paymentWei / 100n
                             const needsApproval =
-                              !currentAllowance || currentAllowance < paymentWei
+                              !currentAllowance || currentAllowance < grossPaymentWei
                             const hasValidAmount =
                               currentPaymentAmount &&
                               parseFloat(currentPaymentAmount) > 0

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -196,10 +196,10 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
 
     setIsApprovingPayment(true)
     try {
-      const paymentWei =
-        paymentType === 'balance'
-          ? loan.remainingBalance
-          : parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
+      const paymentWei = parseTokenAmount(
+        currentPaymentAmount,
+        tokenConfig.loanToken.decimals
+      )
 
       await approveTokenAllowance(paymentWei)
 
@@ -337,10 +337,10 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
 
     setIsProcessingPayment(true)
     try {
-      const paymentWei =
-        paymentType === 'balance'
-          ? loan.remainingBalance
-          : parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
+      const paymentWei = parseTokenAmount(
+        currentPaymentAmount,
+        tokenConfig.loanToken.decimals
+      )
 
       // Check if user has sufficient token balance
       if (userLoanTokenBalance && paymentWei > userLoanTokenBalance) {
@@ -833,11 +833,9 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                             // Check if approval is needed
                             const currentPaymentAmount = getPaymentAmount(loan)
                             const paymentWei =
-                              paymentType === 'balance'
-                                ? loan.remainingBalance
-                                : currentPaymentAmount && tokenConfig?.loanToken.decimals
-                                  ? parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
-                                  : 0n
+                              currentPaymentAmount && tokenConfig?.loanToken.decimals
+                                ? parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
+                                : 0n
                             const needsApproval =
                               !currentAllowance || currentAllowance < paymentWei
                             const hasValidAmount =

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -196,10 +196,10 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
 
     setIsApprovingPayment(true)
     try {
-      const paymentWei = parseTokenAmount(
-        currentPaymentAmount,
-        tokenConfig.loanToken.decimals
-      )
+      const paymentWei =
+        paymentType === 'balance'
+          ? loan.remainingBalance
+          : parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
 
       await approveTokenAllowance(paymentWei)
 
@@ -337,11 +337,10 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
 
     setIsProcessingPayment(true)
     try {
-      // Convert payment amount to wei using loan token decimals from contract
-      const paymentWei = parseTokenAmount(
-        currentPaymentAmount,
-        tokenConfig.loanToken.decimals
-      )
+      const paymentWei =
+        paymentType === 'balance'
+          ? loan.remainingBalance
+          : parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
 
       // Check if user has sufficient token balance
       if (userLoanTokenBalance && paymentWei > userLoanTokenBalance) {
@@ -834,13 +833,11 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                             // Check if approval is needed
                             const currentPaymentAmount = getPaymentAmount(loan)
                             const paymentWei =
-                              currentPaymentAmount &&
-                              tokenConfig?.loanToken.decimals
-                                ? parseTokenAmount(
-                                    currentPaymentAmount,
-                                    tokenConfig.loanToken.decimals
-                                  )
-                                : 0n
+                              paymentType === 'balance'
+                                ? loan.remainingBalance
+                                : currentPaymentAmount && tokenConfig?.loanToken.decimals
+                                  ? parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
+                                  : 0n
                             const needsApproval =
                               !currentAllowance || currentAllowance < paymentWei
                             const hasValidAmount =

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -374,7 +374,7 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
             <label className='text-xs font-medium text-muted-foreground'>Lock Duration · Interest Multiplier</label>
             <div className='flex gap-2 flex-wrap'>
               {enabledTiers.map((tier, idx) => {
-                const mult = Number(tier.interestMultiplier) / 10000
+                const mult = Number(tier.interestMultiplier) / 100
                 return (
                   <Button
                     key={idx}
@@ -463,7 +463,7 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
             <p className='text-sm text-muted-foreground'>
               Your deposit will be locked for <span className='font-semibold text-foreground'>{formatLockDurationLong(selectedLockDuration)}</span>.
               {selectedTier && !isNonEarning && (
-                <> Interest share multiplier: <span className='font-semibold text-foreground'>{Number(selectedTier.interestMultiplier) / 10000}x</span>.</>
+                <> Interest share multiplier: <span className='font-semibold text-foreground'>{Number(selectedTier.interestMultiplier) / 100}x</span>.</>
               )}
             </p>
             {requiresSwap && (

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -269,7 +269,16 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
         />
         <StatItem
           label='Pool Protected Shares'
-          value={poolStatus ? formatShares(poolStatus.totalLiquidityShares - poolStatus.totalInterestShares, decimals) : 'Loading...'}
+          value={
+            poolStatus
+              ? formatShares(
+                  poolStatus.totalLiquidityShares > poolStatus.totalInterestShares
+                    ? poolStatus.totalLiquidityShares - poolStatus.totalInterestShares
+                    : 0n,
+                  decimals,
+                )
+              : 'Loading...'
+          }
         />
         {liquidityStatus && liquidityStatus.principalDeficitAmount > 0n && (
           <StatItem

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -569,6 +569,22 @@ export const useLoanOperations = (
         }
       }
 
+      // Pre-simulate via eth_call so contract reverts (e.g. LoanNotActive when a
+      // time-based default has occurred but loanStatus() hasn't been written yet)
+      // surface as decoded custom errors instead of the wallet's gas-estimation
+      // fallback, which on chains MetaMask doesn't natively know about gets
+      // surfaced as the cryptic "tx fee exceeds the configured cap" error.
+      if (publicClient && loansContractAddress) {
+        await publicClient.simulateContract({
+          address: loansContractAddress,
+          abi: loansAbi,
+          functionName: 'makeLoanPayment',
+          args: [loanId, amount],
+          value: paymentNativeFee ?? 0n,
+          account: address,
+        })
+      }
+
       const txHash = await makeLoanPayment({
         args: [loanId, amount],
         value: paymentNativeFee ?? 0n,
@@ -618,6 +634,7 @@ export const useLoanOperations = (
       userLoanTokenBalance,
       currentAllowance,
       approveTokenAllowance,
+      paymentNativeFee,
       publicClient,
       queryClient
     ]

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -104,8 +104,11 @@ export const useLoanOperations = (
   const loansContractAddress =
     loansAddress[chainId as keyof typeof loansAddress]
 
-  // Collateral manager address is resolved on-chain from Loans.collateralManager()
-  const { collateralManager: cmAddress } = useProtocolAddresses()
+  // Collateral manager + liquidity pool addresses are resolved on-chain.
+  // makeLoanPayment routes the loan-token transferFrom through the pool, so
+  // payment allowances must target liquidityPool (not the Loans contract).
+  const { collateralManager: cmAddress, liquidityPool: poolAddress } =
+    useProtocolAddresses()
 
   // Get contract token and decimal configuration
   const {
@@ -144,18 +147,19 @@ export const useLoanOperations = (
       }
     })
 
-  // Get current token allowance for payments
+  // Loan-token allowance for payments — granted to the LiquidityPool, since
+  // makeLoanPayment internally pulls funds through the pool's transferFrom.
   const { data: currentAllowance, refetch: refetchAllowance } = useReadContract(
     {
       address: loanTokenAddress,
       abi: erc20Abi,
       functionName: 'allowance',
       args:
-        address && loansContractAddress
-          ? [address, loansContractAddress]
+        address && poolAddress
+          ? [address, poolAddress]
           : undefined,
       query: {
-        enabled: !!loanTokenAddress && !!address && !!loansContractAddress
+        enabled: !!loanTokenAddress && !!address && !!poolAddress
       }
     }
   )
@@ -487,10 +491,11 @@ export const useLoanOperations = (
     ]
   )
 
-  // Function to approve token allowance if needed
+  // Approve loan-token spending for payments — target is LiquidityPool, since
+  // that's the spender makeLoanPayment ultimately routes through.
   const approveTokenAllowance = useCallback(
     async (amount: bigint) => {
-      if (!address || !loanTokenAddress || !loansContractAddress) {
+      if (!address || !loanTokenAddress || !poolAddress) {
         throw new Error('Missing required data for token approval')
       }
 
@@ -498,7 +503,7 @@ export const useLoanOperations = (
         address: loanTokenAddress,
         abi: erc20Abi,
         functionName: 'approve',
-        args: [loansContractAddress, amount]
+        args: [poolAddress, amount]
       })
 
       // Wait for transaction to be mined
@@ -514,7 +519,7 @@ export const useLoanOperations = (
     [
       address,
       loanTokenAddress,
-      loansContractAddress,
+      poolAddress,
       approveToken,
       refetchAllowance,
       publicClient

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -105,10 +105,11 @@ export const useLoanOperations = (
     loansAddress[chainId as keyof typeof loansAddress]
 
   // Collateral manager + liquidity pool addresses are resolved on-chain.
-  // makeLoanPayment routes the loan-token transferFrom through the pool, so
-  // payment allowances must target liquidityPool (not the Loans contract).
-  const { collateralManager: cmAddress, liquidityPool: poolAddress } =
-    useProtocolAddresses()
+  // CollateralManager is the spender for collateral approvals; LiquidityPool
+  // is only used for origination-fee approvals on initiateLoan. Loan-token
+  // approvals for makeLoanPayment target the Loans contract itself, since
+  // makeLoanPayment does `loanToken.safeTransferFrom(msg.sender, address(this), …)`.
+  const { collateralManager: cmAddress } = useProtocolAddresses()
 
   // Get contract token and decimal configuration
   const {
@@ -147,19 +148,19 @@ export const useLoanOperations = (
       }
     })
 
-  // Loan-token allowance for payments — granted to the LiquidityPool, since
-  // makeLoanPayment internally pulls funds through the pool's transferFrom.
+  // Loan-token allowance for payments — granted to the Loans contract,
+  // which is the spender in makeLoanPayment's transferFrom.
   const { data: currentAllowance, refetch: refetchAllowance } = useReadContract(
     {
       address: loanTokenAddress,
       abi: erc20Abi,
       functionName: 'allowance',
       args:
-        address && poolAddress
-          ? [address, poolAddress]
+        address && loansContractAddress
+          ? [address, loansContractAddress]
           : undefined,
       query: {
-        enabled: !!loanTokenAddress && !!address && !!poolAddress
+        enabled: !!loanTokenAddress && !!address && !!loansContractAddress
       }
     }
   )
@@ -491,19 +492,24 @@ export const useLoanOperations = (
     ]
   )
 
-  // Approve loan-token spending for payments — target is LiquidityPool, since
-  // that's the spender makeLoanPayment ultimately routes through.
+  // Approve loan-token spending for payments. Spender is the Loans contract,
+  // which is what makeLoanPayment's transferFrom pulls through. The contract
+  // pulls amount + protocol fee (FEE_BPS = 25 → 0.25%), so we gross the
+  // approval up by 1% to comfortably cover the fee — a "Pay Balance" with a
+  // bare-amount approval would otherwise revert with insufficient allowance.
   const approveTokenAllowance = useCallback(
     async (amount: bigint) => {
-      if (!address || !loanTokenAddress || !poolAddress) {
+      if (!address || !loanTokenAddress || !loansContractAddress) {
         throw new Error('Missing required data for token approval')
       }
+
+      const grossAmount = amount + amount / 100n
 
       const txHash = await approveToken({
         address: loanTokenAddress,
         abi: erc20Abi,
         functionName: 'approve',
-        args: [poolAddress, amount]
+        args: [loansContractAddress, grossAmount]
       })
 
       // Wait for transaction to be mined
@@ -519,7 +525,7 @@ export const useLoanOperations = (
     [
       address,
       loanTokenAddress,
-      poolAddress,
+      loansContractAddress,
       approveToken,
       refetchAllowance,
       publicClient
@@ -558,13 +564,17 @@ export const useLoanOperations = (
         throw new Error('Loans contract address not found')
       }
 
+      // Contract pulls amount + protocol fee (FEE_BPS = 25 → 0.25%) on
+      // makeLoanPayment, so balance and allowance must cover the gross.
+      const grossAmount = amount + amount / 100n
+
       // Check if user has sufficient loan token balance
-      if (userLoanTokenBalance && userLoanTokenBalance < amount) {
+      if (userLoanTokenBalance && userLoanTokenBalance < grossAmount) {
         throw new Error(`Insufficient loan token balance`)
       }
 
       // Check if we need to approve tokens first
-      if (!currentAllowance || currentAllowance < amount) {
+      if (!currentAllowance || currentAllowance < grossAmount) {
         try {
           // First approve the tokens
           await approveTokenAllowance(amount)

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -52,13 +52,14 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
   const grace = config.loanConfig?.balloonPaymentGraceDuration ?? 0n
   const effectiveLoans = useMemo(() => {
     const nowSec = BigInt(Math.floor(Date.now() / 1000))
-    return userData.loans.map((loan) => {
-      if (loan.status !== LOAN_STATUS.ACTIVE) return loan
+    return userData.loans.flatMap((loan) => {
+      if (!loan) return []
+      if (loan.status !== LOAN_STATUS.ACTIVE) return [loan]
       const defaultAt = loan.createdAt + loan.duration + grace
       if (nowSec >= defaultAt) {
-        return { ...loan, status: LOAN_STATUS.DEFAULT }
+        return [{ ...loan, status: LOAN_STATUS.DEFAULT }]
       }
-      return loan
+      return [loan]
     })
   }, [userData.loans, grace])
 

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -1,7 +1,8 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useUserLoans } from './loans/useUserLoans'
 import { useLoanOperations } from './loans/useLoanOperations'
 import { useLoanConfig } from './loans/useLoanConfig'
+import { LOAN_STATUS } from '@/src/constants'
 import type { UseLoansOptions, UseLoansReturn } from './types'
 export type { LoanRequest } from './loans/useLoanOperations'
 
@@ -42,12 +43,55 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
   const config = useLoanConfig(options?.loanRequest?.collateralToken)
   const operations = useLoanOperations(options)
 
+  // The contract's loanStatus() returns the *stored* status, which only
+  // changes when a state-writing function runs. A loan whose grace window
+  // has elapsed will keep returning ACTIVE until someone touches it, even
+  // though makeLoanPayment will revert with LoanNotActive. Compute an
+  // effective status here so the UI reflects reality: badge as Defaulted,
+  // drop from active list, and prevent the doomed payment flow.
+  const grace = config.loanConfig?.balloonPaymentGraceDuration ?? 0n
+  const effectiveLoans = useMemo(() => {
+    const nowSec = BigInt(Math.floor(Date.now() / 1000))
+    return userData.loans.map((loan) => {
+      if (loan.status !== LOAN_STATUS.ACTIVE) return loan
+      const defaultAt = loan.createdAt + loan.duration + grace
+      if (nowSec >= defaultAt) {
+        return { ...loan, status: LOAN_STATUS.DEFAULT }
+      }
+      return loan
+    })
+  }, [userData.loans, grace])
+
+  const activeLoans = useMemo(
+    () =>
+      effectiveLoans.filter(
+        (loan) =>
+          loan.status === LOAN_STATUS.ACTIVE ||
+          loan.status === LOAN_STATUS.UNLOCKED
+      ),
+    [effectiveLoans]
+  )
+  const loanHistory = useMemo(
+    () =>
+      effectiveLoans.filter(
+        (loan) =>
+          loan.status === LOAN_STATUS.COMPLETED ||
+          loan.status === LOAN_STATUS.DEFAULT ||
+          loan.status === LOAN_STATUS.LIQUIDATED
+      ),
+    [effectiveLoans]
+  )
+  const getLoanById = useCallback(
+    (id: `0x${string}`) => effectiveLoans.find((loan) => loan.id === id),
+    [effectiveLoans]
+  )
+
   return {
-    // Data from useUserLoans
-    loans: userData.loans,
-    activeLoans: userData.activeLoans,
-    loanHistory: userData.loanHistory,
-    getLoanById: userData.getLoanById,
+    // Data from useUserLoans (with effective-status overrides applied)
+    loans: effectiveLoans,
+    activeLoans,
+    loanHistory,
+    getLoanById,
     refetch: userData.refetch,
 
     // Operations from useLoanOperations

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -67,7 +67,7 @@ const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   LoanAlreadyWithdrawn: 'Collateral for this loan has already been withdrawn.',
   LoanAmountExceedsMax: 'Loan amount exceeds the maximum allowed.',
   LoanLocked: 'This loan is currently locked and cannot be modified.',
-  LoanNotActive: 'This loan is not active.',
+  LoanNotActive: 'This loan is no longer active — it may have defaulted or already been paid off.',
   LoanNotDefaulted: 'This loan has not defaulted.',
   LoanNotFound: 'Loan not found.',
   NoFeePrice: 'No fee price is configured.',


### PR DESCRIPTION
Promotes ten follow-up fixes (nine `fix:` + one `docs:`) from `develop` to `main`.

> **Loan-payment-allowance note:** `56faa3c` mis-routed the loan-token approval to the LiquidityPool. `b18188b` reverts that to the Loans contract and adds the missing fee gross-up. The two should land together; reviewing only the net diff between this branch and `main` (rather than `56faa3c` in isolation) is correct.

## Summary

### Liquidity page

- **`c49b6a7` — lock-tier multiplier scale + first-deposit crash.** Tier buttons now read `1x`, `1.25x`, `1.5x`, `2x`, `3x` (new `/100` scale) instead of `0.01x`-style values from the old bps `/10000` divisor. Also guards the "Pool Protected Shares" stat: with bonus tiers (>1x), `totalInterestShares` can exceed `totalLiquidityShares`, so the subtraction underflowed and `formatTokenAmount` threw — that's the generic Web3ErrorBoundary fallback users were seeing right after their very first deposit.

### Loan calculator

- **`cf4cb44` — calculator UX cleanup.** Red `Minimum loan is \$X` line under the amount input when below `minLoanAmount`; replaces the alarming "Contract calculation not available" with `—` when the contract simulation has no data; stops rendering "Collateral Collateral" when the symbol hasn't resolved yet (single neutral "Collateral" label, unit dropped on the amount until known); surfaces "Insufficient {SYMBOL} balance to cover the origination fee." next to the disabled Create New Loan button so the disabled-state reason is visible; comma-formats the origination-fee token amount, monthly payment, and the min-loan hint.

### Loan payments

- **`b18188b` — revert payment approval to Loans contract + cover protocol fee.** `makeLoanPayment` does `loanToken.safeTransferFrom(msg.sender, address(this), amount + fee)` where `address(this)` is the **Loans** contract — the LiquidityPool is not in that transfer path. `56faa3c` was incorrect: it routed the approval to the pool, leaving the Loans-side allowance untouched. Custom and minimum payments appeared to work because of residual Loans-side allowance from prior testing; "Pay Balance" exceeded that residual and reverted with a generic "Contract error". This commit switches the allowance read and approve target back to the Loans contract and grosses approvals and the dapp-side preflight checks (allowance + balance) up by 1% to cover the `FEE_BPS = 25` (0.25%) protocol fee. The dialog's "approve vs confirm" hand-off also checks the gross amount so it doesn't silently skip an approval that's about to revert on chain.
- **`507f237` — unify Pay Balance with the minimum/custom parse path.** The 'balance' branch was special-cased to send `loan.remainingBalance` straight through, while minimum/custom went through `parseTokenAmount(getPaymentAmount(loan), decimals)`. Drops the special case in all three sites (`handleApproval`, `handlePayment`, and the inline approval check inside the dialog) so balance pays through the same flow as the working options. The roundtrip is lossless because `parseUnits`/`formatUnits` operate on strings, not floats.
- **`56faa3c` — (superseded by `b18188b`).** Originally switched the spender to the LiquidityPool on a wrong premise; included for history but the net effect on `main` is undone by `b18188b` plus the gross-up.
- **`0f6413d` — pre-simulate `makeLoanPayment` to surface reverts cleanly.** Mirrors the `initiateLoan` pattern: runs `publicClient.simulateContract` right before the wallet write so viem decodes the custom error. Avoids MetaMask's huge-gas-limit fallback on chains it doesn't natively recognize, which was masking real revert reasons (e.g. `LoanNotActive`) as "tx fee exceeds the configured cap".
- **`1046b2e` — earlier "float roundtrip" fix.** Was based on a wrong premise (`parseUnits`/`formatUnits` are lossless). Effectively superseded by `507f237`, which puts balance back on the same parse path as the working options.

### Active loans

- **`c55c906` — derive effective loan status from time, not just stored status.** `Loans.loanStatus()` only updates when a state-writing function runs, so a loan past its grace window keeps returning `ACTIVE` until someone touches it on-chain — but `makeLoanPayment` reverts with `LoanNotActive`. The dapp was rendering such loans under Active Loans with a doomed Make Payment button. `useLoans` now overlays a client-side time check (`now >= createdAt + duration + balloonGrace`); defaulted loans badge as Defaulted, move to `loanHistory`, and the payment button never renders. Also tightens the `LoanNotActive` toast copy for the mid-click race.
- **`52c1a67` — guard against undefined loan entries in effective-status mapping.** `useUserLoans.loans` can include `undefined` while individual queries are still loading; the existing filter only dropped `null`. Switched to `flatMap` with an explicit guard so the map runs cleanly during initial load instead of throwing a `TypeError`.

### Docs

- **`d33401f` — refresh `docs/mainnet-setup.md` against current ABIs.** Step 3 wires every cross-contract reference on `Loans` (`collateralManager`, `liquidityPool`, `priceHelper`, `priceFeed`, `originationFeeToken`, `nativeGasToken`) plus existing `CollateralManager` references; Step 4 replaces the non-existent `LOANS_ROLE` with the actual `MANAGER_ROLE` and documents the full role surface (incl. `LENDER_ROLE` on `Loans` for the `LiquidityPool`, `PRICE_SETTER_ROLE` for the keeper); new Step 6 covers global `Loans` parameters (`setLoanConfiguration`, `setMaxLoanAmount`, `setWithdrawalReserve`) — the dapp's calculator reads `loanConfig()` at load and is unusable without these; new Step 7 covers origination-fee distribution (`setOriginationFeeReceiver`, `setOriginationFeeSplit`); steps 8–15 renumbered; final checklist updated.

## Test plan

- [ ] Liquidity page: tier buttons read whole-number multipliers (`1x`, `2x`, `3x`) and the fractional ones (`1.25x`, `1.5x`, `1.75x`).
- [ ] First-ever liquidity deposit (sole LP, any bonus tier) no longer crashes the LiquidityPerformance card with "Something went wrong" — Pool Protected Shares falls back to `0` instead of underflowing.
- [ ] Loan calculator with amount `< minimum`: input has red border AND a red `Minimum loan is \$X.XXX TOKEN` line under it; LoanSummary collateral row reads `—` rather than "Contract calculation not available".
- [ ] Loan calculator before a collateral symbol resolves: row reads `Collateral` (single word), not `Collateral Collateral`. After symbol resolves: `LEMX Collateral` etc.
- [ ] Loan calculator with insufficient LMLN: red `Insufficient LMLN balance to cover the origination fee.` appears above the disabled `Create New Loan` button (in addition to the red origination-fee row).
- [ ] Origination-fee LMLN amount, monthly payment, and the min-loan hint all use thousands separators.
- [ ] **Pay Loan Balance:** with no prior approval (or only a small residual), clicking the radio shows the **Approve Tokens** button; approving once moves to **Confirm Payment**; the payment goes through (no "Contract error" / `ERC20: insufficient allowance`). Etherscan shows the loan-token approval landing on the **Loans contract**, not the LiquidityPool.
- [ ] Minimum and custom payments still work through the same path (no regression).
- [ ] A loan whose grace window has elapsed renders as `Defaulted` under loan history with no Make Payment button — and a clean revert message if someone is mid-click when the grace period elapses.
- [ ] `mainnet-setup.md` walks cleanly end-to-end against a fresh deployment (the role grants and Loans wiring steps are the most likely drift source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)