### PR TITLE
Release: calculator UX polish + 360-day convention + pool stat relabel

### DIFF
--- a/docs/mainnet-setup.md
+++ b/docs/mainnet-setup.md
@@ -151,6 +151,12 @@ The price feed is configured independently of the LiquidityPool and CollateralMa
 
 These globals apply to every loan regardless of collateral and back the constants the dapp reads at app load (the loan calculator's min/max amount, slider bounds, and grace period).
 
+> **Time convention:** the project uses a **360-day year** and **30-day month** across both APR scaling and lock-tier durations. The dapp's duration formatters render years in 360-day units, so contract config should match — anything else makes "10 years" mean two different lengths in two different places.
+>
+> Quick reference:
+> - 1 month = `30 * 86400` = `2_592_000` s
+> - 1 year  = `360 * 86400` = `31_104_000` s
+
 ```solidity
 Loans.setLoanConfiguration(
   <minLoanAmount>,                // raw stable-token wei
@@ -158,7 +164,7 @@ Loans.setLoanConfiguration(
   <maxLoanDuration>,              // seconds
   <balloonPaymentGraceDuration>,  // seconds — grace after loan end before default
   <loanCycleDuration>,            // seconds per cycle (drives interest cadence)
-  <aprYearDuration>               // seconds in a year (e.g. 31536000); APR scales by this
+  <aprYearDuration>               // seconds in a year — use 31_104_000 (360 days)
 )
 
 Loans.setMaxLoanAmount(<absolute ceiling, raw stable-token wei>)
@@ -326,7 +332,7 @@ Each user-depositable asset must have at least one lock tier before the deposit 
 ```solidity
 LiquidityPool.addAssetLockTier(
   <token address>,
-  <durationSeconds>,       // e.g. 1800 = 30 min, 2592000 = 30 days
+  <durationSeconds>,       // 360-day years / 30-day months — e.g. 2_592_000 = 1 month, 31_104_000 = 1 year
   <interestMultiplierBps>  // e.g. 10000 = 1× base rate, 15000 = 1.5×
 )
 ```

--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -174,7 +174,7 @@ export function LoanParameters({
               }}
               min={minLoanAmount > 0 ? minLoanAmount : undefined}
               max={maxLoanAmount}
-              className={`pl-8 text-lg ${!isDashboard ? 'bg-white/10 border-white/20 text-white placeholder:text-gray-400 disabled:opacity-50 disabled:cursor-not-allowed' : 'placeholder:text-muted-foreground disabled:opacity-50 disabled:cursor-not-allowed'} ${isBelowMinimum ? 'border-red-500 ring-1 ring-red-500' : ''}`}
+              className={`pl-8 text-lg ${!isDashboard ? 'bg-white/10 border-white/20 text-white placeholder:text-gray-400/40 disabled:opacity-50 disabled:cursor-not-allowed' : 'placeholder:text-muted-foreground/30 disabled:opacity-50 disabled:cursor-not-allowed'} ${isBelowMinimum ? 'border-red-500 ring-1 ring-red-500' : ''}`}
               placeholder={minLoanAmount > 0 ? String(minLoanAmount) : ''}
             />
           </div>

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -155,7 +155,7 @@ export function LoanSummary({
               <span
                 className={`font-medium ${!isDashboard ? 'text-yellow-400' : 'text-yellow-600'}`}
               >
-                {calculation.apr.toFixed(1)}%
+                {Math.round(calculation.apr)}%
               </span>
             </div>
 

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -221,6 +221,19 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
       ? loanOperations.error
       : null
 
+  // Pick the APR tier whose duration band covers the current slider position.
+  // Decouples the displayed APR from the amount input — sliding LTV / Duration
+  // updates the APR live even before the user has typed an amount.
+  const aprFromDuration = useMemo(() => {
+    if (!tokenConfig || perAssetConfig.interestAprConfigs.length === 0) return 0
+    const tier = perAssetConfig.interestAprConfigs.find(
+      (c) =>
+        selectedDuration >= c.minDuration && selectedDuration <= c.maxDuration
+    )
+    if (!tier) return 0
+    return Number(formatPercentage(tier.interestApr, tokenConfig.aprDecimals))
+  }, [perAssetConfig.interestAprConfigs, selectedDuration, tokenConfig])
+
   // Calculate loan details using contract calculation data
   const calculation = useMemo(() => {
     // Create base structure
@@ -231,10 +244,15 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
       ltv
     )
 
+    // APR + LTV are derived from the slider positions and contract config, so
+    // they should render even when the simulation hasn't run yet (no amount
+    // typed, below-min, etc.).
+    const baseWithDials = { ...base, apr: aprFromDuration }
+
     // Check if we're still loading contract configuration
     if (!tokenConfig || !selectedCollateral || perAssetConfig.interestAprConfigs.length === 0) {
       return {
-        ...base,
+        ...baseWithDials,
         priceError: 'Loading contract data...'
       }
     }
@@ -246,7 +264,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
       // alarming error string — the form surfaces actionable validation
       // (red border + min-amount hint) elsewhere.
       return {
-        ...base,
+        ...baseWithDials,
         priceError: loanOperations.isSimulating
           ? 'Calculating collateral...'
           : '—'
@@ -262,7 +280,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
 
     if (!formatted) {
       return {
-        ...base,
+        ...baseWithDials,
         priceError: 'Error formatting calculation data'
       }
     }
@@ -290,7 +308,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
       : undefined)
 
     return {
-      ...base,
+      ...baseWithDials,
       ...formatted,
       loanCycles,
       balloonPayment: loanAmount,
@@ -302,6 +320,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     selectedDuration,
     duration,
     ltv,
+    aprFromDuration,
     loanOperations.calculationData,
     loanOperations.isSimulating,
     tokenConfig,

--- a/src/components/common/LoanConfirmationModal.tsx
+++ b/src/components/common/LoanConfirmationModal.tsx
@@ -80,7 +80,7 @@ export function LoanConfirmationModal({
             </div>
             <div className='flex justify-between'>
               <span className='font-medium'>APR:</span>
-              <span>{calculation.apr.toFixed(1)}%</span>
+              <span>{Math.round(calculation.apr)}%</span>
             </div>
             <div className='flex justify-between'>
               <span className='font-medium'>Collateral Required:</span>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -193,7 +193,7 @@ export function Dashboard() {
             Loan Calculator
           </CardTitle>
           <CardDescription>
-            Calculate loan terms and create new loans
+            Calculate loan terms and create new loans. Note: 1 year = 360 days throughout the protocol.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -272,8 +272,8 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           value={totalLoansIssued !== undefined ? Number(totalLoansIssued).toLocaleString() : 'Loading...'}
         />
         <StatItem
-          label='Total Liquidity Shares'
-          value={poolStatus ? formatShares(poolStatus.totalLiquidityShares, decimals) : 'Loading...'}
+          label='Total Interest Shares'
+          value={poolStatus ? formatShares(poolStatus.totalInterestShares, decimals) : 'Loading...'}
         />
         {liquidityStatus && liquidityStatus.principalDeficitAmount > 0n && (
           <StatItem

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -272,17 +272,8 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           value={totalLoansIssued !== undefined ? Number(totalLoansIssued).toLocaleString() : 'Loading...'}
         />
         <StatItem
-          label='Pool Protected Shares'
-          value={
-            poolStatus
-              ? formatShares(
-                  poolStatus.totalLiquidityShares > poolStatus.totalInterestShares
-                    ? poolStatus.totalLiquidityShares - poolStatus.totalInterestShares
-                    : 0n,
-                  decimals,
-                )
-              : 'Loading...'
-          }
+          label='Total Liquidity Shares'
+          value={poolStatus ? formatShares(poolStatus.totalLiquidityShares, decimals) : 'Loading...'}
         />
         {liquidityStatus && liquidityStatus.principalDeficitAmount > 0n && (
           <StatItem


### PR DESCRIPTION
Promotes four follow-up fixes from \`develop\` to \`main\`.

## Summary

### Loan calculator

- **\`ae29f62\` — 360-day note, decoupled APR/LTV, whole-number APR.**
  - Adds "Note: 1 year = 360 days throughout the protocol" to the Loan Calculator card description so the convention is visible at the form.
  - Derives the displayed APR from the duration slider directly (matching the \`interestAprConfigs\` tier whose \`[minDuration, maxDuration]\` band covers the slider position) so sliding LTV / Duration updates the APR live even before any amount is typed. Previously the calculator only showed APR after a successful contract simulation, which required a valid amount — sliders looked dead from the user's perspective.
  - Rounds APR to a whole number in both the Loan Summary card and the Loan Confirmation Modal — configured tiers are whole percentages and the trailing \`12.0%\` decimal was visual noise.
- **\`0b982a7\` — fade the loan-amount placeholder.** Drops placeholder opacity to 30% on dashboard / 40% on public page so the suggested minimum-loan number reads as placeholder hint rather than competing with a real input value.

### Liquidity page

- **\`ae29f62\` (also) — replace "Pool Protected Shares" with a meaningful stat.** The previous stat was \`totalLiquidityShares - totalInterestShares\`, which had no clear semantics under bonus-multiplier tiers (and was the source of the first-deposit underflow we fixed earlier).
- **\`724257f\` — show Total Interest Shares.** The earnings-bearing share total is the more meaningful number for an LP looking at the pool overview. Now reads "Total Interest Shares" and renders \`poolStatus.totalInterestShares\` directly.

### Docs

- **\`7f48e6c\` — lock in 360-day year / 30-day month convention.** Documents the project-wide convention used across APR scaling and lock-tier durations, with a quick reference for the derived constants. Updates the \`aprYearDuration\` example from 365-day (\`31_536_000\`) to 360-day (\`31_104_000\`) and the lock-tier example to call out 1 month / 1 year so deploys can't drift back to 365.

## Test plan

- [ ] Loan Calculator card description reads "Calculate loan terms and create new loans. Note: 1 year = 360 days throughout the protocol."
- [ ] With no amount entered, sliding LTV updates the LTV % in the summary; sliding Duration updates the Estimated APR % in the summary. Both change live without a contract simulation.
- [ ] Estimated APR renders as a whole number (e.g. \`12%\`, not \`12.0%\`) in both the Loan Summary card and the Loan Confirmation Modal.
- [ ] Loan-amount input placeholder ("\`1000\`" or similar) reads as faded hint text — clearly less prominent than a typed value.
- [ ] LiquidityPerformance pool overview shows "Total Interest Shares" with the pool's \`totalInterestShares\` rendered with thousands separators.
- [ ] \`docs/mainnet-setup.md\` Step 6 callout shows the 360-day convention; \`aprYearDuration\` example reads \`31_104_000\`; lock-tier example mentions \`2_592_000\` = 1 month and \`31_104_000\` = 1 year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)