### PR TITLE
P2: UX polish, edge cases, and cleanups (audit follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "wagmi generate && npx prettier --write src/generated.ts && next build",
-    "build:local": "wagmi generate && npx prettier --write src/generated.ts && next build",
+    "build": "wagmi generate && npx prettier --write src/generated.ts && NODE_OPTIONS=--max-old-space-size=6144 next build",
+    "build:local": "wagmi generate && npx prettier --write src/generated.ts && NODE_OPTIONS=--max-old-space-size=6144 next build",
     "start": "next start",
     "lint": "next lint",
     "pages:build": "npx @cloudflare/next-on-pages",

--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -173,9 +173,14 @@ export function LoanParameters({
                 }
 
                 const numValue = Number(value)
-                if (numValue <= maxLoanAmount) {
-                  setLoanAmount(numValue)
+                // Reject garbage and negatives (a negative passed the old
+                // <= max check and flowed into parseUnits), and clamp
+                // above-max input to the max instead of silently swallowing
+                // the keystroke — a frozen input reads as a broken app.
+                if (!Number.isFinite(numValue) || numValue < 0) {
+                  return
                 }
+                setLoanAmount(Math.min(numValue, maxLoanAmount))
               }}
               min={minLoanAmount > 0 ? minLoanAmount : undefined}
               max={maxLoanAmount}

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -3,6 +3,7 @@
 import { Button } from '../ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { Plus } from 'lucide-react'
+import { formatDuration } from '../../utils/format'
 import { useState } from 'react'
 import { DisclaimerModal } from '../common/DisclaimerModal'
 import { LoanConfirmationModal } from '../common/LoanConfirmationModal'
@@ -192,7 +193,9 @@ export function LoanSummary({
               <span
                 className={`${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'}`}
               >
-                Monthly Payment
+                {/* Labeled by the actual cycle, not "Monthly" — a 14-day
+                    cycle config would understate the real monthly cost 2×. */}
+                Payment per Cycle
               </span>
               <span
                 className={`font-medium ${!isDashboard ? 'text-white' : ''}`}
@@ -230,13 +233,15 @@ export function LoanSummary({
                 >
                   {calculation.loanCycles} {calculation.loanCycles === 1 ? 'cycle' : 'cycles'}
                 </span>
-                {calculation.loanCycleDuration && (
+                {calculation.loanCycleDuration ? (
                   <div
                     className={`text-xs ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'} mt-0.5`}
                   >
-                    {Math.round(Number(calculation.loanCycleDuration) / (24 * 60 * 60))} day loan cycles
+                    {/* formatDuration handles sub-day (testnet) cycles that
+                        used to render as "0 day loan cycles". */}
+                    {formatDuration(calculation.loanCycleDuration)} loan cycles
                   </div>
-                )}
+                ) : null}
               </div>
             </div>
           </div>

--- a/src/components/common/ProtocolStatusBanner.tsx
+++ b/src/components/common/ProtocolStatusBanner.tsx
@@ -1,14 +1,18 @@
 'use client'
 
-import { useReadContract } from 'wagmi'
-import { useReadLoansPaused, liquidityPoolAbi } from '@/src/generated'
+import { useAccount, useChainId, useReadContract, useSwitchChain } from 'wagmi'
+import {
+  useReadLoansPaused,
+  liquidityPoolAbi,
+  loansAddress
+} from '@/src/generated'
 import { useProtocolAddresses } from '@/src/hooks/useProtocolAddresses'
 import { usePricing } from '@/src/hooks/usePricing'
 import {
   extractErrorMessage,
   type ContractError
 } from '@/src/utils/errorHandling'
-import { AlertTriangle, PauseCircle } from 'lucide-react'
+import { AlertTriangle, PauseCircle, Network } from 'lucide-react'
 
 /**
  * Global protocol health banner. Every fee-bearing write depends on the
@@ -17,6 +21,25 @@ import { AlertTriangle, PauseCircle } from 'lucide-react'
  * in a flow (approve succeeds, then the real tx reverts).
  */
 export function ProtocolStatusBanner() {
+  const { isConnected } = useAccount()
+  const chainId = useChainId()
+  const { switchChain, chains } = useSwitchChain()
+
+  // Wrong / unsupported network: without a Loans address every config read
+  // silently never resolves, and the only cue was the tiny wallet-button
+  // pill. Detect it here and offer a one-click switch. Widen to string —
+  // the generated literal types make a zero-address comparison a TS error,
+  // but at runtime an unconfigured env var really does yield the zero addr.
+  const hasLoansAddress = (id: number): boolean => {
+    const addr = loansAddress[id as keyof typeof loansAddress] as
+      | string
+      | undefined
+    return !!addr && addr !== '0x0000000000000000000000000000000000000000'
+  }
+  const isUnsupportedNetwork = isConnected && !hasLoansAddress(chainId)
+  const fallbackChain = chains.find((c) => hasLoansAddress(c.id))
+
+  // @ts-ignore - wagmi deep type instantiation
   const { data: loansPaused } = useReadLoansPaused({
     query: { refetchInterval: 30_000 }
   })
@@ -41,10 +64,32 @@ export function ProtocolStatusBanner() {
 
   const isPaused = Boolean(loansPaused) || Boolean(lpPaused)
 
-  if (!isPaused && !showPriceWarning) return null
+  if (!isPaused && !showPriceWarning && !isUnsupportedNetwork) return null
 
   return (
     <div className='space-y-2'>
+      {isUnsupportedNetwork && (
+        <div className='flex items-start gap-3 rounded-lg border border-orange-300 bg-orange-50 dark:border-orange-900 dark:bg-orange-950/40 p-4'>
+          <Network className='h-5 w-5 shrink-0 text-orange-600 dark:text-orange-400 mt-0.5' />
+          <div className='flex-1'>
+            <p className='text-sm font-semibold text-orange-800 dark:text-orange-300'>
+              Unsupported network
+            </p>
+            <p className='text-sm text-orange-700 dark:text-orange-400'>
+              Your wallet is connected to a network this app doesn&apos;t
+              support, so no data can load.
+            </p>
+          </div>
+          {fallbackChain && (
+            <button
+              onClick={() => switchChain({ chainId: fallbackChain.id })}
+              className='shrink-0 rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700 transition-colors'
+            >
+              Switch to {fallbackChain.name}
+            </button>
+          )}
+        </div>
+      )}
       {isPaused && (
         <div className='flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950/40 p-4'>
           <PauseCircle className='h-5 w-5 shrink-0 text-red-600 dark:text-red-400 mt-0.5' />

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -161,6 +161,17 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
       tokenConfig.loanToken.decimals
     )
     const rounded = Math.ceil(parseFloat(minPayment) * 10) / 10
+    // Rounding a cost up is the safe direction, but near payoff the rounded
+    // minimum can exceed the remaining balance — and the payment guard then
+    // rejects the app's own default suggestion with "Payment Too Large".
+    // Clamp to the exact remaining balance in that case.
+    const remaining = formatTokenAmount(
+      loan.remainingBalance,
+      tokenConfig.loanToken.decimals
+    )
+    if (rounded > parseFloat(remaining)) {
+      return remaining
+    }
     return rounded.toFixed(1)
   }
 
@@ -723,8 +734,11 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                   </span>
                   <span>
                     {isInGracePeriod ? 'Principal' : 'Remaining'}:{' '}
+                    {/* remainingBalance in both phases — showing the original
+                        loanAmount here overstated the debt for borrowers who
+                        prepaid part of the principal before the grace window. */}
                     {formatAmountWithSymbol(
-                      isInGracePeriod ? loan.loanAmount : loan.remainingBalance,
+                      loan.remainingBalance,
                       tokenConfig?.loanToken.symbol || 'Token'
                     )}
                   </span>
@@ -796,6 +810,11 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                   <Dialog
                     open={isPaymentDialogOpen && selectedLoan === loan.id}
                     onOpenChange={(open) => {
+                      // Don't let ESC / outside-click dismiss mid-transaction —
+                      // the user would lose the pending-payment context.
+                      if (!open && (isApprovingPayment || isProcessingPayment)) {
+                        return
+                      }
                       setIsPaymentDialogOpen(open)
                       if (!open) {
                         setSelectedLoan(null)
@@ -1071,6 +1090,13 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                       selectedLoanForExtension === loan.id
                     }
                     onOpenChange={(open) => {
+                      // Don't dismiss mid-transaction (see payment dialog).
+                      if (
+                        !open &&
+                        (isApprovingExtension || isProcessingExtension)
+                      ) {
+                        return
+                      }
                       setIsExtensionDialogOpen(open)
                       if (!open) {
                         setSelectedLoanForExtension(null)
@@ -1212,6 +1238,26 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                              *  We suppress the balance warning while a delegate is unlocked
                              *  but unauthorized — the field's "not authorized" message is
                              *  the actionable error to show first. */}
+                            {/* A verified delegate with insufficient allowance used to
+                                leave "Confirm Extension" inexplicably dead while the
+                                field showed green — say why and what to do. */}
+                            {!isExtensionPayerLocked &&
+                              !extensionPayerValidation.isSelf &&
+                              extensionPayerValidation.isValid &&
+                              needsApproval &&
+                              loan.originationFee > 0n &&
+                              !hasInsufficientBalance && (
+                                <p className='text-sm text-destructive flex items-center gap-2'>
+                                  <AlertCircle className='h-4 w-4 shrink-0' />
+                                  <span>
+                                    The delegate hasn&apos;t approved enough{' '}
+                                    {tokenConfig?.feeToken.symbol || 'LMLN'} to the
+                                    Loans contract. They need to grant approval (the
+                                    Delegation Manager does this when authorizing)
+                                    before you can extend.
+                                  </span>
+                                </p>
+                              )}
                             <div className='flex gap-2'>
                               {hasInsufficientBalance &&
                               (isExtensionPayerLocked ||

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -450,6 +450,30 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
               Insufficient balance. You need ~{tokenEquivalent} {symbol} but your balance is only worth ${balanceInUsd ?? '0'} USD.
             </p>
           )}
+          {/* The Deposit button used to sit inexplicably disabled when a
+              required choice was missing (or no tiers are enabled, in which
+              case the tier section doesn't render at all) — say why. */}
+          {amount && selectedAsset === undefined && (
+            <p className='text-sm text-muted-foreground'>
+              Select a token above to continue.
+            </p>
+          )}
+          {selectedAsset !== undefined && enabledTiers.length === 0 && (
+            <p className='text-sm text-destructive'>
+              No lock durations are currently enabled for this token — deposits
+              are unavailable.
+            </p>
+          )}
+          {amount &&
+            selectedAsset !== undefined &&
+            enabledTiers.length > 0 &&
+            selectedTier === undefined &&
+            !isBelowMinimum &&
+            !insufficientBalance && (
+              <p className='text-sm text-muted-foreground'>
+                Select a lock duration to continue.
+              </p>
+            )}
         </div>
 
         <div>

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -242,7 +242,11 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     setIsProcessing(actionName)
     try {
       await action()
-      toast({ title: '\u2705 Success', description: successMsg })
+      // Title the toast with the actual action ("\u2705 Claim Earnings Successful")
+      // instead of a generic "\u2705 Success" shared by five different operations.
+      // Split camelCase names ("TransferAccount" \u2192 "Transfer Account").
+      const title = actionName.replace(/([a-z])([A-Z])/g, '$1 $2')
+      toast({ title: `\u2705 ${title} Successful`, description: successMsg })
       await refetch()
     } catch (err: unknown) {
       handleContractError(err as ContractError, toast, `${actionName} Failed`)

--- a/src/hooks/loans/useLoanConfig.ts
+++ b/src/hooks/loans/useLoanConfig.ts
@@ -64,12 +64,12 @@ export const useLoanConfig = (asset?: `0x${string}`) => {
   const ltvOptions = useMemo(() => {
     if (!originationFeesRaw) return []
     const [ltvs = [], fees = []] = originationFeesRaw || []
-    return ltvs
-      .map((ltv, index) => ({
-        ltv,
-        fee: fees[index] ?? 0n
-      }))
-      .filter((option) => option.fee && option.fee > 0n)
+    // Every configured tier is selectable — a zero fee is a legitimate
+    // configuration (free origination at that LTV), not a missing entry.
+    return ltvs.map((ltv, index) => ({
+      ltv,
+      fee: fees[index] ?? 0n
+    }))
   }, [originationFeesRaw])
 
   const isLoading =

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -526,7 +526,9 @@ export const useLoanOperations = (
         throw new Error('Unable to calculate collateral amount. Please try again.')
       }
       
-      if (!originationFee || originationFee === 0n) {
+      // undefined means the calculation hasn't resolved; 0n is a legitimate
+      // zero-fee LTV tier and must not block creation.
+      if (originationFee === undefined) {
         throw new Error('Unable to calculate origination fee. Please try again.')
       }
 
@@ -676,13 +678,7 @@ export const useLoanOperations = (
 
       // Check if we need to approve tokens first
       if (!currentAllowance || currentAllowance < grossAmount) {
-        try {
-          // First approve the tokens
-          await approveTokenAllowance(amount)
-        } catch (error) {
-          // Re-throw the error to be handled by the calling component
-          throw error
-        }
+        await approveTokenAllowance(amount)
       }
 
       const nativeFee = paymentNativeFee ?? 0n

--- a/src/hooks/loans/useLoanPayment.ts
+++ b/src/hooks/loans/useLoanPayment.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { parseUnits } from 'viem'
 import type { Loan } from '../useLoans'
 import { LOAN_STATUS } from '@/src/constants'
 
@@ -28,12 +29,17 @@ export const useLoanPayment = (
     return loan?.remainingBalance ?? 0n
   }, [loan?.remainingBalance])
 
-  // Convert payment string to BigInt wei
+  // Convert payment string to BigInt wei. Must use parseUnits — float
+  // multiplication exceeds IEEE-754 precision at 18 decimals (1.1 * 1e18 =
+  // 1100000000000000128) and would produce a wrong payment amount.
   const parsePaymentAmount = useCallback(
     (paymentString: string): bigint => {
       if (!paymentString || isNaN(parseFloat(paymentString))) return 0n
-      const multiplier = 10 ** loanTokenDecimals
-      return BigInt(Math.floor(parseFloat(paymentString) * multiplier))
+      try {
+        return parseUnits(paymentString.trim(), loanTokenDecimals)
+      } catch {
+        return 0n
+      }
     },
     [loanTokenDecimals]
   )

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -421,7 +421,7 @@ export const handleContractError = (
     description: string
     variant?: 'destructive'
   }) => void,
-  successTitle: string = 'Operation Failed'
+  errorTitle: string = 'Operation Failed'
 ): void => {
   // Don't show error toast for user rejections - user knows they cancelled
   if (isUserRejection(error)) {
@@ -439,7 +439,7 @@ export const handleContractError = (
   const errorMessage = extractErrorMessage(error)
 
   showToast({
-    title: successTitle,
+    title: errorTitle,
     description: errorMessage,
     variant: 'destructive'
   })


### PR DESCRIPTION
## Summary

Final tranche of the production-readiness audit. **Stacked on #28** (base branch is `feat/p1-config-correctness`) — merge #28 first, then retarget this to `develop` or merge as-is after.

### Displayed-figure fixes
- Grace-period **Principal** row shows `remainingBalance` instead of the original `loanAmount` — the old display overstated the debt for borrowers who prepaid part of the principal.
- The suggested **minimum payment** (ceiled to 0.1) clamps to the remaining balance near payoff, so the app's default option can no longer be rejected by its own "Payment Too Large" guard.
- "Monthly Payment" → **"Payment per Cycle"** (a 14-day cycle config understated real monthly cost 2×), and the cycle caption uses `formatDuration` so sub-day testnet cycles no longer render as "0 day loan cycles".

### UX gaps
- Payment and extension dialogs can't be dismissed by ESC/outside-click **mid-transaction**.
- Loan amount input **clamps to max and rejects negatives** instead of silently swallowing keystrokes (a negative used to flow into `parseUnits`).
- Extend-loan now **explains the dead Confirm button** when a verified delegate lacks LMLN allowance (field showed green while the CTA was inexplicably disabled).
- AddLiquidity shows **why Deposit is disabled**: token not selected, lock duration not selected, or no tiers enabled at all (previously the tier section just didn't render).
- ProtocolStatusBanner detects **unsupported networks** and offers a one-click switch to a supported chain.

### Cleanups
- `parsePaymentAmount` uses `parseUnits` — the float path produced wrong wei past 15 significant digits (`1.1 × 1e18 = 1100000000000000128`). Dormant, but one call-site away from a wrong payment.
- Zero-fee LTV tiers are selectable (a configured $0 fee is legitimate, not a missing entry); `createLoan` guard distinguishes "not loaded" from "genuinely zero".
- Per-action success toast titles ("✅ Claim Earnings Successful") instead of a generic "✅ Success" shared by five operations.
- Removed a no-op `try { … } catch (e) { throw e }`; renamed `handleContractError`'s misleading `successTitle` param to `errorTitle`.

## Verification
- `tsc --noEmit` clean, `next lint` no errors, `vitest` 97/97, `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)