### PR TITLE
test: QA suite — ABI drift guards, error coverage, display math

### DIFF
--- a/src/__tests__/contract-parsers.test.ts
+++ b/src/__tests__/contract-parsers.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import type { Abi } from 'viem'
+import { loansAbi } from '../generated'
+import {
+  parseLoanStruct,
+  parseLoanConfig,
+  type LoanStructResponse,
+  type LoanConfigResponse
+} from '../types/contracts'
+
+/**
+ * The app decodes several contract tuples BY INDEX (hand-written parsers in
+ * src/types/contracts.ts). If a contract regen reorders, renames, inserts, or
+ * removes a field, those indices silently point at the wrong values — these
+ * guards pin the ABI shape so the regen fails CI instead.
+ */
+
+type AbiFunctionItem = Extract<Abi[number], { type: 'function' }>
+
+function outputsOf(fnName: string): readonly { name?: string; type: string }[] {
+  const fn = (loansAbi as Abi).find(
+    (item): item is AbiFunctionItem => item.type === 'function' && item.name === fnName
+  )
+  if (!fn) throw new Error(`${fnName} missing from Loans ABI`)
+  return fn.outputs ?? []
+}
+
+describe('ABI shape guards (index-based decoders)', () => {
+  it('loans() field order matches parseLoanStruct indices', () => {
+    expect(outputsOf('loans').map((o) => o.name)).toEqual([
+      'account',
+      'collateralToken',
+      'createdAt',
+      'loanAmount',
+      'duration',
+      'originalDuration',
+      'interestAmount',
+      'interestApr',
+      'paidAmount',
+      'ltv',
+      'originationFee',
+      'collateralAmount',
+      'loanCycleDuration',
+      'balloonGraceSnapshot'
+    ])
+  })
+
+  it('loanConfig() field order matches parseLoanConfig indices', () => {
+    expect(outputsOf('loanConfig').map((o) => o.name)).toEqual([
+      'minLoanAmount',
+      'minLoanDuration',
+      'maxLoanDuration',
+      'balloonPaymentGraceDuration',
+      'loanCycleDuration',
+      'aprYearDuration'
+    ])
+  })
+
+  it('calculateLoanDetails() output order matches the destructuring in useLoanOperations', () => {
+    expect(outputsOf('calculateLoanDetails').map((o) => o.name)).toEqual([
+      'interestAmount',
+      'interestApr',
+      'originationFee',
+      'collateralAmount',
+      'loanCycleDuration',
+      'firstLoanPayment'
+    ])
+  })
+
+  it('getLiquidityStatus() output order matches parseLiquidityStatus indices', () => {
+    expect(outputsOf('getLiquidityStatus').map((o) => o.name)).toEqual([
+      'principalDeposited',
+      'principalWithdrawn',
+      'principalInLoans',
+      'principalDeficitAmount',
+      'principalAvailable',
+      'interestEarned',
+      'interestDistributed',
+      'interestAvailable'
+    ])
+  })
+})
+
+describe('parseLoanStruct', () => {
+  const base = [
+    '0x' + 'aa'.repeat(20), // account
+    '0x' + 'bb'.repeat(20), // collateralToken
+    1_700_000_000n, // createdAt
+    10_000n, // loanAmount
+    3_600n, // duration
+    3_600n, // originalDuration
+    500n, // interestAmount
+    12_500_000n, // interestApr
+    250n, // paidAmount
+    20_000_000n, // ltv
+    8_448n, // originationFee
+    123_456n, // collateralAmount
+    300n, // loanCycleDuration
+    86_400n // balloonGraceSnapshot
+  ] as unknown as LoanStructResponse
+
+  it('maps every index to the right field, including balloonGraceSnapshot at [13]', () => {
+    const loan = parseLoanStruct(base)
+    expect(loan.account).toBe('0x' + 'aa'.repeat(20))
+    expect(loan.collateralToken).toBe('0x' + 'bb'.repeat(20))
+    expect(loan.createdAt).toBe(1_700_000_000n)
+    expect(loan.loanAmount).toBe(10_000n)
+    expect(loan.duration).toBe(3_600n)
+    expect(loan.originalDuration).toBe(3_600n)
+    expect(loan.interestAmount).toBe(500n)
+    expect(loan.interestApr).toBe(12_500_000n)
+    expect(loan.paidAmount).toBe(250n)
+    expect(loan.ltv).toBe(20_000_000n)
+    expect(loan.originationFee).toBe(8_448n)
+    expect(loan.collateralAmount).toBe(123_456n)
+    expect(loan.loanCycleDuration).toBe(300n)
+    expect(loan.balloonGraceSnapshot).toBe(86_400n)
+  })
+
+  it('defaults balloonGraceSnapshot to 0n for pre-upgrade 13-field tuples', () => {
+    const preUpgrade = (base as unknown as unknown[]).slice(0, 13) as unknown as LoanStructResponse
+    expect(parseLoanStruct(preUpgrade).balloonGraceSnapshot).toBe(0n)
+  })
+})
+
+describe('parseLoanConfig', () => {
+  it('maps all six fields in order', () => {
+    const config = parseLoanConfig([
+      1_000n,
+      300n,
+      31_104_000n,
+      86_400n,
+      2_592_000n,
+      31_104_000n
+    ] as unknown as LoanConfigResponse)
+    expect(config).toEqual({
+      minLoanAmount: 1_000n,
+      minLoanDuration: 300n,
+      maxLoanDuration: 31_104_000n,
+      balloonPaymentGraceDuration: 86_400n,
+      loanCycleDuration: 2_592_000n,
+      aprYearDuration: 31_104_000n
+    })
+  })
+})

--- a/src/__tests__/display-math.test.ts
+++ b/src/__tests__/display-math.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import { formatPercentage, parseTokenAmount, formatTokenAmount } from '../utils/decimals'
+import { floorToDecimals, formatDuration, formatAmountWithSymbol } from '../utils/format'
+import { grossPaymentAmount } from '../utils/fees'
+import {
+  resolveGraceDuration,
+  loanDefaultTimestamp,
+  isPastDefault
+} from '../utils/loanStatus'
+
+/** Contract convention on this deployment: ltvDecimals = aprDecimals = 8. */
+const PCT_DECIMALS = 8
+
+describe('formatPercentage (2-decimal precision)', () => {
+  it('keeps whole percentages unchanged', () => {
+    expect(formatPercentage(20_000_000n, PCT_DECIMALS)).toBe('20')
+    expect(formatPercentage(60_000_000n, PCT_DECIMALS)).toBe('60')
+  })
+
+  it('preserves fractional percentages instead of rounding to a whole percent', () => {
+    // 12.5% APR used to display as "13" — a wrong number on a financial figure.
+    expect(formatPercentage(12_500_000n, PCT_DECIMALS)).toBe('12.5')
+    expect(formatPercentage(32_500_000n, PCT_DECIMALS)).toBe('32.5')
+    expect(formatPercentage(12_340_000n, PCT_DECIMALS)).toBe('12.34')
+  })
+
+  it('LTV tier matching round-trip is lossless for non-integer tiers', () => {
+    // The calculator finds the selected tier by comparing the slider value
+    // against Number(formatPercentage(tier.ltv)). Every distinct tier must
+    // survive that transformation uniquely.
+    const tiers = [20_000_000n, 30_000_000n, 32_500_000n, 50_000_000n, 62_500_000n]
+    const displayed = tiers.map((t) => Number(formatPercentage(t, PCT_DECIMALS)))
+    expect(displayed).toEqual([20, 30, 32.5, 50, 62.5])
+    expect(new Set(displayed).size).toBe(tiers.length)
+  })
+})
+
+describe('floorToDecimals (balances must round DOWN)', () => {
+  it('floors instead of rounding half-up', () => {
+    expect(floorToDecimals(99.996, 2)).toBe(99.99)
+    expect(floorToDecimals(99.994, 2)).toBe(99.99)
+    expect(floorToDecimals(0.129, 2)).toBe(0.12)
+  })
+
+  it('leaves exact values untouched', () => {
+    expect(floorToDecimals(100, 2)).toBe(100)
+    expect(floorToDecimals(1.25, 2)).toBe(1.25)
+    expect(floorToDecimals(0, 2)).toBe(0)
+  })
+
+  it('supports 4-decimal displays', () => {
+    expect(floorToDecimals(0.00005, 4)).toBe(0)
+    expect(floorToDecimals(1.23456789, 4)).toBe(1.2345)
+  })
+})
+
+describe('formatDuration (cycle captions)', () => {
+  it('renders sub-day cycles instead of "0 day"', () => {
+    // 5-minute testnet cycles used to render as "0 day loan cycles".
+    expect(formatDuration(300n)).toMatch(/minute/i)
+    expect(formatDuration(3_600n)).toMatch(/hour/i)
+  })
+
+  it('renders financial-calendar days and months', () => {
+    expect(formatDuration(86_400n)).toMatch(/day/i)
+    expect(formatDuration(2_592_000n)).toMatch(/month|30/i)
+  })
+})
+
+describe('parse/format token amounts', () => {
+  it('parseTokenAmount is exact where float math is not', () => {
+    // 1.1 * 1e18 in IEEE-754 is 1100000000000000128 — parseUnits must be exact.
+    expect(parseTokenAmount('1.1', 18)).toBe(1_100_000_000_000_000_000n)
+    expect(parseTokenAmount('123456789.123456789123456789', 18)).toBe(
+      123_456_789_123_456_789_123_456_789n
+    )
+  })
+
+  it('round-trips exactly through formatTokenAmount', () => {
+    const wei = parseTokenAmount('42.000001', 18)
+    expect(parseTokenAmount(formatTokenAmount(wei, 18), 18)).toBe(wei)
+  })
+
+  it('formatAmountWithSymbol renders two decimals with the symbol', () => {
+    expect(formatAmountWithSymbol(1_500_000_000_000_000_000n, 'USDT')).toBe('1.50 USDT')
+  })
+})
+
+describe('grossPaymentAmount (protocol fee coverage)', () => {
+  const DENOM = 10_000n
+
+  it('adds the exact fee for cleanly divisible amounts', () => {
+    // 10_000 wei at 25 bps → fee 25
+    expect(grossPaymentAmount(10_000n, 25n, DENOM)).toBe(10_025n)
+  })
+
+  it('rounds the fee UP so the approval always covers the on-chain pull', () => {
+    // 10_001 * 25 / 10_000 = 25.0025 → contract pulls ≤ 26; we approve 26.
+    expect(grossPaymentAmount(10_001n, 25n, DENOM)).toBe(10_001n + 26n)
+    // 1 wei payment still reserves 1 wei of fee.
+    expect(grossPaymentAmount(1n, 25n, DENOM)).toBe(2n)
+  })
+
+  it('gross always covers amount + floor(amount*fee/denom) (contract-side floor)', () => {
+    for (const amount of [1n, 3n, 999n, 10_000n, 123_456_789n, 10n ** 24n]) {
+      for (const bps of [1n, 25n, 100n, 999n]) {
+        const gross = grossPaymentAmount(amount, bps, DENOM)
+        const contractPull = amount + (amount * bps) / DENOM
+        expect(gross >= contractPull).toBe(true)
+        // and never overshoots by more than one rounding unit
+        expect(gross - contractPull <= 1n).toBe(true)
+      }
+    }
+  })
+
+  it('handles zero fee and zero amount', () => {
+    expect(grossPaymentAmount(10_000n, 0n, DENOM)).toBe(10_000n)
+    expect(grossPaymentAmount(0n, 25n, DENOM)).toBe(0n)
+  })
+})
+
+describe('loan default timing (balloonGraceSnapshot)', () => {
+  const createdAt = 1_700_000_000n
+  const duration = 3_600n
+
+  it('uses the per-loan snapshot when present', () => {
+    expect(resolveGraceDuration(86_400n, 43_200n)).toBe(86_400n)
+  })
+
+  it('falls back to the global config for pre-upgrade loans (snapshot = 0)', () => {
+    expect(resolveGraceDuration(0n, 43_200n)).toBe(43_200n)
+  })
+
+  it('a global grace change does NOT move a snapshotted loan’s default moment', () => {
+    const snapshot = 86_400n
+    const before = loanDefaultTimestamp(createdAt, duration, resolveGraceDuration(snapshot, 43_200n))
+    const afterConfigChange = loanDefaultTimestamp(createdAt, duration, resolveGraceDuration(snapshot, 1n))
+    expect(afterConfigChange).toBe(before)
+  })
+
+  it('flips to defaulted exactly at createdAt + duration + grace', () => {
+    const grace = 86_400n
+    const defaultAt = createdAt + duration + grace
+    expect(isPastDefault(createdAt, duration, grace, 0n, defaultAt - 1n)).toBe(false)
+    expect(isPastDefault(createdAt, duration, grace, 0n, defaultAt)).toBe(true)
+  })
+
+  it('shortening the global grace CAN default a pre-upgrade loan (documented fallback)', () => {
+    const now = createdAt + duration + 10_000n
+    expect(isPastDefault(createdAt, duration, 0n, 86_400n, now)).toBe(false)
+    expect(isPastDefault(createdAt, duration, 0n, 5_000n, now)).toBe(true)
+  })
+})

--- a/src/__tests__/error-coverage.test.ts
+++ b/src/__tests__/error-coverage.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { encodeErrorResult, type Abi } from 'viem'
+import { extractErrorMessage, isUserRejection, type ContractError } from '../utils/errorHandling'
+import {
+  loansAbi,
+  liquidityPoolAbi,
+  priceDataFeedAbi,
+  priceHelperAbi,
+  collateralManagerAbi
+} from '../generated'
+import defaultLiquidatorAbi from '../abis/DefaultLiquidator.json'
+
+/**
+ * ABI-drift QA guards.
+ *
+ * These tests enumerate every custom error in every protocol ABI and assert
+ * that the full pipeline — encode revert data exactly as a node returns it →
+ * extractErrorMessage — produces a human-readable message. When a contract
+ * regen adds a new error, the coverage test FAILS until a friendly message is
+ * added to CONTRACT_ERROR_MESSAGES, which is exactly the reminder we want.
+ */
+
+type AbiErrorItem = Extract<Abi[number], { type: 'error' }>
+
+const CONTRACTS: Array<{ name: string; abi: Abi }> = [
+  { name: 'Loans', abi: loansAbi as Abi },
+  { name: 'LiquidityPool', abi: liquidityPoolAbi as Abi },
+  { name: 'PriceDataFeed', abi: priceDataFeedAbi as Abi },
+  { name: 'PriceHelper', abi: priceHelperAbi as Abi },
+  { name: 'CollateralManager', abi: collateralManagerAbi as Abi },
+  { name: 'DefaultLiquidator', abi: defaultLiquidatorAbi as Abi }
+]
+
+/** Placeholder arg values per solidity type, enough to encode any error. */
+function placeholderArg(type: string): unknown {
+  if (type === 'address') return '0x' + '11'.repeat(20)
+  if (type === 'bytes32') return '0x' + '22'.repeat(32)
+  if (type.startsWith('uint') || type.startsWith('int')) return 1n // fits every width incl. uint8
+  if (type === 'bool') return true
+  if (type === 'string') return 'x'
+  if (type === 'bytes') return '0xdeadbeef'
+  throw new Error(`No placeholder for solidity type ${type} — extend the test`)
+}
+
+function allErrors(abi: Abi): AbiErrorItem[] {
+  return abi.filter((item): item is AbiErrorItem => item.type === 'error')
+}
+
+describe('contract error coverage (ABI drift guard)', () => {
+  for (const { name, abi } of CONTRACTS) {
+    describe(`${name}`, () => {
+      for (const err of allErrors(abi)) {
+        it(`decodes ${err.name}(${(err.inputs || []).map((i) => i.type).join(',')}) to a friendly message`, () => {
+          const data = encodeErrorResult({
+            abi: [err],
+            errorName: err.name,
+            args: (err.inputs || []).map((i) => placeholderArg(i.type)) as never
+          })
+
+          // Shape of a raw eth_call revert: viem reports an unknown reason
+          // and the payload survives only in a nested `data` field.
+          const rawCallError = {
+            message: 'Execution reverted for an unknown reason.',
+            cause: { cause: { data } }
+          } as unknown as ContractError
+
+          const message = extractErrorMessage(rawCallError)
+
+          // Decoding must have worked (not the raw viem string)…
+          expect(message).not.toBe('Execution reverted for an unknown reason.')
+          // …and every error must have a human-readable entry, not the
+          // "Contract error: X" fallback. A failure here means a new error
+          // was added to an ABI without a message in CONTRACT_ERROR_MESSAGES.
+          expect(message).not.toBe(`Contract error: ${err.name}`)
+        })
+      }
+    })
+  }
+
+  it('selector-only revert data (no args) still resolves parameterized errors', () => {
+    const loanNotActive = allErrors(loansAbi as Abi).find((e) => e.name === 'LoanNotActive')!
+    const full = encodeErrorResult({
+      abi: [loanNotActive],
+      errorName: 'LoanNotActive',
+      args: ['0x' + '33'.repeat(32)] as never
+    })
+    const selectorOnly = full.slice(0, 10)
+    const err = {
+      message: `reverted with the following signature:\n${selectorOnly}`
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe(
+      'This loan is no longer active — it may have defaulted or already been paid off.'
+    )
+  })
+
+  it('unknown selectors fall through without crashing', () => {
+    const err = {
+      message: 'Execution reverted for an unknown reason.',
+      cause: { data: '0x12345678' }
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe('Execution reverted for an unknown reason.')
+  })
+})
+
+describe('isUserRejection wallet variants', () => {
+  it('detects MetaMask phrasings', () => {
+    expect(isUserRejection({ message: 'User rejected the request.' } as ContractError)).toBe(true)
+    expect(isUserRejection({ message: 'MetaMask Tx Signature: User denied transaction signature.' } as ContractError)).toBe(true)
+  })
+
+  it('detects WalletConnect / other-wallet phrasings case-insensitively', () => {
+    expect(isUserRejection({ message: 'user canceled' } as ContractError)).toBe(true)
+    expect(isUserRejection({ message: 'User cancelled the transaction' } as ContractError)).toBe(true)
+    expect(isUserRejection({ message: 'Transaction declined' } as ContractError)).toBe(true)
+  })
+
+  it('detects EIP-1193 code 4001 at top level and nested in the cause chain', () => {
+    expect(isUserRejection({ message: 'x', code: 4001 } as ContractError)).toBe(true)
+    expect(
+      isUserRejection({
+        message: 'request failed',
+        cause: { cause: { code: 4001 } }
+      } as unknown as ContractError)
+    ).toBe(true)
+  })
+
+  it('detects viem UserRejectedRequestError by name in the chain', () => {
+    expect(
+      isUserRejection({
+        message: 'something wrapped',
+        cause: { name: 'UserRejectedRequestError', message: 'rejected' }
+      } as unknown as ContractError)
+    ).toBe(true)
+  })
+
+  it('does NOT flag real failures as rejections', () => {
+    expect(isUserRejection({ message: 'Execution reverted for an unknown reason.' } as ContractError)).toBe(false)
+    expect(isUserRejection({ message: 'insufficient funds for gas * price + value' } as ContractError)).toBe(false)
+    expect(isUserRejection({ message: 'LoanNotActive()' } as ContractError)).toBe(false)
+  })
+})

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -22,6 +22,7 @@ import {
 import { useReadContract, useWriteContract, usePublicClient } from 'wagmi'
 import { config } from '@/src/config/wagmi'
 import { erc20Abi, formatEther } from 'viem'
+import { grossPaymentAmount } from '@/src/utils/fees'
 import { useContractTokenConfiguration } from '../useContractTokenConfiguration'
 import { useProtocolAddresses } from '../useProtocolAddresses'
 
@@ -309,8 +310,7 @@ export const useLoanOperations = (
   // Gross amount the contract pulls on makeLoanPayment: amount + fee, with the
   // fee rounded up so approvals/balance checks always cover the on-chain pull.
   const getGrossPaymentAmount = useCallback(
-    (amount: bigint) =>
-      amount + (amount * paymentFeeBps + bpsDenominator - 1n) / bpsDenominator,
+    (amount: bigint) => grossPaymentAmount(amount, paymentFeeBps, bpsDenominator),
     [paymentFeeBps, bpsDenominator]
   )
 

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -3,6 +3,7 @@ import { useUserLoans } from './loans/useUserLoans'
 import { useLoanOperations } from './loans/useLoanOperations'
 import { useLoanConfig } from './loans/useLoanConfig'
 import { LOAN_STATUS } from '@/src/constants'
+import { isPastDefault } from '@/src/utils/loanStatus'
 import type { UseLoansOptions, UseLoansReturn } from './types'
 export type { LoanRequest } from './loans/useLoanOperations'
 
@@ -61,10 +62,15 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
     return userData.loans.flatMap((loan) => {
       if (!loan) return []
       if (loan.status !== LOAN_STATUS.ACTIVE) return [loan]
-      const grace =
-        loan.balloonGraceSnapshot > 0n ? loan.balloonGraceSnapshot : globalGrace
-      const defaultAt = loan.createdAt + loan.duration + grace
-      if (nowSec >= defaultAt) {
+      if (
+        isPastDefault(
+          loan.createdAt,
+          loan.duration,
+          loan.balloonGraceSnapshot,
+          globalGrace,
+          nowSec
+        )
+      ) {
         return [{ ...loan, status: LOAN_STATUS.DEFAULT }]
       }
       return [loan]

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -1,0 +1,18 @@
+/**
+ * Protocol fee math shared by the payment flow (hook + dialog display).
+ * Kept pure so the exact amounts users are charged are unit-testable.
+ */
+
+/**
+ * Gross amount the Loans contract pulls on makeLoanPayment: the payment
+ * plus the protocol fee (FEE_BPS), with the fee rounded UP so approvals
+ * and balance checks always cover the on-chain transfer.
+ */
+export function grossPaymentAmount(
+  amount: bigint,
+  feeBps: bigint,
+  bpsDenominator: bigint
+): bigint {
+  if (bpsDenominator === 0n) return amount
+  return amount + (amount * feeBps + bpsDenominator - 1n) / bpsDenominator
+}

--- a/src/utils/loanStatus.ts
+++ b/src/utils/loanStatus.ts
@@ -1,0 +1,42 @@
+/**
+ * Effective loan default timing, shared by useLoans (status override) and
+ * the ActiveLoans countdown. Kept pure so the exact moment the UI flips a
+ * loan to Defaulted is unit-testable.
+ */
+
+/**
+ * The grace window that applies to a specific loan: its creation-time
+ * snapshot when present, otherwise the global config value. Loans created
+ * before the contract upgrade that added the snapshot read 0 there.
+ */
+export function resolveGraceDuration(
+  balloonGraceSnapshot: bigint,
+  globalGrace: bigint
+): bigint {
+  return balloonGraceSnapshot > 0n ? balloonGraceSnapshot : globalGrace
+}
+
+/** Absolute timestamp (seconds) at which a loan defaults. */
+export function loanDefaultTimestamp(
+  createdAt: bigint,
+  duration: bigint,
+  grace: bigint
+): bigint {
+  return createdAt + duration + grace
+}
+
+/**
+ * True when an ACTIVE-per-contract loan has actually passed its default
+ * moment. The contract's stored status only changes when a state-writing
+ * function runs, so the UI must compute this itself.
+ */
+export function isPastDefault(
+  createdAt: bigint,
+  duration: bigint,
+  balloonGraceSnapshot: bigint,
+  globalGrace: bigint,
+  nowSec: bigint
+): boolean {
+  const grace = resolveGraceDuration(balloonGraceSnapshot, globalGrace)
+  return nowSec >= loanDefaultTimestamp(createdAt, duration, grace)
+}


### PR DESCRIPTION
## Summary

Re-opened copy of #30, which GitHub auto-closed when its base branch (`feat/p2-ux-polish`, PR #29) was merged and deleted. Content is identical — see #30 for the full description.

TL;DR: suite grows 97 → **219 tests**. Every custom error across all six protocol ABIs must decode to a friendly message (fails CI when a contract regen adds an unmapped error); the field order of index-decoded tuples (`loans()`, `loanConfig()`, `calculateLoanDetails()`, `getLiquidityStatus()`) is pinned; financial display math (LTV round-trip, fee ceil coverage, default timing, flooring) is verified; `isUserRejection` wallet matrix. Pure-function extractions: `utils/fees.ts`, `utils/loanStatus.ts` (no behavior change).

## Verification
- `vitest` 219/219, `tsc --noEmit` clean, `next lint` no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)