### PR TITLE
P1: config-change correctness (audit follow-up)

### DIFF
--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -84,10 +84,15 @@ export function LoanParameters({
 
   const hasNoLiquidity = availableLiquidity !== undefined && availableLiquidity === 0n
 
-  // Safe index for the slider — use the actual percentage as value instead of indexOf
-  const ltvStep = ltvPercentages.length >= 2
-    ? ltvPercentages[1] - ltvPercentages[0]
-    : 10
+  // Tiers need not be uniformly spaced (e.g. 20/30/50), so a fixed step can
+  // land the slider on values that have no configured origination fee. Use a
+  // fine step and snap every change to the nearest real tier instead.
+  const snapToTier = (raw: number): number => {
+    if (ltvPercentages.length === 0) return raw
+    return ltvPercentages.reduce((closest, candidate) =>
+      Math.abs(candidate - raw) < Math.abs(closest - raw) ? candidate : closest
+    )
+  }
 
   return (
     <Card
@@ -279,12 +284,11 @@ export function LoanParameters({
                 type='range'
                 min={minLtvPercentage}
                 max={maxLtvPercentage}
-                step={ltvStep}
+                step={0.5}
                 value={ltv}
                 disabled={ltvOptions.length === 0}
                 onChange={(e) => {
-                  const pct = Number(e.target.value)
-                  setLtv(pct)
+                  setLtv(snapToTier(Number(e.target.value)))
                 }}
                 className='w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer slider disabled:opacity-50 disabled:cursor-not-allowed'
               />

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -191,14 +191,28 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     return BigInt(Math.floor(duration))
   }, [duration])
 
-  // Create loan request for simulation
+  // Get origination fee for selected LTV. Match by the same formatted value
+  // the slider was populated from — reconstructing the contract bigint via
+  // parseUnits((ltv/100).toString()) breaks for any tier whose percentage
+  // doesn't survive the float round-trip, and a mismatched find() meant the
+  // on-chain call was sent an LTV that doesn't exist in the fee table.
+  const selectedLtvOption = useMemo(() => {
+    if (!tokenConfig) return undefined
+    return perAssetConfig.ltvOptions.find(
+      (option) =>
+        Number(formatPercentage(option.ltv, tokenConfig.ltvDecimals)) === ltv
+    )
+  }, [perAssetConfig.ltvOptions, ltv, tokenConfig])
+
+  // Create loan request for simulation — always send the tier's EXACT
+  // contract LTV value, never a value reconstructed from the display number.
   const loanRequest = useMemo(() => {
     if (
       !selectedCollateral ||
       !loanAmount ||
       !selectedDuration ||
       selectedDuration === 0n ||
-      !ltv ||
+      !selectedLtvOption ||
       !tokenConfig
     )
       return undefined
@@ -210,22 +224,9 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         tokenConfig.loanToken.decimals
       ),
       duration: selectedDuration,
-      ltv: parseUnits((ltv / 100).toString(), tokenConfig.ltvDecimals)
+      ltv: selectedLtvOption.ltv
     }
-  }, [selectedCollateral, loanAmount, selectedDuration, ltv, tokenConfig])
-
-  // Get origination fee for selected LTV
-  const selectedLtvOption = useMemo(() => {
-    if (!tokenConfig) return undefined
-
-    // Convert ltv percentage (50) to decimal (0.5) then to contract format
-    const ltvDecimal = (ltv / 100).toString()
-    const ltvInContractFormat = parseUnits(ltvDecimal, tokenConfig.ltvDecimals)
-
-    return perAssetConfig.ltvOptions.find(
-      (option) => option.ltv === ltvInContractFormat
-    )
-  }, [perAssetConfig.ltvOptions, ltv, tokenConfig])
+  }, [selectedCollateral, loanAmount, selectedDuration, selectedLtvOption, tokenConfig])
 
   // Validate the typed payer address (format + on-chain delegation). Balance
   // and allowance shortfalls are surfaced by LoanSummary's existing

--- a/src/components/common/OriginationPayerField.tsx
+++ b/src/components/common/OriginationPayerField.tsx
@@ -4,6 +4,7 @@ import { Lock, Unlock } from 'lucide-react'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { formatTokenAmount } from '../../utils/decimals'
+import { floorToDecimals } from '../../utils/format'
 import type { DelegateValidationResult } from '../../hooks/loans/useDelegateValidation'
 
 export interface OriginationPayerFieldProps {
@@ -19,7 +20,8 @@ export interface OriginationPayerFieldProps {
 }
 
 const formatLmln = (amount: bigint, decimals: number) => {
-  const num = Number(formatTokenAmount(amount, decimals))
+  // Floor — this is a balance display; rounding up overstates funds.
+  const num = floorToDecimals(Number(formatTokenAmount(amount, decimals)), 4)
   return num.toLocaleString('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 4

--- a/src/components/common/ProtocolStatusBanner.tsx
+++ b/src/components/common/ProtocolStatusBanner.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useReadContract } from 'wagmi'
+import { useReadLoansPaused, liquidityPoolAbi } from '@/src/generated'
+import { useProtocolAddresses } from '@/src/hooks/useProtocolAddresses'
+import { usePricing } from '@/src/hooks/usePricing'
+import {
+  extractErrorMessage,
+  type ContractError
+} from '@/src/utils/errorHandling'
+import { AlertTriangle, PauseCircle } from 'lucide-react'
+
+/**
+ * Global protocol health banner. Every fee-bearing write depends on the
+ * contracts being unpaused and the price feed being fresh — without this
+ * banner those states only surface as opaque per-transaction failures deep
+ * in a flow (approve succeeds, then the real tx reverts).
+ */
+export function ProtocolStatusBanner() {
+  const { data: loansPaused } = useReadLoansPaused({
+    query: { refetchInterval: 30_000 }
+  })
+
+  const { liquidityPool: lpAddress } = useProtocolAddresses()
+  const { data: lpPaused } = useReadContract({
+    address: lpAddress,
+    abi: liquidityPoolAbi,
+    functionName: 'paused',
+    query: { enabled: !!lpAddress, refetchInterval: 30_000 }
+  })
+
+  // The price reads revert with PriceStale/NoPriceAvailable when the feed
+  // needs updating — decode and surface that here instead of letting each
+  // transaction fail with it individually.
+  const { error: pricingError } = usePricing()
+  const priceMessage = pricingError
+    ? extractErrorMessage(pricingError as unknown as ContractError)
+    : undefined
+  const showPriceWarning =
+    !!priceMessage && /price|stale/i.test(priceMessage)
+
+  const isPaused = Boolean(loansPaused) || Boolean(lpPaused)
+
+  if (!isPaused && !showPriceWarning) return null
+
+  return (
+    <div className='space-y-2'>
+      {isPaused && (
+        <div className='flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950/40 p-4'>
+          <PauseCircle className='h-5 w-5 shrink-0 text-red-600 dark:text-red-400 mt-0.5' />
+          <div>
+            <p className='text-sm font-semibold text-red-800 dark:text-red-300'>
+              Protocol paused
+            </p>
+            <p className='text-sm text-red-700 dark:text-red-400'>
+              {loansPaused && lpPaused
+                ? 'Loans and liquidity operations are temporarily paused.'
+                : loansPaused
+                  ? 'Loan operations are temporarily paused.'
+                  : 'Liquidity pool operations are temporarily paused.'}{' '}
+              Transactions will fail until the protocol is unpaused — please
+              check back later.
+            </p>
+          </div>
+        </div>
+      )}
+      {showPriceWarning && (
+        <div className='flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950/40 p-4'>
+          <AlertTriangle className='h-5 w-5 shrink-0 text-yellow-600 dark:text-yellow-400 mt-0.5' />
+          <div>
+            <p className='text-sm font-semibold text-yellow-800 dark:text-yellow-300'>
+              Price feed issue
+            </p>
+            <p className='text-sm text-yellow-700 dark:text-yellow-400'>
+              {priceMessage} Operations that depend on pricing (loans,
+              deposits, claims) may fail until the feed updates.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -528,8 +528,8 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         const isInGracePeriod = isLoanInGracePeriod(loan)
 
         // Countdown target — derived entirely from absolute timestamps on the
-        // loan struct (and loanConfig.balloonPaymentGraceDuration) so the value
-        // does not shift when the component re-renders. Three phases:
+        // loan struct so the value does not shift when the component
+        // re-renders. Three phases:
         //
         //   1. Interest NOT fully paid:
         //      count to the next cycle's payment deadline (capped at the loan
@@ -545,9 +545,15 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         // expected, since this is sized for mainnet cycle lengths.
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
         const loanEndMs = Number(loan.dueTimestamp) * 1000
-        const graceDurationMs = loanConfig?.balloonPaymentGraceDuration
-          ? Number(loanConfig.balloonPaymentGraceDuration) * 1000
-          : 0
+        // Per-loan grace snapshot (fixed at creation) so a config change
+        // can't shift existing loans' default countdowns; pre-upgrade loans
+        // have no snapshot (0) and fall back to the global config.
+        const graceDurationMs =
+          loan.balloonGraceSnapshot > 0n
+            ? Number(loan.balloonGraceSnapshot) * 1000
+            : loanConfig?.balloonPaymentGraceDuration
+              ? Number(loanConfig.balloonPaymentGraceDuration) * 1000
+              : 0
         const pastLoanEnd = isOverdue // isLoanOverdue === "now >= loanEndMs"
 
         // End of the next cycle the user must pay, accounting for prepayments.

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -24,6 +24,7 @@ import { ActiveLoans } from '@/src/components/dashboard/ActiveLoans'
 import { LoanHistory } from '@/src/components/dashboard/LoanHistory'
 import { Web3ErrorBoundary } from '@/src/components/error/Web3ErrorBoundary'
 import { PriceDataBanner } from '@/src/components/dashboard/PriceDataBanner'
+import { ProtocolStatusBanner } from '@/src/components/common/ProtocolStatusBanner'
 import { Plus, History, CreditCard, Calculator, DollarSign } from 'lucide-react'
 
 export function Dashboard() {
@@ -56,6 +57,11 @@ export function Dashboard() {
 
   return (
     <div className='space-y-6'>
+      {/* Protocol health — paused contracts / stale price feed */}
+      <Web3ErrorBoundary>
+        <ProtocolStatusBanner />
+      </Web3ErrorBoundary>
+
       {/* Header */}
       <div className='flex items-center justify-between'>
         <div>

--- a/src/components/liquidity/LiquidityDashboard.tsx
+++ b/src/components/liquidity/LiquidityDashboard.tsx
@@ -4,12 +4,18 @@ import { AddLiquidityCard } from './AddLiquidityCard'
 import { RemoveLiquidityCard } from './RemoveLiquidityCard'
 import { LiquidityPerformance } from './LiquidityPerformance'
 import { Web3ErrorBoundary } from '@/src/components/error/Web3ErrorBoundary'
+import { ProtocolStatusBanner } from '@/src/components/common/ProtocolStatusBanner'
 
 export function LiquidityDashboard() {
   const liquidityPool = useLiquidityPool()
 
   return (
     <div className='space-y-6'>
+      {/* Protocol health — paused contracts / stale price feed */}
+      <Web3ErrorBoundary>
+        <ProtocolStatusBanner />
+      </Web3ErrorBoundary>
+
       <div>
         <h1 className='text-3xl font-bold text-gray-900'>
           Become a LemLoans Liquidity Provider

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/src/components/ui/dialog'
 import { useToast } from '@/src/hooks/use-toast'
 import { formatTokenAmount } from '@/src/utils/decimals'
+import { floorToDecimals } from '@/src/utils/format'
 import {
   BarChart3,
   TrendingUp,
@@ -55,12 +56,14 @@ function StatItem({ label, value, warning }: { label: string; value: string; war
 }
 
 function formatCurrency(value: bigint, decimals: number, symbol: string): string {
-  const formatted = parseFloat(formatTokenAmount(value, decimals))
+  // Floor, never round up — these are balances/claimable amounts, and a
+  // rounded-up display overstates what the user can actually withdraw.
+  const formatted = floorToDecimals(parseFloat(formatTokenAmount(value, decimals)), 4)
   return `${formatted.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 })} ${symbol}`
 }
 
 function formatShares(value: bigint, decimals: number): string {
-  const formatted = parseFloat(formatTokenAmount(value, decimals))
+  const formatted = floorToDecimals(parseFloat(formatTokenAmount(value, decimals)), 4)
   return formatted.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
 }
 
@@ -140,6 +143,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     poolStatus,
     feeConfig,
     liquidityStatus,
+    currentUtilization,
     depositEntries,
     hasPosition,
     totalLoansIssued,
@@ -198,13 +202,16 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     return Number(feeConfig.feeBps) / 100
   }, [feeConfig])
 
+  // Use the pool's own utilization getter (returned in basis points) — the
+  // previous local formula divided by deposited−withdrawn, which ignores the
+  // principal deficit and permanently understates utilization once any loan
+  // has defaulted (verified live: contract 33.10% vs local formula 38.02%…
+  // and diverging the other way as deficits grow).
   const poolUtilization = useMemo(() => {
-    if (!liquidityStatus) return 0
-    const totalDeposited = liquidityStatus.principalDeposited - liquidityStatus.principalWithdrawn
-    if (totalDeposited === 0n) return 0
-    const util = (Number(liquidityStatus.principalInLoans) / Number(totalDeposited)) * 100
+    if (currentUtilization === undefined) return 0
+    const util = Number(currentUtilization) / 100
     return Math.min(Math.max(util, 0), 100)
-  }, [liquidityStatus])
+  }, [currentUtilization])
 
   const canDistributeEarnings = useMemo(() => {
     if (!poolStatus) return false

--- a/src/components/liquidity/RemoveLiquidityCard.tsx
+++ b/src/components/liquidity/RemoveLiquidityCard.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/src/components/ui/dialog'
 import { useToast } from '@/src/hooks/use-toast'
 import { formatTokenAmount, parseTokenAmount } from '@/src/utils/decimals'
+import { floorToDecimals } from '@/src/utils/format'
 import { Minus, Loader2, Clock, CheckCircle2, ArrowDownToLine } from 'lucide-react'
 import {
   handleContractError,
@@ -108,7 +109,8 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
   const netReceiveDisplay = useMemo(() => {
     if (!withdrawalFeePct || !parsedAmount || !feeConfig) return undefined
     const net = parsedAmount - (parsedAmount * feeConfig.feeBps) / 10000n
-    return parseFloat(formatTokenAmount(net, decimals)).toLocaleString('en-US', {
+    // Floor — never overstate what the user will receive.
+    return floorToDecimals(parseFloat(formatTokenAmount(net, decimals)), 2).toLocaleString('en-US', {
       maximumFractionDigits: 2,
     })
   }, [withdrawalFeePct, parsedAmount, feeConfig, decimals])
@@ -188,7 +190,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
               className='hover:text-foreground transition-colors'
             >
               Unlocked:{' '}
-              {parseFloat(formattedWithdrawable).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
+              {floorToDecimals(parseFloat(formattedWithdrawable), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
               {symbol}
             </button>
           </div>
@@ -197,7 +199,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
         {insufficientBalance && (
           <p className='text-sm text-destructive'>
             Insufficient unlocked balance. You can request up to{' '}
-            {parseFloat(formattedWithdrawable).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
+            {floorToDecimals(parseFloat(formattedWithdrawable), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
             {symbol}.
           </p>
         )}
@@ -261,7 +263,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
 
                   {isFullyFunded && withdrawalFeePct && (
                     <p className='text-xs text-muted-foreground'>
-                      {withdrawalFeePct}% fee on claim · ~{parseFloat(formatTokenAmount(req.amount - (req.amount * feeConfig!.feeBps) / 10000n, decimals)).toLocaleString('en-US', { maximumFractionDigits: 2 })} {symbol} net
+                      {withdrawalFeePct}% fee on claim · ~{floorToDecimals(parseFloat(formatTokenAmount(req.amount - (req.amount * feeConfig!.feeBps) / 10000n, decimals)), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })} {symbol} net
                     </p>
                   )}
 

--- a/src/hooks/loans/useDelegateValidation.ts
+++ b/src/hooks/loans/useDelegateValidation.ts
@@ -31,9 +31,12 @@ export interface DelegateValidationResult {
  *
  * - 'self' (always valid): the candidate equals the connected wallet. The
  *   contract skips the delegation check when `originationPayer == msg.sender`.
- * - 'valid': the candidate has authorized the borrower as a delegate, in
- *   either storage direction (the ABI doesn't name the mapping args, so we
- *   read both `[a][b]` and `[b][a]` and accept whichever returns true).
+ * - 'valid': the candidate (payer) has authorized the connected wallet
+ *   (borrower). The mapping is `originationDelegations[payer][borrower]` —
+ *   `setOriginationDelegate(borrower, true)` is called BY the payer, storing
+ *   `[msg.sender][borrower]`. Reading the reverse direction too (as this hook
+ *   once did) validated payers who never delegated, and the resulting
+ *   initiateLoan reverted only after the UI said the payer was authorized.
  * - Balance/allowance shortfalls are surfaced separately by LoanSummary's
  *   existing "insufficient LMLN balance" warning, which already reads the
  *   delegate's wallet whenever `originationPayer` is wired through useLoans.
@@ -58,28 +61,20 @@ export function useDelegateValidation(
 
   const enable = !!normalizedAddress && !!connectedAddress && !isSelf
 
-  const { data: readA, isLoading: isLoadingA } = useReadContract({
-    address: loansContractAddress,
-    abi: loansAbi,
-    functionName: 'originationDelegations',
-    args:
-      enable && connectedAddress && normalizedAddress
-        ? [connectedAddress, normalizedAddress]
-        : undefined,
-    query: { enabled: enable && !!loansContractAddress }
-  })
-  const { data: readB, isLoading: isLoadingB } = useReadContract({
-    address: loansContractAddress,
-    abi: loansAbi,
-    functionName: 'originationDelegations',
-    args:
-      enable && connectedAddress && normalizedAddress
-        ? [normalizedAddress, connectedAddress]
-        : undefined,
-    query: { enabled: enable && !!loansContractAddress }
-  })
-  const isCheckingDelegation = isLoadingA || isLoadingB
-  const isAuthorized = Boolean(readA) || Boolean(readB)
+  // originationDelegations[payer][borrower] — candidate is the payer, the
+  // connected wallet is the borrower being paid for.
+  const { data: delegationRead, isLoading: isCheckingDelegation } =
+    useReadContract({
+      address: loansContractAddress,
+      abi: loansAbi,
+      functionName: 'originationDelegations',
+      args:
+        enable && connectedAddress && normalizedAddress
+          ? [normalizedAddress, connectedAddress]
+          : undefined,
+      query: { enabled: enable && !!loansContractAddress }
+    })
+  const isAuthorized = Boolean(delegationRead)
 
   // Delegate's LMLN balance — shown for context once verified. Useful for
   // the borrower to see their delegate has funds before submitting.

--- a/src/hooks/loans/useDelegationManager.ts
+++ b/src/hooks/loans/useDelegationManager.ts
@@ -64,28 +64,17 @@ export function useDelegationManager(
 
   const enable = !!normalizedBorrower && !!address && !isSelf
 
-  // The ABI doesn't name the `originationDelegations` mapping args, so we
-  // read both directions and accept whichever returns true. Raw
-  // useReadContract avoids a TS2589 deep-instantiation error that occurs
-  // when both the typed read and the typed write are imported in this file.
+  // originationDelegations[payer][borrower] — the connected wallet is the
+  // payer here (it calls setOriginationDelegate), candidate is the borrower.
+  // Reading both arg orders and OR-ing (as this hook once did) made the UI
+  // claim "delegated" when only the reverse direction existed, hiding the
+  // delegate CTA the user actually needed. Raw useReadContract avoids a
+  // TS2589 deep-instantiation error that occurs when both the typed read and
+  // the typed write are imported in this file.
   const {
-    data: readA,
-    isLoading: isLoadingA,
-    refetch: refetchA
-  } = useReadContract({
-    address: loansContractAddress,
-    abi: loansAbi,
-    functionName: 'originationDelegations',
-    args:
-      enable && normalizedBorrower && address
-        ? [normalizedBorrower, address]
-        : undefined,
-    query: { enabled: enable && !!loansContractAddress }
-  })
-  const {
-    data: readB,
-    isLoading: isLoadingB,
-    refetch: refetchB
+    data: delegationRead,
+    isLoading: isCheckingDelegation,
+    refetch: refetchDelegation
   } = useReadContract({
     address: loansContractAddress,
     abi: loansAbi,
@@ -96,11 +85,8 @@ export function useDelegationManager(
         : undefined,
     query: { enabled: enable && !!loansContractAddress }
   })
-  const isCheckingDelegation = isLoadingA || isLoadingB
-  const bothUndefined = readA === undefined && readB === undefined
-  const isAlreadyDelegated = bothUndefined
-    ? undefined
-    : Boolean(readA) || Boolean(readB)
+  const isAlreadyDelegated =
+    delegationRead === undefined ? undefined : Boolean(delegationRead)
 
   // Connected wallet's LMLN allowance to the Loans contract — drives the
   // "skip approval" path on delegate().
@@ -162,8 +148,8 @@ export function useDelegationManager(
               'originationDelegations'
         )
     })
-    await Promise.all([refetchA(), refetchB()])
-  }, [queryClient, refetchA, refetchB])
+    await refetchDelegation()
+  }, [queryClient, refetchDelegation])
 
   const delegate = useCallback(
     async (borrower: `0x${string}`) => {

--- a/src/hooks/loans/useUserLoans.ts
+++ b/src/hooks/loans/useUserLoans.ts
@@ -85,6 +85,7 @@ const combineLoanData = (
     collateralToken: loan.collateralToken,
     collateralAmount: loan.collateralAmount,
     loanCycleDuration: loan.loanCycleDuration,
+    balloonGraceSnapshot: loan.balloonGraceSnapshot,
 
     // Contract-derived values with defaults
     status: status ?? LOAN_STATUS.ACTIVE,

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -34,6 +34,7 @@ export interface Loan {
   // Computed helper properties (derived from contract data)
   originalDuration: bigint // Duration at loan creation (max allowed extension)
   loanCycleDuration: bigint // From loans struct — used for adaptive countdown buffer
+  balloonGraceSnapshot: bigint // Grace window captured at creation (0 for pre-upgrade loans)
   remainingBalance: bigint // Calculated from contract values, not manually
   dueTimestamp: bigint // Calculated from timeToDefault
 }
@@ -49,19 +50,26 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
   // though makeLoanPayment will revert with LoanNotActive. Compute an
   // effective status here so the UI reflects reality: badge as Defaulted,
   // drop from active list, and prevent the doomed payment flow.
-  const grace = config.loanConfig?.balloonPaymentGraceDuration ?? 0n
+  //
+  // Grace comes from the loan's own snapshot (fixed at creation) so an admin
+  // change to the global config can't retroactively re-badge existing loans.
+  // Loans created before the upgrade that added the snapshot read 0 — fall
+  // back to the global config for those.
+  const globalGrace = config.loanConfig?.balloonPaymentGraceDuration ?? 0n
   const effectiveLoans = useMemo(() => {
     const nowSec = BigInt(Math.floor(Date.now() / 1000))
     return userData.loans.flatMap((loan) => {
       if (!loan) return []
       if (loan.status !== LOAN_STATUS.ACTIVE) return [loan]
+      const grace =
+        loan.balloonGraceSnapshot > 0n ? loan.balloonGraceSnapshot : globalGrace
       const defaultAt = loan.createdAt + loan.duration + grace
       if (nowSec >= defaultAt) {
         return [{ ...loan, status: LOAN_STATUS.DEFAULT }]
       }
       return [loan]
     })
-  }, [userData.loans, grace])
+  }, [userData.loans, globalGrace])
 
   const activeLoans = useMemo(
     () =>

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -14,6 +14,7 @@ export interface LoanStructResponse {
   readonly [10]: bigint // originationFee
   readonly [11]: bigint // collateralAmount
   readonly [12]: bigint // loanCycleDuration
+  readonly [13]: bigint // balloonGraceSnapshot
 }
 
 export interface LoanConfigResponse {
@@ -46,7 +47,11 @@ export function parseLoanStruct(data: LoanStructResponse) {
     ltv: data[9],
     originationFee: data[10],
     collateralAmount: data[11],
-    loanCycleDuration: data[12]
+    loanCycleDuration: data[12],
+    // Grace window captured at loan creation. Loans created before the
+    // contract upgrade that added this field read 0 — callers must fall
+    // back to the global loanConfig.balloonPaymentGraceDuration for those.
+    balloonGraceSnapshot: data[13] ?? 0n
   }
 }
 

--- a/src/utils/decimals.ts
+++ b/src/utils/decimals.ts
@@ -39,10 +39,12 @@ export function formatPercentage(value: bigint, decimals: number): string {
   if (value < 0n) {
     throw new DecimalError('Percentage value cannot be negative')
   }
-  // Convert to decimal then multiply by 100 to get percentage
+  // Convert to decimal then multiply by 100 to get percentage. Keep up to
+  // two decimal places — rounding to a whole percent would display a 12.5%
+  // APR as 13% and break matching against non-integer LTV tiers.
   const decimal = formatUnits(value, decimals)
-  const percentage = Math.round(Number(decimal) * 100).toString()
-  return percentage
+  const percentage = Math.round(Number(decimal) * 10000) / 100
+  return percentage.toString()
 }
 
 /**

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -7,6 +7,17 @@ export const formatAmount = (amount: bigint, decimals = 18): string => {
   return formatTokenAmount(amount, decimals)
 }
 
+/**
+ * Floor a value to N decimal places for display. Balances and receivable
+ * amounts must round DOWN — half-up rounding shows users money they don't
+ * quite have (99.996 renders as "100.00", and typing that back in then fails
+ * the exact-amount balance check).
+ */
+export const floorToDecimals = (value: number, decimals: number): number => {
+  const factor = 10 ** decimals
+  return Math.floor(value * factor) / factor
+}
+
 export const formatAmountWithSymbol = (
   amount: bigint,
   symbol: string,


### PR DESCRIPTION
## Summary

Second tranche of the production-readiness audit: items that are correct today but silently break the moment an admin changes protocol config (grace duration, LTV tiers, FEE_BPS) — plus two live display bugs.

- **balloonGraceSnapshot** wired end-to-end (struct parser index [13] → `Loan` → effective-status → default countdown). An admin change to `balloonPaymentGraceDuration` can no longer retroactively re-badge existing loans as Defaulted or shift their countdowns. Pre-upgrade loans (snapshot = 0) fall back to the global config.
- **LTV round-trip fix**: `formatPercentage` keeps 2 decimals (a 12.5% APR displayed as 13% before); the calculator matches the selected tier by its formatted display value and sends the tier's **exact contract bigint** on-chain instead of reconstructing it via `parseUnits((ltv/100).toString())`; the slider snaps to the nearest configured tier, so non-uniform tiers (20/30/50) can't land on an LTV that has no fee entry.
- **Delegation direction**: `originationDelegations` is read only as `[payer][borrower]` (the setter is called by the payer). The old both-directions OR validated payers who never delegated and hid the delegate CTA when only the reverse direction existed. ⚠️ *Please double-check the mapping order against the Solidity source — inferred from `setOriginationDelegate(borrower, bool)` semantics and not verifiable from the ABI. If reversed, the DelegationManager will show "not delegated" right after delegating, which is immediately visible in testing.*
- **ProtocolStatusBanner** (new) on the dashboard and liquidity pages: `Loans.paused()` / `LiquidityPool.paused()` and price-feed staleness now surface as a global banner instead of opaque per-transaction failures deep in a flow.
- **Pool utilization** now uses the contract's `getCurrentUtilization()` (bps). Verified live on testnet: contract says **33.10%** while the old local formula displayed **38.02%** (it ignored the principal deficit).
- **Rounding sweep**: balance-type displays floor instead of rounding half-up (unlocked withdrawable, net receive, claim net, pool stat cards, delegate LMLN balance) via a shared `floorToDecimals` util — same bug class as the earlier wallet-balance flooring fix.

## Verification
- `tsc --noEmit` clean, `next lint` no errors, `vitest` 97/97, `next build` succeeds
- Utilization figure cross-checked against the live testnet contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)