### PR TITLE
Release: pool overview reorg, withdraw confirm modal, deposit fee, countdown popover

### DIFF
--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -57,7 +57,6 @@ import {
 } from 'lucide-react'
 import { LoanCompletionModal } from '../common/LoanCompletionModal'
 import { useCollateralManager } from '@/src/hooks/useCollateralManager'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/src/components/ui/tooltip'
 
 interface ActiveLoansProps {
   compact?: boolean
@@ -115,6 +114,7 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
     useState<`0x${string}` | null>(null)
   const [isWithdrawingCollateral, setIsWithdrawingCollateral] = useState(false)
   const [copiedLoanId, setCopiedLoanId] = useState<string | null>(null)
+  const [openInfoLoanId, setOpenInfoLoanId] = useState<string | null>(null)
 
   const handleCopyLoanId = (id: string) => {
     navigator.clipboard.writeText(id)
@@ -591,16 +591,29 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                     <Clock className='h-3 w-3' />
                     {countdownLabel}
                     {showCountdownTooltip && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Info className='h-3 w-3 cursor-pointer' />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>Time includes a safety buffer to account for blockchain timing.</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
+                      <span className='relative inline-flex'>
+                        <button
+                          type='button'
+                          aria-label='Countdown info'
+                          aria-expanded={openInfoLoanId === loan.id}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setOpenInfoLoanId(openInfoLoanId === loan.id ? null : loan.id)
+                          }}
+                          onBlur={() => setOpenInfoLoanId(null)}
+                          className='inline-flex items-center'
+                        >
+                          <Info className='h-3 w-3 cursor-pointer' />
+                        </button>
+                        {openInfoLoanId === loan.id && (
+                          <span
+                            role='tooltip'
+                            className='absolute top-full left-1/2 -translate-x-1/2 mt-1 z-50 bg-muted text-foreground text-xs rounded-md px-3 py-1.5 shadow-md max-w-xs w-max'
+                          >
+                            Time includes a safety buffer to account for blockchain timing.
+                          </span>
+                        )}
+                      </span>
                     )}
                   </p>
                   <div className='font-medium'>

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -255,10 +255,14 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
     })
   }, [depositFeeApplies, tokenAmount, feeConfig, decimals])
 
+  // Floor the wallet balance to 2 decimals (don't round) so the displayed
+  // value never exceeds what the user actually has — typing the shown value
+  // back into the deposit field shouldn't trip an insufficient-balance check.
   const balanceInUsd = useMemo(() => {
     if (balanceCreditRaw === undefined) return undefined
-    return parseFloat(formatTokenAmount(balanceCreditRaw as unknown as bigint, stableDecimals))
-      .toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    const raw = parseFloat(formatTokenAmount(balanceCreditRaw as unknown as bigint, stableDecimals))
+    const floored = Math.floor(raw * 100) / 100
+    return floored.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
   }, [balanceCreditRaw, stableDecimals])
 
   const isBelowMinimum = useMemo(() => {

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -79,6 +79,7 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
     stableTokenAddress,
     stableTokenDecimals,
     liquidityPoolContractAddress,
+    feeConfig,
     approveToken,
     deposit,
     refetch,
@@ -235,6 +236,24 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
     const formatted = parseFloat(formatTokenAmount(tokenAmount, decimals))
     return formatted.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
   }, [tokenAmount, decimals])
+
+  // Pool deposit fee — same FEE_BPS the contract takes via _takeIncomingFee
+  // for earning deposits. Skipped for non-earning deposits (contract path
+  // pulls only `amount`, no fee). feeReceiver === address(0) disables it.
+  const depositFeePct = useMemo(() => {
+    if (!feeConfig || feeConfig.feeBps === 0n) return null
+    return Number(feeConfig.feeBps) / 100
+  }, [feeConfig])
+  const depositFeeApplies = !!depositFeePct && !isNonEarning
+
+  const depositFeeTokens = useMemo(() => {
+    if (!depositFeeApplies || !tokenAmount || !feeConfig) return undefined
+    const fee = (tokenAmount * feeConfig.feeBps) / 10000n
+    return parseFloat(formatTokenAmount(fee, decimals)).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+  }, [depositFeeApplies, tokenAmount, feeConfig, decimals])
 
   const balanceInUsd = useMemo(() => {
     if (balanceCreditRaw === undefined) return undefined
@@ -471,6 +490,15 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
                 <> Interest share multiplier: <span className='font-semibold text-foreground'>{Number(selectedTier.interestMultiplier) / 100}x</span>.</>
               )}
             </p>
+            {depositFeeApplies && (
+              <p className='text-sm text-muted-foreground'>
+                A <span className='font-semibold text-foreground'>{depositFeePct}%</span> deposit fee applies
+                {depositFeeTokens && (
+                  <> — ~<span className='font-semibold text-foreground'>{depositFeeTokens} {symbol}</span> will be taken on top of the deposit amount</>
+                )}
+                .
+              </p>
+            )}
             {requiresSwap && (
               <p className='text-sm text-muted-foreground'>
                 Your {symbol} will be queued for conversion to stablecoins via the SwapScheduler.

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -248,16 +248,17 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
   // defaulted-principal stat needs to share row 1 with the three primary
   // pool metrics; row 2 (3 share/loan stats) keeps the same column widths.
   const PoolOverview = () => {
-    const hasDeficit = !!(
+    const deficitAmount =
       liquidityStatus && liquidityStatus.principalDeficitAmount > 0n
-    )
+        ? liquidityStatus.principalDeficitAmount
+        : undefined
     return (
       <div className='space-y-3'>
         <h3 className='text-sm font-semibold flex items-center gap-2'>
           <BarChart3 className='h-4 w-4' /> Pool Overview
         </h3>
         <div
-          className={`grid grid-cols-2 ${hasDeficit ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-4`}
+          className={`grid grid-cols-2 ${deficitAmount ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-4`}
         >
           <StatItem
             label='Total Liquidity Available'
@@ -271,10 +272,10 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
             label='Pool Utilization'
             value={formatPct(poolUtilization)}
           />
-          {hasDeficit && (
+          {deficitAmount !== undefined && (
             <StatItem
               label='Defaulted Principal'
-              value={formatCurrency(liquidityStatus!.principalDeficitAmount, decimals, symbol)}
+              value={formatCurrency(deficitAmount, decimals, symbol)}
               warning
             />
           )}

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -252,8 +252,8 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
       </h3>
       <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
         <StatItem
-          label='Total Pool Value'
-          value={poolStatus ? formatCurrency(poolStatus.totalPoolValue, decimals, symbol) : 'Loading...'}
+          label='Total Liquidity Available'
+          value={liquidityStatus ? formatCurrency(liquidityStatus.principalAvailable, decimals, symbol) : 'Loading...'}
         />
         <StatItem
           label='Principal in Active Loans'
@@ -264,16 +264,16 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           value={formatPct(poolUtilization)}
         />
         <StatItem
-          label='Total Interest Generated'
-          value={liquidityStatus ? formatCurrency(liquidityStatus.interestEarned, decimals, symbol) : 'Loading...'}
-        />
-        <StatItem
-          label='Total Loans Issued'
-          value={totalLoansIssued !== undefined ? Number(totalLoansIssued).toLocaleString() : 'Loading...'}
+          label='Total Pool Shares'
+          value={poolStatus ? formatShares(poolStatus.totalLiquidityShares, decimals) : 'Loading...'}
         />
         <StatItem
           label='Total Interest Shares'
           value={poolStatus ? formatShares(poolStatus.totalInterestShares, decimals) : 'Loading...'}
+        />
+        <StatItem
+          label='Total Loans Issued'
+          value={totalLoansIssued !== undefined ? Number(totalLoansIssued).toLocaleString() : 'Loading...'}
         />
         {liquidityStatus && liquidityStatus.principalDeficitAmount > 0n && (
           <StatItem
@@ -293,6 +293,10 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
         <RefreshCw className='h-4 w-4' /> Earnings Distribution
       </h3>
       <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
+        <StatItem
+          label='Total Interest Generated'
+          value={liquidityStatus ? formatCurrency(liquidityStatus.interestEarned, decimals, symbol) : 'Loading...'}
+        />
         <StatItem
           label='Uncollected Pool Earnings'
           value={poolStatus ? formatCurrency(poolStatus.availableEarningsInLoans, decimals, symbol) : 'Loading...'}

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -244,47 +244,56 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     }
   }
 
-  // Pool Overview section (always shown)
-  const PoolOverview = () => (
-    <div className='space-y-3'>
-      <h3 className='text-sm font-semibold flex items-center gap-2'>
-        <BarChart3 className='h-4 w-4' /> Pool Overview
-      </h3>
-      <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
-        <StatItem
-          label='Total Liquidity Available'
-          value={liquidityStatus ? formatCurrency(liquidityStatus.principalAvailable, decimals, symbol) : 'Loading...'}
-        />
-        <StatItem
-          label='Principal in Active Loans'
-          value={liquidityStatus ? formatCurrency(liquidityStatus.principalInLoans, decimals, symbol) : 'Loading...'}
-        />
-        <StatItem
-          label='Pool Utilization'
-          value={formatPct(poolUtilization)}
-        />
-        <StatItem
-          label='Total Pool Shares'
-          value={poolStatus ? formatShares(poolStatus.totalLiquidityShares, decimals) : 'Loading...'}
-        />
-        <StatItem
-          label='Total Interest Shares'
-          value={poolStatus ? formatShares(poolStatus.totalInterestShares, decimals) : 'Loading...'}
-        />
-        <StatItem
-          label='Total Loans Issued'
-          value={totalLoansIssued !== undefined ? Number(totalLoansIssued).toLocaleString() : 'Loading...'}
-        />
-        {liquidityStatus && liquidityStatus.principalDeficitAmount > 0n && (
+  // Pool Overview section (always shown). The grid widens to 4 cols when a
+  // defaulted-principal stat needs to share row 1 with the three primary
+  // pool metrics; row 2 (3 share/loan stats) keeps the same column widths.
+  const PoolOverview = () => {
+    const hasDeficit = !!(
+      liquidityStatus && liquidityStatus.principalDeficitAmount > 0n
+    )
+    return (
+      <div className='space-y-3'>
+        <h3 className='text-sm font-semibold flex items-center gap-2'>
+          <BarChart3 className='h-4 w-4' /> Pool Overview
+        </h3>
+        <div
+          className={`grid grid-cols-2 ${hasDeficit ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-4`}
+        >
           <StatItem
-            label='Defaulted Principal'
-            value={formatCurrency(liquidityStatus.principalDeficitAmount, decimals, symbol)}
-            warning
+            label='Total Liquidity Available'
+            value={liquidityStatus ? formatCurrency(liquidityStatus.principalAvailable, decimals, symbol) : 'Loading...'}
           />
-        )}
+          <StatItem
+            label='Principal in Active Loans'
+            value={liquidityStatus ? formatCurrency(liquidityStatus.principalInLoans, decimals, symbol) : 'Loading...'}
+          />
+          <StatItem
+            label='Pool Utilization'
+            value={formatPct(poolUtilization)}
+          />
+          {hasDeficit && (
+            <StatItem
+              label='Defaulted Principal'
+              value={formatCurrency(liquidityStatus!.principalDeficitAmount, decimals, symbol)}
+              warning
+            />
+          )}
+          <StatItem
+            label='Total Pool Shares'
+            value={poolStatus ? formatShares(poolStatus.totalLiquidityShares, decimals) : 'Loading...'}
+          />
+          <StatItem
+            label='Total Interest Shares'
+            value={poolStatus ? formatShares(poolStatus.totalInterestShares, decimals) : 'Loading...'}
+          />
+          <StatItem
+            label='Total Loans Issued'
+            value={totalLoansIssued !== undefined ? Number(totalLoansIssued).toLocaleString() : 'Loading...'}
+          />
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 
   // Earnings Distribution section (always shown)
   const EarningsDistribution = () => (
@@ -292,7 +301,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
       <h3 className='text-sm font-semibold flex items-center gap-2'>
         <RefreshCw className='h-4 w-4' /> Earnings Distribution
       </h3>
-      <div className='grid grid-cols-2 md:grid-cols-3 gap-4'>
+      <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
         <StatItem
           label='Total Interest Generated'
           value={liquidityStatus ? formatCurrency(liquidityStatus.interestEarned, decimals, symbol) : 'Loading...'}

--- a/src/components/liquidity/RemoveLiquidityCard.tsx
+++ b/src/components/liquidity/RemoveLiquidityCard.tsx
@@ -13,6 +13,7 @@ import { Badge } from '@/src/components/ui/badge'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -34,6 +35,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
   const [amount, setAmount] = useState('')
   const [isProcessing, setIsProcessing] = useState<string | null>(null)
   const [fundQueueModal, setFundQueueModal] = useState(false)
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const { toast } = useToast()
 
   const {
@@ -79,8 +81,14 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
     setAmount(formattedWithdrawable)
   }
 
-  const handleRequestWithdrawal = async () => {
+  const handleRequestClick = () => {
+    if (!parsedAmount || insufficientBalance) return
+    setShowConfirmDialog(true)
+  }
+
+  const handleConfirmWithdrawal = async () => {
     if (!parsedAmount) return
+    setShowConfirmDialog(false)
     setIsProcessing('request')
     try {
       await requestWithdrawal(parsedAmount)
@@ -96,6 +104,14 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
       setIsProcessing(null)
     }
   }
+
+  const netReceiveDisplay = useMemo(() => {
+    if (!withdrawalFeePct || !parsedAmount || !feeConfig) return undefined
+    const net = parsedAmount - (parsedAmount * feeConfig.feeBps) / 10000n
+    return parseFloat(formatTokenAmount(net, decimals)).toLocaleString('en-US', {
+      maximumFractionDigits: 2,
+    })
+  }, [withdrawalFeePct, parsedAmount, feeConfig, decimals])
 
   const handleClaimWithdrawal = async (requestId: bigint) => {
     setIsProcessing(`claim-${requestId}`)
@@ -166,8 +182,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
               </span>
             </div>
           </div>
-          <div className='flex justify-between text-xs text-muted-foreground'>
-            <span>{withdrawalFeePct ? `${withdrawalFeePct}% withdrawal fee` : '\u00A0'}</span>
+          <div className='flex justify-end text-xs text-muted-foreground'>
             <button
               onClick={handleMax}
               className='hover:text-foreground transition-colors'
@@ -187,14 +202,8 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
           </p>
         )}
 
-        {withdrawalFeePct && parsedAmount && !insufficientBalance && (
-          <p className='text-xs text-muted-foreground'>
-            A {withdrawalFeePct}% fee applies on claim. You will receive ~{parseFloat(formatTokenAmount(parsedAmount - (parsedAmount * feeConfig!.feeBps) / 10000n, decimals)).toLocaleString('en-US', { maximumFractionDigits: 2 })} {symbol}.
-          </p>
-        )}
-
         <Button
-          onClick={handleRequestWithdrawal}
+          onClick={handleRequestClick}
           disabled={isProcessing !== null || !parsedAmount || insufficientBalance}
           className='w-full bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black font-semibold'
         >
@@ -288,6 +297,43 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
           </div>
         )}
       </CardContent>
+
+      {/* Confirm Withdrawal Modal */}
+      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Withdrawal Request</DialogTitle>
+            <DialogDescription>
+              You are about to request a withdrawal of {amount} {symbol} from the liquidity pool.
+            </DialogDescription>
+          </DialogHeader>
+          <div className='space-y-3 py-2'>
+            {withdrawalFeePct ? (
+              <p className='text-sm text-muted-foreground'>
+                A <span className='font-semibold text-foreground'>{withdrawalFeePct}%</span> fee applies on claim. You will receive ~<span className='font-semibold text-foreground'>{netReceiveDisplay} {symbol}</span> after the fee.
+              </p>
+            ) : (
+              <p className='text-sm text-muted-foreground'>
+                No withdrawal fee applies. You will receive the full {amount} {symbol} on claim.
+              </p>
+            )}
+            <p className='text-sm text-muted-foreground'>
+              Your shares will be burned now and the request will join the withdrawal queue. You can claim once the queue funds your request.
+            </p>
+          </div>
+          <DialogFooter className='gap-2 sm:gap-0'>
+            <Button variant='outline' onClick={() => setShowConfirmDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirmWithdrawal}
+              className='bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black font-semibold'
+            >
+              Confirm Withdrawal
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Fund Queue Modal */}
       <Dialog


### PR DESCRIPTION
Promotes six follow-up fixes from \`develop\` to \`main\`.

## Summary

### Liquidity page

- **\`1d5476e\` — countdown info popover opens on click + uses muted background.** Replaces the radix Tooltip wrapper around the countdown info icon with a controlled popover that toggles on click and closes on blur. Hover no longer triggers it. Background swaps from \`bg-primary\` (yellow) to \`bg-muted\` so it visually matches the loan-summary panel.
- **\`8997d6e\` + \`df507b0\` — Pool Overview reorg.** Top-left becomes Total Liquidity Available (\`liquidityStatus.principalAvailable\`), the number an LP wants at a glance. Row 1 is Liquidity Available · Principal in Active Loans · Pool Utilization, with Defaulted Principal slotting in next to Pool Utilization when non-zero (grid widens to 4 cols in that case so row 2 column widths still match). Row 2 is Total Pool Shares (\`totalLiquidityShares\`) · Total Interest Shares · Total Loans Issued. Earnings Distribution becomes a 4-up row: Total Interest Generated · Uncollected Pool Earnings · Last Distribution · Next Distribution Available.
- **\`df507b0\` (also) — deposit fee in confirm modal.** Surfaces the LiquidityPool's \`FEE_BPS\` deposit fee. Earning deposits hit \`_takeIncomingFee\`, which pulls \`amount + fee\` and forwards the fee to \`feeReceiver\`; non-earning deposits skip it. Modal renders "A 0.25% deposit fee applies — ~X.XX TOKEN will be taken on top of the deposit amount." mirroring the withdraw side.
- **\`dc96dd8\` — floor wallet balance display.** \`toLocaleString\` with \`maxFractionDigits=2\` rounds, so a $0.045 balance read as "$0.05". Typing the displayed value back into the deposit input would then fail an insufficient-balance check on chain. \`balanceInUsd\` now does \`Math.floor(raw * 100) / 100\` before formatting.
- **\`4f98539\` — withdraw confirm modal.** Mirrors the deposit flow: clicking Request Withdrawal opens a confirmation dialog laying out the amount, the withdrawal fee %, the net receivable after the fee, and a note that shares are burned on request. Confirm fires the existing \`requestWithdrawal\` call. Inline fee copy ("X% withdrawal fee" hint and "A X% fee applies on claim…" paragraph) is removed from the card body — fee discussion lives in the modal only.

### Cleanup

- **\`7c9c02e\` — drop \`liquidityStatus!\` non-null assertion.** PoolOverview now captures the deficit amount in a narrowed local; behavior unchanged.

## Test plan

- [ ] Liquidity page: clicking the countdown info icon toggles a grey popover (matches loan summary). Hover no longer triggers it. Clicking elsewhere closes it.
- [ ] Pool Overview row 1 (no defaults) reads: Total Liquidity Available · Principal in Active Loans · Pool Utilization. Row 2: Total Pool Shares · Total Interest Shares · Total Loans Issued.
- [ ] When \`liquidityStatus.principalDeficitAmount > 0\`, Defaulted Principal appears as the 4th item on row 1 and the grid widens to 4 cols; row 2 keeps the same column widths.
- [ ] Earnings Distribution renders four stats on a single row.
- [ ] Add Liquidity confirm modal shows the deposit fee for earning deposits and omits it when "Deposit as non-earning" is checked. Numbers (% and token amount) match \`FEE_BPS\` × \`tokenAmount\`.
- [ ] Wallet balance under the loan-amount input never reads higher than the on-chain balance — a $0.045 balance shows "$0.04", not "$0.05".
- [ ] Remove Liquidity card body shows only the Unlocked balance (right-aligned). No inline fee copy. Clicking Request Withdrawal opens a confirm modal that lists the fee % and the net receivable. Confirming submits the request; cancelling closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)