### PR TITLE
Release: 360-day year in lock-tier duration formatters

### DIFF
--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -30,10 +30,15 @@ import type { UseLiquidityPoolReturn } from '@/src/hooks/liquidity/useLiquidityP
 import type { LockDurationTier } from '@/src/types/liquidity'
 import { liquidityPoolAbi } from '@/src/generated'
 
+// Lock-tier durations are configured in 360-day years (e.g. 10 yr =
+// 360 * 86400 * 10 = 311_040_000 s). Using 365.25 here floors a clean
+// 10-year tier to "9yr".
+const SECONDS_PER_YEAR = 360 * 24 * 3600
+
 function formatLockDuration(duration: bigint): string {
   const s = Number(duration)
   if (s === 0) return '0'
-  const years = Math.floor(s / (365.25 * 24 * 3600))
+  const years = Math.floor(s / SECONDS_PER_YEAR)
   if (years > 0) return `${years}yr`
   const days = Math.floor(s / 86400)
   if (days > 0) return `${days}d`
@@ -46,7 +51,7 @@ function formatLockDuration(duration: bigint): string {
 function formatLockDurationLong(duration: bigint): string {
   const s = Number(duration)
   if (s === 0) return 'the lock period'
-  const years = Math.floor(s / (365.25 * 24 * 3600))
+  const years = Math.floor(s / SECONDS_PER_YEAR)
   if (years > 0) return `${years} year${years > 1 ? 's' : ''}`
   const days = Math.floor(s / 86400)
   if (days > 0) return `${days} day${days > 1 ? 's' : ''}`

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -98,10 +98,14 @@ function formatDate(timestamp: bigint): string {
   })
 }
 
+// Lock-tier durations are configured in 360-day years; matching that here
+// keeps a 10 yr tier (311_040_000 s) from rendering as "9-year".
+const SECONDS_PER_YEAR = 360 * 24 * 3600
+
 function formatDuration(seconds: bigint): string {
   const s = Number(seconds)
   if (s === 0) return '0 seconds'
-  const years = Math.floor(s / (365.25 * 24 * 3600))
+  const years = Math.floor(s / SECONDS_PER_YEAR)
   if (years > 0) return years === 1 ? '1 year' : `${years}-year`
   const days = Math.floor(s / 86400)
   if (days > 0) return days === 1 ? '1 day' : `${days}-day`


### PR DESCRIPTION
Promotes the lock-tier duration formatter fix from `develop` to `main`.

## Summary

- **`7c77c18` — use 360-day years in lock-tier duration formatters.** Lock-tier durations are configured as 360-day years (a 10 yr tier is `360 * 86400 * 10 = 311_040_000 s` exactly). The formatters were dividing by `365.25 * 86400`, so that clean 10-year tier floored to `9yr` / `9-year` in the UI. Switched `AddLiquidityCard`'s `formatLockDuration` (short + long forms) and `LiquidityPerformance`'s `formatDuration` to a shared `SECONDS_PER_YEAR = 360 * 86400` so the displayed years match the configured tier.

## Test plan

- [ ] On the Liquidity page, the longest tier (configured as 10 years on-chain) renders as `10yr` in the Add Liquidity tier buttons and `10 years` in the deposit confirmation copy.
- [ ] Sub-year tiers (e.g. 30 days, 1 day, 1 hour) still format correctly — no regression in the days/hours/minutes branches.
- [ ] Deposit History rows under Liquidity Performance show the lock duration in years for multi-year tiers (e.g. `10-year lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)