### PR TITLE
Release: production-readiness overhaul (error handling, fee transparency, config-safety, QA suite)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ robots.txt
 .DS_Store
 *.pem
 
+# claude code runtime artifacts
+.claude/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/docs/mainnet-setup.md
+++ b/docs/mainnet-setup.md
@@ -273,11 +273,18 @@ Each collateral asset must have at least one LTV option with its corresponding o
 Loans.addOriginationFees(
   <collateral token address>,
   [20000000, 30000000, 40000000, 50000000, 60000000], // LTVs scaled by ltvDecimals (20%, 30%, …)
-  [<fee at 20% LTV>, <fee at 30%>, …]                 // origination fee in LMLN wei per LTV tier
+  [1, 2, 4, 7, 10]                                    // origination fee in WHOLE USD per LTV tier (1 = $1)
 )
 ```
 
-`ltvDecimals` is read via `Loans.ltvDecimals()`. Fees are denominated in the origination-fee token (LMLN) in raw wei.
+`ltvDecimals` is read via `Loans.ltvDecimals()`.
+
+> **⚠️ Fee unit:** each fee is a flat **whole-dollar USD amount** (`25` = $25), NOT
+> an LMLN wei amount. The contract converts USD → LMLN at the current price-feed
+> rate when a loan is created, and the borrower pays that LMLN amount. The fee is
+> flat per loan — it does not scale with the loan amount. (Verified against the
+> deployed testnet contract: tier fees `1, 2, 4, 7, 10` and
+> `calculateLoanDetails` returning the equivalent LMLN at the live price.)
 
 **Verify:**
 ```solidity

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "wagmi generate && npx prettier --write src/generated.ts && next build",
-    "build:local": "wagmi generate && npx prettier --write src/generated.ts && next build",
+    "build": "wagmi generate && npx prettier --write src/generated.ts && NODE_OPTIONS=--max-old-space-size=6144 next build",
+    "build:local": "wagmi generate && npx prettier --write src/generated.ts && NODE_OPTIONS=--max-old-space-size=6144 next build",
     "start": "next start",
     "lint": "next lint",
     "pages:build": "npx @cloudflare/next-on-pages",

--- a/src/__tests__/contract-parsers.test.ts
+++ b/src/__tests__/contract-parsers.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import type { Abi } from 'viem'
+import { loansAbi } from '../generated'
+import {
+  parseLoanStruct,
+  parseLoanConfig,
+  type LoanStructResponse,
+  type LoanConfigResponse
+} from '../types/contracts'
+
+/**
+ * The app decodes several contract tuples BY INDEX (hand-written parsers in
+ * src/types/contracts.ts). If a contract regen reorders, renames, inserts, or
+ * removes a field, those indices silently point at the wrong values — these
+ * guards pin the ABI shape so the regen fails CI instead.
+ */
+
+type AbiFunctionItem = Extract<Abi[number], { type: 'function' }>
+
+function outputsOf(fnName: string): readonly { name?: string; type: string }[] {
+  const fn = (loansAbi as Abi).find(
+    (item): item is AbiFunctionItem => item.type === 'function' && item.name === fnName
+  )
+  if (!fn) throw new Error(`${fnName} missing from Loans ABI`)
+  return fn.outputs ?? []
+}
+
+describe('ABI shape guards (index-based decoders)', () => {
+  it('loans() field order matches parseLoanStruct indices', () => {
+    expect(outputsOf('loans').map((o) => o.name)).toEqual([
+      'account',
+      'collateralToken',
+      'createdAt',
+      'loanAmount',
+      'duration',
+      'originalDuration',
+      'interestAmount',
+      'interestApr',
+      'paidAmount',
+      'ltv',
+      'originationFee',
+      'collateralAmount',
+      'loanCycleDuration',
+      'balloonGraceSnapshot'
+    ])
+  })
+
+  it('loanConfig() field order matches parseLoanConfig indices', () => {
+    expect(outputsOf('loanConfig').map((o) => o.name)).toEqual([
+      'minLoanAmount',
+      'minLoanDuration',
+      'maxLoanDuration',
+      'balloonPaymentGraceDuration',
+      'loanCycleDuration',
+      'aprYearDuration'
+    ])
+  })
+
+  it('calculateLoanDetails() output order matches the destructuring in useLoanOperations', () => {
+    expect(outputsOf('calculateLoanDetails').map((o) => o.name)).toEqual([
+      'interestAmount',
+      'interestApr',
+      'originationFee',
+      'collateralAmount',
+      'loanCycleDuration',
+      'firstLoanPayment'
+    ])
+  })
+
+  it('getLiquidityStatus() output order matches parseLiquidityStatus indices', () => {
+    expect(outputsOf('getLiquidityStatus').map((o) => o.name)).toEqual([
+      'principalDeposited',
+      'principalWithdrawn',
+      'principalInLoans',
+      'principalDeficitAmount',
+      'principalAvailable',
+      'interestEarned',
+      'interestDistributed',
+      'interestAvailable'
+    ])
+  })
+})
+
+describe('parseLoanStruct', () => {
+  const base = [
+    '0x' + 'aa'.repeat(20), // account
+    '0x' + 'bb'.repeat(20), // collateralToken
+    1_700_000_000n, // createdAt
+    10_000n, // loanAmount
+    3_600n, // duration
+    3_600n, // originalDuration
+    500n, // interestAmount
+    12_500_000n, // interestApr
+    250n, // paidAmount
+    20_000_000n, // ltv
+    8_448n, // originationFee
+    123_456n, // collateralAmount
+    300n, // loanCycleDuration
+    86_400n // balloonGraceSnapshot
+  ] as unknown as LoanStructResponse
+
+  it('maps every index to the right field, including balloonGraceSnapshot at [13]', () => {
+    const loan = parseLoanStruct(base)
+    expect(loan.account).toBe('0x' + 'aa'.repeat(20))
+    expect(loan.collateralToken).toBe('0x' + 'bb'.repeat(20))
+    expect(loan.createdAt).toBe(1_700_000_000n)
+    expect(loan.loanAmount).toBe(10_000n)
+    expect(loan.duration).toBe(3_600n)
+    expect(loan.originalDuration).toBe(3_600n)
+    expect(loan.interestAmount).toBe(500n)
+    expect(loan.interestApr).toBe(12_500_000n)
+    expect(loan.paidAmount).toBe(250n)
+    expect(loan.ltv).toBe(20_000_000n)
+    expect(loan.originationFee).toBe(8_448n)
+    expect(loan.collateralAmount).toBe(123_456n)
+    expect(loan.loanCycleDuration).toBe(300n)
+    expect(loan.balloonGraceSnapshot).toBe(86_400n)
+  })
+
+  it('defaults balloonGraceSnapshot to 0n for pre-upgrade 13-field tuples', () => {
+    const preUpgrade = (base as unknown as unknown[]).slice(0, 13) as unknown as LoanStructResponse
+    expect(parseLoanStruct(preUpgrade).balloonGraceSnapshot).toBe(0n)
+  })
+})
+
+describe('parseLoanConfig', () => {
+  it('maps all six fields in order', () => {
+    const config = parseLoanConfig([
+      1_000n,
+      300n,
+      31_104_000n,
+      86_400n,
+      2_592_000n,
+      31_104_000n
+    ] as unknown as LoanConfigResponse)
+    expect(config).toEqual({
+      minLoanAmount: 1_000n,
+      minLoanDuration: 300n,
+      maxLoanDuration: 31_104_000n,
+      balloonPaymentGraceDuration: 86_400n,
+      loanCycleDuration: 2_592_000n,
+      aprYearDuration: 31_104_000n
+    })
+  })
+})

--- a/src/__tests__/display-math.test.ts
+++ b/src/__tests__/display-math.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import { formatPercentage, parseTokenAmount, formatTokenAmount } from '../utils/decimals'
+import { floorToDecimals, formatDuration, formatAmountWithSymbol } from '../utils/format'
+import { grossPaymentAmount } from '../utils/fees'
+import {
+  resolveGraceDuration,
+  loanDefaultTimestamp,
+  isPastDefault
+} from '../utils/loanStatus'
+
+/** Contract convention on this deployment: ltvDecimals = aprDecimals = 8. */
+const PCT_DECIMALS = 8
+
+describe('formatPercentage (2-decimal precision)', () => {
+  it('keeps whole percentages unchanged', () => {
+    expect(formatPercentage(20_000_000n, PCT_DECIMALS)).toBe('20')
+    expect(formatPercentage(60_000_000n, PCT_DECIMALS)).toBe('60')
+  })
+
+  it('preserves fractional percentages instead of rounding to a whole percent', () => {
+    // 12.5% APR used to display as "13" — a wrong number on a financial figure.
+    expect(formatPercentage(12_500_000n, PCT_DECIMALS)).toBe('12.5')
+    expect(formatPercentage(32_500_000n, PCT_DECIMALS)).toBe('32.5')
+    expect(formatPercentage(12_340_000n, PCT_DECIMALS)).toBe('12.34')
+  })
+
+  it('LTV tier matching round-trip is lossless for non-integer tiers', () => {
+    // The calculator finds the selected tier by comparing the slider value
+    // against Number(formatPercentage(tier.ltv)). Every distinct tier must
+    // survive that transformation uniquely.
+    const tiers = [20_000_000n, 30_000_000n, 32_500_000n, 50_000_000n, 62_500_000n]
+    const displayed = tiers.map((t) => Number(formatPercentage(t, PCT_DECIMALS)))
+    expect(displayed).toEqual([20, 30, 32.5, 50, 62.5])
+    expect(new Set(displayed).size).toBe(tiers.length)
+  })
+})
+
+describe('floorToDecimals (balances must round DOWN)', () => {
+  it('floors instead of rounding half-up', () => {
+    expect(floorToDecimals(99.996, 2)).toBe(99.99)
+    expect(floorToDecimals(99.994, 2)).toBe(99.99)
+    expect(floorToDecimals(0.129, 2)).toBe(0.12)
+  })
+
+  it('leaves exact values untouched', () => {
+    expect(floorToDecimals(100, 2)).toBe(100)
+    expect(floorToDecimals(1.25, 2)).toBe(1.25)
+    expect(floorToDecimals(0, 2)).toBe(0)
+  })
+
+  it('supports 4-decimal displays', () => {
+    expect(floorToDecimals(0.00005, 4)).toBe(0)
+    expect(floorToDecimals(1.23456789, 4)).toBe(1.2345)
+  })
+})
+
+describe('formatDuration (cycle captions)', () => {
+  it('renders sub-day cycles instead of "0 day"', () => {
+    // 5-minute testnet cycles used to render as "0 day loan cycles".
+    expect(formatDuration(300n)).toMatch(/minute/i)
+    expect(formatDuration(3_600n)).toMatch(/hour/i)
+  })
+
+  it('renders financial-calendar days and months', () => {
+    expect(formatDuration(86_400n)).toMatch(/day/i)
+    expect(formatDuration(2_592_000n)).toMatch(/month|30/i)
+  })
+})
+
+describe('parse/format token amounts', () => {
+  it('parseTokenAmount is exact where float math is not', () => {
+    // 1.1 * 1e18 in IEEE-754 is 1100000000000000128 — parseUnits must be exact.
+    expect(parseTokenAmount('1.1', 18)).toBe(1_100_000_000_000_000_000n)
+    expect(parseTokenAmount('123456789.123456789123456789', 18)).toBe(
+      123_456_789_123_456_789_123_456_789n
+    )
+  })
+
+  it('round-trips exactly through formatTokenAmount', () => {
+    const wei = parseTokenAmount('42.000001', 18)
+    expect(parseTokenAmount(formatTokenAmount(wei, 18), 18)).toBe(wei)
+  })
+
+  it('formatAmountWithSymbol renders two decimals with the symbol', () => {
+    expect(formatAmountWithSymbol(1_500_000_000_000_000_000n, 'USDT')).toBe('1.50 USDT')
+  })
+})
+
+describe('grossPaymentAmount (protocol fee coverage)', () => {
+  const DENOM = 10_000n
+
+  it('adds the exact fee for cleanly divisible amounts', () => {
+    // 10_000 wei at 25 bps → fee 25
+    expect(grossPaymentAmount(10_000n, 25n, DENOM)).toBe(10_025n)
+  })
+
+  it('rounds the fee UP so the approval always covers the on-chain pull', () => {
+    // 10_001 * 25 / 10_000 = 25.0025 → contract pulls ≤ 26; we approve 26.
+    expect(grossPaymentAmount(10_001n, 25n, DENOM)).toBe(10_001n + 26n)
+    // 1 wei payment still reserves 1 wei of fee.
+    expect(grossPaymentAmount(1n, 25n, DENOM)).toBe(2n)
+  })
+
+  it('gross always covers amount + floor(amount*fee/denom) (contract-side floor)', () => {
+    for (const amount of [1n, 3n, 999n, 10_000n, 123_456_789n, 10n ** 24n]) {
+      for (const bps of [1n, 25n, 100n, 999n]) {
+        const gross = grossPaymentAmount(amount, bps, DENOM)
+        const contractPull = amount + (amount * bps) / DENOM
+        expect(gross >= contractPull).toBe(true)
+        // and never overshoots by more than one rounding unit
+        expect(gross - contractPull <= 1n).toBe(true)
+      }
+    }
+  })
+
+  it('handles zero fee and zero amount', () => {
+    expect(grossPaymentAmount(10_000n, 0n, DENOM)).toBe(10_000n)
+    expect(grossPaymentAmount(0n, 25n, DENOM)).toBe(0n)
+  })
+})
+
+describe('loan default timing (balloonGraceSnapshot)', () => {
+  const createdAt = 1_700_000_000n
+  const duration = 3_600n
+
+  it('uses the per-loan snapshot when present', () => {
+    expect(resolveGraceDuration(86_400n, 43_200n)).toBe(86_400n)
+  })
+
+  it('falls back to the global config for pre-upgrade loans (snapshot = 0)', () => {
+    expect(resolveGraceDuration(0n, 43_200n)).toBe(43_200n)
+  })
+
+  it('a global grace change does NOT move a snapshotted loan’s default moment', () => {
+    const snapshot = 86_400n
+    const before = loanDefaultTimestamp(createdAt, duration, resolveGraceDuration(snapshot, 43_200n))
+    const afterConfigChange = loanDefaultTimestamp(createdAt, duration, resolveGraceDuration(snapshot, 1n))
+    expect(afterConfigChange).toBe(before)
+  })
+
+  it('flips to defaulted exactly at createdAt + duration + grace', () => {
+    const grace = 86_400n
+    const defaultAt = createdAt + duration + grace
+    expect(isPastDefault(createdAt, duration, grace, 0n, defaultAt - 1n)).toBe(false)
+    expect(isPastDefault(createdAt, duration, grace, 0n, defaultAt)).toBe(true)
+  })
+
+  it('shortening the global grace CAN default a pre-upgrade loan (documented fallback)', () => {
+    const now = createdAt + duration + 10_000n
+    expect(isPastDefault(createdAt, duration, 0n, 86_400n, now)).toBe(false)
+    expect(isPastDefault(createdAt, duration, 0n, 5_000n, now)).toBe(true)
+  })
+})

--- a/src/__tests__/error-coverage.test.ts
+++ b/src/__tests__/error-coverage.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { encodeErrorResult, type Abi } from 'viem'
+import { extractErrorMessage, isUserRejection, type ContractError } from '../utils/errorHandling'
+import {
+  loansAbi,
+  liquidityPoolAbi,
+  priceDataFeedAbi,
+  priceHelperAbi,
+  collateralManagerAbi
+} from '../generated'
+import defaultLiquidatorAbi from '../abis/DefaultLiquidator.json'
+
+/**
+ * ABI-drift QA guards.
+ *
+ * These tests enumerate every custom error in every protocol ABI and assert
+ * that the full pipeline — encode revert data exactly as a node returns it →
+ * extractErrorMessage — produces a human-readable message. When a contract
+ * regen adds a new error, the coverage test FAILS until a friendly message is
+ * added to CONTRACT_ERROR_MESSAGES, which is exactly the reminder we want.
+ */
+
+type AbiErrorItem = Extract<Abi[number], { type: 'error' }>
+
+const CONTRACTS: Array<{ name: string; abi: Abi }> = [
+  { name: 'Loans', abi: loansAbi as Abi },
+  { name: 'LiquidityPool', abi: liquidityPoolAbi as Abi },
+  { name: 'PriceDataFeed', abi: priceDataFeedAbi as Abi },
+  { name: 'PriceHelper', abi: priceHelperAbi as Abi },
+  { name: 'CollateralManager', abi: collateralManagerAbi as Abi },
+  { name: 'DefaultLiquidator', abi: defaultLiquidatorAbi as Abi }
+]
+
+/** Placeholder arg values per solidity type, enough to encode any error. */
+function placeholderArg(type: string): unknown {
+  if (type === 'address') return '0x' + '11'.repeat(20)
+  if (type === 'bytes32') return '0x' + '22'.repeat(32)
+  if (type.startsWith('uint') || type.startsWith('int')) return 1n // fits every width incl. uint8
+  if (type === 'bool') return true
+  if (type === 'string') return 'x'
+  if (type === 'bytes') return '0xdeadbeef'
+  throw new Error(`No placeholder for solidity type ${type} — extend the test`)
+}
+
+function allErrors(abi: Abi): AbiErrorItem[] {
+  return abi.filter((item): item is AbiErrorItem => item.type === 'error')
+}
+
+describe('contract error coverage (ABI drift guard)', () => {
+  for (const { name, abi } of CONTRACTS) {
+    describe(`${name}`, () => {
+      for (const err of allErrors(abi)) {
+        it(`decodes ${err.name}(${(err.inputs || []).map((i) => i.type).join(',')}) to a friendly message`, () => {
+          const data = encodeErrorResult({
+            abi: [err],
+            errorName: err.name,
+            args: (err.inputs || []).map((i) => placeholderArg(i.type)) as never
+          })
+
+          // Shape of a raw eth_call revert: viem reports an unknown reason
+          // and the payload survives only in a nested `data` field.
+          const rawCallError = {
+            message: 'Execution reverted for an unknown reason.',
+            cause: { cause: { data } }
+          } as unknown as ContractError
+
+          const message = extractErrorMessage(rawCallError)
+
+          // Decoding must have worked (not the raw viem string)…
+          expect(message).not.toBe('Execution reverted for an unknown reason.')
+          // …and every error must have a human-readable entry, not the
+          // "Contract error: X" fallback. A failure here means a new error
+          // was added to an ABI without a message in CONTRACT_ERROR_MESSAGES.
+          expect(message).not.toBe(`Contract error: ${err.name}`)
+        })
+      }
+    })
+  }
+
+  it('selector-only revert data (no args) still resolves parameterized errors', () => {
+    const loanNotActive = allErrors(loansAbi as Abi).find((e) => e.name === 'LoanNotActive')!
+    const full = encodeErrorResult({
+      abi: [loanNotActive],
+      errorName: 'LoanNotActive',
+      args: ['0x' + '33'.repeat(32)] as never
+    })
+    const selectorOnly = full.slice(0, 10)
+    const err = {
+      message: `reverted with the following signature:\n${selectorOnly}`
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe(
+      'This loan is no longer active — it may have defaulted or already been paid off.'
+    )
+  })
+
+  it('unknown selectors fall through without crashing', () => {
+    const err = {
+      message: 'Execution reverted for an unknown reason.',
+      cause: { data: '0x12345678' }
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe('Execution reverted for an unknown reason.')
+  })
+})
+
+describe('isUserRejection wallet variants', () => {
+  it('detects MetaMask phrasings', () => {
+    expect(isUserRejection({ message: 'User rejected the request.' } as ContractError)).toBe(true)
+    expect(isUserRejection({ message: 'MetaMask Tx Signature: User denied transaction signature.' } as ContractError)).toBe(true)
+  })
+
+  it('detects WalletConnect / other-wallet phrasings case-insensitively', () => {
+    expect(isUserRejection({ message: 'user canceled' } as ContractError)).toBe(true)
+    expect(isUserRejection({ message: 'User cancelled the transaction' } as ContractError)).toBe(true)
+    expect(isUserRejection({ message: 'Transaction declined' } as ContractError)).toBe(true)
+  })
+
+  it('detects EIP-1193 code 4001 at top level and nested in the cause chain', () => {
+    expect(isUserRejection({ message: 'x', code: 4001 } as ContractError)).toBe(true)
+    expect(
+      isUserRejection({
+        message: 'request failed',
+        cause: { cause: { code: 4001 } }
+      } as unknown as ContractError)
+    ).toBe(true)
+  })
+
+  it('detects viem UserRejectedRequestError by name in the chain', () => {
+    expect(
+      isUserRejection({
+        message: 'something wrapped',
+        cause: { name: 'UserRejectedRequestError', message: 'rejected' }
+      } as unknown as ContractError)
+    ).toBe(true)
+  })
+
+  it('does NOT flag real failures as rejections', () => {
+    expect(isUserRejection({ message: 'Execution reverted for an unknown reason.' } as ContractError)).toBe(false)
+    expect(isUserRejection({ message: 'insufficient funds for gas * price + value' } as ContractError)).toBe(false)
+    expect(isUserRejection({ message: 'LoanNotActive()' } as ContractError)).toBe(false)
+  })
+})

--- a/src/__tests__/error-decoding.test.ts
+++ b/src/__tests__/error-decoding.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { encodeErrorResult } from 'viem'
+import { extractErrorMessage, type ContractError } from '../utils/errorHandling'
+import { loansAbi, priceDataFeedAbi } from '../generated'
+
+/**
+ * The revert-data decoding pipeline: raw revert payloads (selector + args)
+ * must resolve to friendly messages wherever they appear in the error shape —
+ * this is exactly what a raw eth_call re-simulation error looks like, where
+ * viem reports only "Execution reverted for an unknown reason." and the
+ * payload survives solely in a nested `data` field.
+ */
+describe('extractErrorMessage — ABI-driven revert data decoding', () => {
+  const loanNotActiveData = encodeErrorResult({
+    abi: loansAbi,
+    errorName: 'LoanNotActive',
+    args: ['0x' + '11'.repeat(32) as `0x${string}`]
+  })
+
+  const priceStaleData = encodeErrorResult({
+    abi: priceDataFeedAbi,
+    errorName: 'PriceStale',
+    args: ['0x' + '22'.repeat(20) as `0x${string}`, 12345n]
+  })
+
+  it('decodes parameterized Loans errors from nested cause data (raw eth_call shape)', () => {
+    const err = {
+      message: 'Execution reverted for an unknown reason.',
+      cause: { cause: { data: loanNotActiveData } }
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe(
+      'This loan is no longer active — it may have defaulted or already been paid off.'
+    )
+  })
+
+  it('decodes sub-contract (PriceDataFeed) errors surfacing through another contract', () => {
+    const err = {
+      message: 'Execution reverted for an unknown reason.',
+      cause: { data: priceStaleData }
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe(
+      'Price data is stale — the LMLN price feed needs to be updated before this operation can proceed.'
+    )
+  })
+
+  it('decodes revert data that only appears inside message text', () => {
+    const err = {
+      message: `The contract function reverted with the following signature:\n${loanNotActiveData.slice(0, 10)}`
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe(
+      'This loan is no longer active — it may have defaulted or already been paid off.'
+    )
+  })
+
+  it('falls through gracefully on unknown selectors', () => {
+    const err = {
+      message: 'Execution reverted for an unknown reason.',
+      cause: { data: '0xdeadbeef' }
+    } as unknown as ContractError
+    expect(extractErrorMessage(err)).toBe(
+      'Execution reverted for an unknown reason.'
+    )
+  })
+})

--- a/src/__tests__/liquidity-operations.test.ts
+++ b/src/__tests__/liquidity-operations.test.ts
@@ -56,7 +56,7 @@ describe('contract error handling for liquidity operations', () => {
       const err: ContractError = {
         message: 'EstimateGasExecutionError: reverted with the following reason:\nInsufficientBalance\n',
       }
-      expect(extractErrorMessage(err)).toBe('InsufficientBalance')
+      expect(extractErrorMessage(err)).toBe('Insufficient token balance.')
     })
 
     it('returns generic message when gas estimation fails with unknown custom error', () => {

--- a/src/abis/Loans.json
+++ b/src/abis/Loans.json
@@ -1,1 +1,3264 @@
-[{"inputs":[],"name":"AddressZero","type":"error"},{"inputs":[{"internalType":"uint256","name":"length1","type":"uint256"},{"internalType":"uint256","name":"length2","type":"uint256"}],"name":"ArrayMismatch","type":"error"},{"inputs":[{"internalType":"uint256","name":"index","type":"uint256"},{"internalType":"uint256","name":"max","type":"uint256"}],"name":"BadIndex","type":"error"},{"inputs":[],"name":"BadPrice","type":"error"},{"inputs":[],"name":"ConfigExists","type":"error"},{"inputs":[],"name":"ConfigNotFound","type":"error"},{"inputs":[],"name":"DecimalsTooHigh","type":"error"},{"inputs":[],"name":"EmptyArray","type":"error"},{"inputs":[{"internalType":"uint256","name":"max","type":"uint256"},{"internalType":"uint256","name":"attempted","type":"uint256"}],"name":"ExcessivePayment","type":"error"},{"inputs":[],"name":"FirstPaymentTooLarge","type":"error"},{"inputs":[{"internalType":"uint256","name":"required","type":"uint256"},{"internalType":"uint256","name":"available","type":"uint256"}],"name":"InsufficientBalance","type":"error"},{"inputs":[{"internalType":"uint256","name":"required","type":"uint256"},{"internalType":"uint256","name":"provided","type":"uint256"}],"name":"InsufficientCollateral","type":"error"},{"inputs":[],"name":"InvalidAPR","type":"error"},{"inputs":[],"name":"InvalidAmount","type":"error"},{"inputs":[],"name":"InvalidConfiguration","type":"error"},{"inputs":[],"name":"InvalidDecimals","type":"error"},{"inputs":[],"name":"InvalidDuration","type":"error"},{"inputs":[],"name":"InvalidLTV","type":"error"},{"inputs":[],"name":"InvalidMarketValue","type":"error"},{"inputs":[],"name":"InvalidRange","type":"error"},{"inputs":[],"name":"LoanAmountExceedsMax","type":"error"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"LoanLocked","type":"error"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"LoanNotActive","type":"error"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"LoanNotFound","type":"error"},{"inputs":[],"name":"NoFeePrice","type":"error"},{"inputs":[],"name":"NotDivisible","type":"error"},{"inputs":[],"name":"RangeOverlap","type":"error"},{"inputs":[],"name":"SameAddress","type":"error"},{"inputs":[],"name":"TooLarge","type":"error"},{"inputs":[],"name":"TransferFailed","type":"error"},{"inputs":[{"internalType":"address","name":"caller","type":"address"},{"internalType":"address","name":"expected","type":"address"}],"name":"UnauthorizedUser","type":"error"},{"inputs":[],"name":"ZeroCycles","type":"error"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"address","name":"previousAdmin","type":"address"},{"indexed":false,"internalType":"address","name":"newAdmin","type":"address"}],"name":"AdminChanged","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"beacon","type":"address"}],"name":"BeaconUpgraded","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"executor","type":"address"},{"indexed":true,"internalType":"bytes32","name":"loanId","type":"bytes32"},{"indexed":false,"internalType":"address","name":"borrower","type":"address"},{"indexed":false,"internalType":"uint256","name":"collateralAmount","type":"uint256"},{"indexed":false,"internalType":"address","name":"receiver","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"CollateralForfeited","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"collateralManager","type":"address"}],"name":"CollateralManagerSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"prevPrice","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"newPrice","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"CollateralTokenPriceSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":false,"internalType":"address","name":"oldToken","type":"address"},{"indexed":false,"internalType":"address","name":"newToken","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"CollateralTokenUpdated","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"borrower","type":"address"},{"indexed":true,"internalType":"bytes32","name":"loanId","type":"bytes32"},{"indexed":false,"internalType":"uint256","name":"collateralAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"CollateralWithdrawn","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"pausedBy","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"ContractPaused","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"unpausedBy","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"ContractUnpaused","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":true,"internalType":"address","name":"oldReceiver","type":"address"},{"indexed":true,"internalType":"address","name":"newReceiver","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"DefaultCollateralReceiverSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"address","name":"feeReceiver","type":"address"}],"name":"FeeReceiverUpdated","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint8","name":"version","type":"uint8"}],"name":"Initialized","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"components":[{"internalType":"uint256","name":"minDuration","type":"uint256"},{"internalType":"uint256","name":"maxDuration","type":"uint256"},{"internalType":"uint256","name":"interestApr","type":"uint256"}],"indexed":false,"internalType":"struct Loans.InterestAprConfig[]","name":"aprConfigs","type":"tuple[]"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"InterestAprConfigAdded","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":false,"internalType":"uint256","name":"index","type":"uint256"},{"components":[{"internalType":"uint256","name":"minDuration","type":"uint256"},{"internalType":"uint256","name":"maxDuration","type":"uint256"},{"internalType":"uint256","name":"interestApr","type":"uint256"}],"indexed":false,"internalType":"struct Loans.InterestAprConfig","name":"aprConfig","type":"tuple"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"InterestAprConfigRemoved","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"caller","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"newTotalPrincipalDeposited","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"newAvailableInterest","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"InterestDepositedAsPrincipal","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"withdrawer","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"availableInterest","type":"uint256"},{"indexed":false,"internalType":"address","name":"receiver","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"InterestWithdrawn","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"depositor","type":"address"},{"indexed":false,"internalType":"uint256","name":"totalAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"deficitCovered","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"surplusToPool","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"deficitBefore","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"deficitAfter","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"availablePrincipalAfter","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"LiquidationDeposited","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"depositor","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"totalDeposited","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"LiquidityDeposited","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":true,"internalType":"address","name":"oldLiquidityPool","type":"address"},{"indexed":true,"internalType":"address","name":"newLiquidityPool","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"LiquidityPoolSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":false,"internalType":"uint256","name":"minLoanAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"minLoanDuration","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"maxLoanDuration","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"balloonPaymentGraceDuration","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"loanCycleDuration","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"LoanConfigurationSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"borrower","type":"address"},{"indexed":true,"internalType":"bytes32","name":"loanId","type":"bytes32"},{"indexed":false,"internalType":"uint256","name":"extensionDuration","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"newTotalDuration","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"additionalInterest","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"newTotalInterest","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"extensionFee","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"LoanExtended","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"borrower","type":"address"},{"indexed":true,"internalType":"bytes32","name":"loanId","type":"bytes32"},{"indexed":false,"internalType":"uint256","name":"loanAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"interestAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"collateralAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"originationFee","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"ltv","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"duration","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"LoanInitiated","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"payer","type":"address"},{"indexed":true,"internalType":"bytes32","name":"loanId","type":"bytes32"},{"indexed":false,"internalType":"uint256","name":"paymentAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"totalPaidAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"remainingInterest","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"remainingPrincipal","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"LoanPaymentMade","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":false,"internalType":"uint256","name":"oldMaxLoanAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"newMaxLoanAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"MaxLoanAmountSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"burnAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"donationAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"keepAmount","type":"uint256"}],"name":"OriginationFeeProcessed","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":true,"internalType":"address","name":"oldReceiver","type":"address"},{"indexed":true,"internalType":"address","name":"newReceiver","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"OriginationFeeReceiverSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"burnBps","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"donationBps","type":"uint256"}],"name":"OriginationFeeSplitUpdated","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":true,"internalType":"address","name":"oldToken","type":"address"},{"indexed":true,"internalType":"address","name":"newToken","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"OriginationFeeTokenSet","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":false,"internalType":"uint256[]","name":"ltvs","type":"uint256[]"},{"indexed":false,"internalType":"uint256[]","name":"fees","type":"uint256[]"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"OriginationFeesAdded","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":false,"internalType":"uint256[]","name":"ltvs","type":"uint256[]"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"OriginationFeesRemoved","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"address","name":"account","type":"address"}],"name":"Paused","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"updater","type":"address"},{"indexed":true,"internalType":"address","name":"oldPriceFeed","type":"address"},{"indexed":true,"internalType":"address","name":"newPriceFeed","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"PriceFeedUpdated","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"withdrawer","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"availablePrincipal","type":"uint256"},{"indexed":false,"internalType":"address","name":"receiver","type":"address"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"PrincipalWithdrawn","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"asset","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"coverAmount","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"surplus","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"deficitBefore","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"deficitAfter","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"availablePrincipalAfter","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"RecoveryReceived","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"previousAdminRole","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"newAdminRole","type":"bytes32"}],"name":"RoleAdminChanged","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"address","name":"account","type":"address"},{"indexed":true,"internalType":"address","name":"sender","type":"address"}],"name":"RoleGranted","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"address","name":"account","type":"address"},{"indexed":true,"internalType":"address","name":"sender","type":"address"}],"name":"RoleRevoked","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"address","name":"account","type":"address"}],"name":"Unpaused","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"implementation","type":"address"}],"name":"Upgraded","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"oldReserve","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"newReserve","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"availablePrincipalAfter","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"timestamp","type":"uint256"}],"name":"WithdrawalReserveUpdated","type":"event"},{"inputs":[],"name":"BPS_DENOMINATOR","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"DEFAULT_ADMIN_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"FEE_BPS","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"LENDER_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"MANAGER_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"PRICE_SETTER_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"UPGRADER_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"components":[{"internalType":"uint256","name":"minDuration","type":"uint256"},{"internalType":"uint256","name":"maxDuration","type":"uint256"},{"internalType":"uint256","name":"interestApr","type":"uint256"}],"internalType":"struct Loans.InterestAprConfig[]","name":"aprConfigs","type":"tuple[]"}],"name":"addInterestAprConfigs","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256[]","name":"ltvs","type":"uint256[]"},{"internalType":"uint256[]","name":"fees","type":"uint256[]"}],"name":"addOriginationFees","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"aprDecimals","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"availableInterest","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"availablePrincipal","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256","name":"loanDuration","type":"uint256"},{"internalType":"uint256","name":"loanAmount","type":"uint256"},{"internalType":"uint256","name":"ltv","type":"uint256"}],"name":"calculateLoanDetails","outputs":[{"internalType":"uint256","name":"interestAmount","type":"uint256"},{"internalType":"uint256","name":"interestApr","type":"uint256"},{"internalType":"uint256","name":"originationFee","type":"uint256"},{"internalType":"uint256","name":"collateralAmount","type":"uint256"},{"internalType":"uint256","name":"loanCycleDuration","type":"uint256"},{"internalType":"uint256","name":"firstLoanPayment","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"collateralManager","outputs":[{"internalType":"contract ICollateralManager","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"cumulativeLoanValue","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"depositInterestAsPrincipal","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"depositLiquidity","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"elapsedTimeInCycle","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"},{"internalType":"uint256","name":"extendTime","type":"uint256"}],"name":"extendLoan","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"feeReceiver","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"fullCyclesAhead","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"},{"internalType":"uint256","name":"offset","type":"uint256"},{"internalType":"uint256","name":"limit","type":"uint256"}],"name":"getAccountLoanIds","outputs":[{"internalType":"bytes32[]","name":"","type":"bytes32[]"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"}],"name":"getAllInterestAprConfigs","outputs":[{"components":[{"internalType":"uint256","name":"minDuration","type":"uint256"},{"internalType":"uint256","name":"maxDuration","type":"uint256"},{"internalType":"uint256","name":"interestApr","type":"uint256"}],"internalType":"struct Loans.InterestAprConfig[]","name":"","type":"tuple[]"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"}],"name":"getAllOriginationFees","outputs":[{"internalType":"uint256[]","name":"ltvs","type":"uint256[]"},{"internalType":"uint256[]","name":"fees","type":"uint256[]"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256","name":"loanDuration","type":"uint256"}],"name":"getInterestApr","outputs":[{"internalType":"uint256","name":"interestApr","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"getLiquidityStatus","outputs":[{"internalType":"uint256","name":"principalDeposited","type":"uint256"},{"internalType":"uint256","name":"principalWithdrawn","type":"uint256"},{"internalType":"uint256","name":"principalInLoans","type":"uint256"},{"internalType":"uint256","name":"principalDeficitAmount","type":"uint256"},{"internalType":"uint256","name":"principalAvailable","type":"uint256"},{"internalType":"uint256","name":"interestEarned","type":"uint256"},{"internalType":"uint256","name":"interestDistributed","type":"uint256"},{"internalType":"uint256","name":"interestAvailable","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"feeUSD","type":"uint256"}],"name":"getNativeFee","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"}],"name":"getRoleAdmin","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"grantRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"hasRole","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"loanTokenAddress","type":"address"},{"internalType":"address","name":"feeTokenAddress","type":"address"},{"internalType":"address","name":"priceDataFeedAddress","type":"address"},{"internalType":"address","name":"nativeGasTokenAddress","type":"address"},{"internalType":"address","name":"originationFeeReceiverAddress","type":"address"}],"name":"initialize","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256","name":"loanDuration","type":"uint256"},{"internalType":"uint256","name":"loanAmount","type":"uint256"},{"internalType":"uint256","name":"ltv","type":"uint256"}],"name":"initiateLoan","outputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"stateMutability":"payable","type":"function"},{"inputs":[],"name":"initiateLoanFeeUSD","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"interestAprConfigsByAsset","outputs":[{"internalType":"uint256","name":"minDuration","type":"uint256"},{"internalType":"uint256","name":"maxDuration","type":"uint256"},{"internalType":"uint256","name":"interestApr","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"liquidityPool","outputs":[{"internalType":"contract ILiquidityPool","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"loanConfig","outputs":[{"internalType":"uint256","name":"minLoanAmount","type":"uint256"},{"internalType":"uint256","name":"minLoanDuration","type":"uint256"},{"internalType":"uint256","name":"maxLoanDuration","type":"uint256"},{"internalType":"uint256","name":"balloonPaymentGraceDuration","type":"uint256"},{"internalType":"uint256","name":"loanCycleDuration","type":"uint256"},{"internalType":"uint256","name":"aprYearDuration","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"loanPayment","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"loanPaymentFeeUSD","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"loanStatus","outputs":[{"internalType":"enum Loans.LoanStatus","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"loanToken","outputs":[{"internalType":"contract IERC20","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"name":"loans","outputs":[{"internalType":"address","name":"account","type":"address"},{"internalType":"address","name":"collateralToken","type":"address"},{"internalType":"uint256","name":"createdAt","type":"uint256"},{"internalType":"uint256","name":"loanAmount","type":"uint256"},{"internalType":"uint256","name":"duration","type":"uint256"},{"internalType":"uint256","name":"originalDuration","type":"uint256"},{"internalType":"uint256","name":"interestAmount","type":"uint256"},{"internalType":"uint256","name":"interestApr","type":"uint256"},{"internalType":"uint256","name":"paidAmount","type":"uint256"},{"internalType":"uint256","name":"ltv","type":"uint256"},{"internalType":"uint256","name":"originationFee","type":"uint256"},{"internalType":"uint256","name":"collateralAmount","type":"uint256"},{"internalType":"uint256","name":"loanCycleDuration","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"ltvDecimals","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"makeLoanPayment","outputs":[],"stateMutability":"payable","type":"function"},{"inputs":[],"name":"maxLoanAmount","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"nativeFeeReceiver","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"nativeGasToken","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"originationFeeReceiver","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"originationFeeSplit","outputs":[{"internalType":"uint256","name":"burnBps","type":"uint256"},{"internalType":"uint256","name":"donationBps","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"originationFeeToken","outputs":[{"internalType":"contract IERC20","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"originationFeesByAsset","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"pause","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"paused","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"priceDataFeed","outputs":[{"internalType":"contract IPriceDataFeed","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"priceHelper","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"principalDeficit","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32[]","name":"loanIds","type":"bytes32[]"}],"name":"processDefaults","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"proxiableUUID","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"receiveRecovery","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"remainingCycles","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"remainingTimeInCycle","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"removeInterestAprConfig","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"asset","type":"address"},{"internalType":"uint256[]","name":"ltvs","type":"uint256[]"}],"name":"removeOriginationFees","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"renounceRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"revokeRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_collateralManager","type":"address"}],"name":"setCollateralManager","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"receiver","type":"address"}],"name":"setFeeReceiver","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_liquidityPool","type":"address"}],"name":"setLiquidityPool","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"minLoanAmount","type":"uint256"},{"internalType":"uint256","name":"minLoanDuration","type":"uint256"},{"internalType":"uint256","name":"maxLoanDuration","type":"uint256"},{"internalType":"uint256","name":"balloonPaymentGraceDuration","type":"uint256"},{"internalType":"uint256","name":"loanCycleDuration","type":"uint256"},{"internalType":"uint256","name":"aprYearDuration","type":"uint256"}],"name":"setLoanConfiguration","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"newMaxLoanAmount","type":"uint256"}],"name":"setMaxLoanAmount","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"_initiateFeeUSD","type":"uint256"},{"internalType":"uint256","name":"_paymentFeeUSD","type":"uint256"},{"internalType":"address","name":"_receiver","type":"address"}],"name":"setNativeFeeConfig","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newNativeGasToken","type":"address"}],"name":"setNativeGasToken","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"receiver","type":"address"}],"name":"setOriginationFeeReceiver","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"burnBps","type":"uint256"},{"internalType":"uint256","name":"donationBps","type":"uint256"}],"name":"setOriginationFeeSplit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newToken","type":"address"}],"name":"setOriginationFeeToken","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newPriceFeed","type":"address"}],"name":"setPriceFeed","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"_priceHelper","type":"address"}],"name":"setPriceHelper","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"setWithdrawalReserve","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes4","name":"interfaceId","type":"bytes4"}],"name":"supportsInterface","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"timeToDefault","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalInterestDistributed","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalInterestEarned","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalLoansIssued","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"totalNumberOfPayments","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalPrincipalDeposited","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalPrincipalInLoans","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalPrincipalWithdrawn","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"transpiredCycles","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"unpause","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newImplementation","type":"address"}],"name":"upgradeTo","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newImplementation","type":"address"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"upgradeToAndCall","outputs":[],"stateMutability":"payable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"loanId","type":"bytes32"}],"name":"withdrawCollateral","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"address","name":"receiver","type":"address"}],"name":"withdrawInterest","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"address","name":"receiver","type":"address"}],"name":"withdrawPrincipal","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"withdrawalReserve","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"stateMutability":"payable","type":"receive"}]
+[
+  {
+    "inputs": [],
+    "name": "AddressZero",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "length1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length2",
+        "type": "uint256"
+      }
+    ],
+    "name": "ArrayMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "BadIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BadPrice",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConfigExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConfigNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DecimalsTooHigh",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyArray",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "attempted",
+        "type": "uint256"
+      }
+    ],
+    "name": "ExcessivePayment",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FirstPaymentTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "provided",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientCollateral",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAPR",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidConfiguration",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDecimals",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDuration",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidLTV",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidMarketValue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidRange",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LoanAmountExceedsMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LoanLocked",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LoanNotActive",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LoanNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoFeePrice",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotDivisible",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OriginationDelegateNotAuthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RangeOverlap",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SameAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "expected",
+        "type": "address"
+      }
+    ],
+    "name": "UnauthorizedUser",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroCycles",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "beacon",
+        "type": "address"
+      }
+    ],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "executor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollateralForfeited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collateralManager",
+        "type": "address"
+      }
+    ],
+    "name": "CollateralManagerSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "prevPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollateralTokenPriceSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollateralTokenUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollateralWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pausedBy",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "ContractPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "unpausedBy",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "ContractUnpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldReceiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newReceiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "DefaultCollateralReceiverSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "feeReceiver",
+        "type": "address"
+      }
+    ],
+    "name": "FeeReceiverUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "minDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "interestApr",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Loans.InterestAprConfig[]",
+        "name": "aprConfigs",
+        "type": "tuple[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "InterestAprConfigAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "minDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "interestApr",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Loans.InterestAprConfig",
+        "name": "aprConfig",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "InterestAprConfigRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTotalPrincipalDeposited",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAvailableInterest",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "InterestDepositedAsPrincipal",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "availableInterest",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "InterestWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "deficitCovered",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "surplusToPool",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "deficitBefore",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "deficitAfter",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "availablePrincipalAfter",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LiquidationDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalDeposited",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LiquidityDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldLiquidityPool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newLiquidityPool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LiquidityPoolSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minLoanAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minLoanDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxLoanDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "balloonPaymentGraceDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "loanCycleDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanConfigurationSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "extensionDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTotalDuration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "additionalInterest",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTotalInterest",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "extensionFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanExtended",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "loanAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "interestAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "originationFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ltv",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "duration",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "payer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "paymentAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalPaidAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingInterest",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingPrincipal",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LoanPaymentMade",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldMaxLoanAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newMaxLoanAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxLoanAmountSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "burnAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "donationAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "keepAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "OriginationFeeProcessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldReceiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newReceiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "OriginationFeeReceiverSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "burnBps",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "donationBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "OriginationFeeSplitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "OriginationFeeTokenSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "ltvs",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "fees",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "OriginationFeesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "ltvs",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "OriginationFeesRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updater",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldPriceFeed",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newPriceFeed",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "PriceFeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "withdrawer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "availablePrincipal",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "PrincipalWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "coverAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "surplus",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "deficitBefore",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "deficitAfter",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "availablePrincipalAfter",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "RecoveryReceived",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldReserve",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newReserve",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "availablePrincipalAfter",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalReserveUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BPS_DENOMINATOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FEE_BPS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LENDER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MANAGER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_SETTER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UPGRADER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "minDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "interestApr",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Loans.InterestAprConfig[]",
+        "name": "aprConfigs",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "addInterestAprConfigs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ltvs",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "fees",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "addOriginationFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "aprDecimals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "availableInterest",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "availablePrincipal",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ltv",
+        "type": "uint256"
+      }
+    ],
+    "name": "calculateLoanDetails",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "interestAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestApr",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "originationFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateralAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanCycleDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "firstLoanPayment",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "collateralManager",
+    "outputs": [
+      {
+        "internalType": "contract ICollateralManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cumulativeLoanValue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositInterestAsPrincipal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositLiquidity",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "elapsedTimeInCycle",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "extendTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "originationPayer",
+        "type": "address"
+      }
+    ],
+    "name": "extendLoan",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeReceiver",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "fullCyclesAhead",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAccountLoanIds",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      }
+    ],
+    "name": "getAllInterestAprConfigs",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "minDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxDuration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "interestApr",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Loans.InterestAprConfig[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      }
+    ],
+    "name": "getAllOriginationFees",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "ltvs",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "fees",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "getInterestApr",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "interestApr",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLiquidityStatus",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "principalDeposited",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "principalWithdrawn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "principalInLoans",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "principalDeficitAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "principalAvailable",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestEarned",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestDistributed",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestAvailable",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "feeUSD",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNativeFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "loanTokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "feeTokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "priceDataFeedAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "nativeGasTokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "originationFeeReceiverAddress",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ltv",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "originationPayer",
+        "type": "address"
+      }
+    ],
+    "name": "initiateLoan",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initiateLoanFeeUSD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "interestAprConfigsByAsset",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "minDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestApr",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "liquidityPool",
+    "outputs": [
+      {
+        "internalType": "contract ILiquidityPool",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "loanConfig",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "minLoanAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minLoanDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxLoanDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balloonPaymentGraceDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanCycleDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "aprYearDuration",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "loanPayment",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "loanPaymentFeeUSD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "loanStatus",
+    "outputs": [
+      {
+        "internalType": "enum Loans.LoanStatus",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "loanToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "loans",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "createdAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "duration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "originalDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "interestApr",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "paidAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ltv",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "originationFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateralAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanCycleDuration",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ltvDecimals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "makeLoanPayment",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxLoanAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nativeFeeReceiver",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nativeGasToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "originationDelegations",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "originationFeeReceiver",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "originationFeeSplit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "burnBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "donationBps",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "originationFeeToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "originationFeesByAsset",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceDataFeed",
+    "outputs": [
+      {
+        "internalType": "contract IPriceDataFeed",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceHelper",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "principalDeficit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "loanIds",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "processDefaults",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "receiveRecovery",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "remainingCycles",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "remainingTimeInCycle",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeInterestAprConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ltvs",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "removeOriginationFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collateralManager",
+        "type": "address"
+      }
+    ],
+    "name": "setCollateralManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeReceiver",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_liquidityPool",
+        "type": "address"
+      }
+    ],
+    "name": "setLiquidityPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "minLoanAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minLoanDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxLoanDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balloonPaymentGraceDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loanCycleDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "aprYearDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "setLoanConfiguration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newMaxLoanAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxLoanAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_initiateFeeUSD",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_paymentFeeUSD",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "setNativeFeeConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newNativeGasToken",
+        "type": "address"
+      }
+    ],
+    "name": "setNativeGasToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "authorized",
+        "type": "bool"
+      }
+    ],
+    "name": "setOriginationDelegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "setOriginationFeeReceiver",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "burnBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "donationBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setOriginationFeeSplit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newToken",
+        "type": "address"
+      }
+    ],
+    "name": "setOriginationFeeToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPriceFeed",
+        "type": "address"
+      }
+    ],
+    "name": "setPriceFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_priceHelper",
+        "type": "address"
+      }
+    ],
+    "name": "setPriceHelper",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setWithdrawalReserve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "timeToDefault",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalInterestDistributed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalInterestEarned",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalLoansIssued",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "totalNumberOfPayments",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalPrincipalDeposited",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalPrincipalInLoans",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalPrincipalWithdrawn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "transpiredCycles",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "loanId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "withdrawCollateral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawInterest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawPrincipal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalReserve",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/abis/Loans.json
+++ b/src/abis/Loans.json
@@ -1,7 +1,17 @@
 [
   {
     "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
     "name": "AddressZero",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadySet",
     "type": "error"
   },
   {
@@ -1129,37 +1139,6 @@
         "type": "address"
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "oldToken",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newToken",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "timestamp",
-        "type": "uint256"
-      }
-    ],
-    "name": "OriginationFeeTokenSet",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "updater",
-        "type": "address"
-      },
-      {
         "indexed": false,
         "internalType": "uint256[]",
         "name": "ltvs",
@@ -2114,6 +2093,11 @@
         "internalType": "address",
         "name": "originationFeeReceiverAddress",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "aprYearDuration",
+        "type": "uint256"
       }
     ],
     "name": "initialize",
@@ -2395,6 +2379,11 @@
       {
         "internalType": "uint256",
         "name": "loanCycleDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balloonGraceSnapshot",
         "type": "uint256"
       }
     ],
@@ -2841,11 +2830,6 @@
         "internalType": "uint256",
         "name": "loanCycleDuration",
         "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "aprYearDuration",
-        "type": "uint256"
       }
     ],
     "name": "setLoanConfiguration",
@@ -2947,19 +2931,6 @@
       }
     ],
     "name": "setOriginationFeeSplit",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newToken",
-        "type": "address"
-      }
-    ],
-    "name": "setOriginationFeeToken",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -173,9 +173,14 @@ export function LoanParameters({
                 }
 
                 const numValue = Number(value)
-                if (numValue <= maxLoanAmount) {
-                  setLoanAmount(numValue)
+                // Reject garbage and negatives (a negative passed the old
+                // <= max check and flowed into parseUnits), and clamp
+                // above-max input to the max instead of silently swallowing
+                // the keystroke — a frozen input reads as a broken app.
+                if (!Number.isFinite(numValue) || numValue < 0) {
+                  return
                 }
+                setLoanAmount(Math.min(numValue, maxLoanAmount))
               }}
               min={minLoanAmount > 0 ? minLoanAmount : undefined}
               max={maxLoanAmount}

--- a/src/components/calculator/LoanParameters.tsx
+++ b/src/components/calculator/LoanParameters.tsx
@@ -84,10 +84,15 @@ export function LoanParameters({
 
   const hasNoLiquidity = availableLiquidity !== undefined && availableLiquidity === 0n
 
-  // Safe index for the slider — use the actual percentage as value instead of indexOf
-  const ltvStep = ltvPercentages.length >= 2
-    ? ltvPercentages[1] - ltvPercentages[0]
-    : 10
+  // Tiers need not be uniformly spaced (e.g. 20/30/50), so a fixed step can
+  // land the slider on values that have no configured origination fee. Use a
+  // fine step and snap every change to the nearest real tier instead.
+  const snapToTier = (raw: number): number => {
+    if (ltvPercentages.length === 0) return raw
+    return ltvPercentages.reduce((closest, candidate) =>
+      Math.abs(candidate - raw) < Math.abs(closest - raw) ? candidate : closest
+    )
+  }
 
   return (
     <Card
@@ -279,12 +284,11 @@ export function LoanParameters({
                 type='range'
                 min={minLtvPercentage}
                 max={maxLtvPercentage}
-                step={ltvStep}
+                step={0.5}
                 value={ltv}
                 disabled={ltvOptions.length === 0}
                 onChange={(e) => {
-                  const pct = Number(e.target.value)
-                  setLtv(pct)
+                  setLtv(snapToTier(Number(e.target.value)))
                 }}
                 className='w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer slider disabled:opacity-50 disabled:cursor-not-allowed'
               />

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -6,12 +6,15 @@ import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import { DisclaimerModal } from '../common/DisclaimerModal'
 import { LoanConfirmationModal } from '../common/LoanConfirmationModal'
+import { OriginationPayerField } from '../common/OriginationPayerField'
+import type { DelegateValidationResult } from '../../hooks/loans/useDelegateValidation'
 
 interface LoanSummaryProps {
   calculation: any
   tokenConfig: any
   collateralSymbol?: string
   hasInsufficientLmln: boolean
+  hasInsufficientCollateral: boolean
   hasInsufficientLiquidity: boolean
   userLmlnBalance: bigint | undefined
   operationError: any
@@ -27,6 +30,14 @@ interface LoanSummaryProps {
   needsApproval: boolean
   isDashboard?: boolean
   selectedLtvOption?: { ltv: bigint; fee: bigint }
+  // Origination-fee payer field (shown only in dashboard mode where the CTA exists).
+  originationPayerInput: string
+  onOriginationPayerChange: (value: string) => void
+  isPayerLocked: boolean
+  onTogglePayerLock: () => void
+  payerValidation: DelegateValidationResult
+  /** True when the LMLN reads/CTA target a delegate, not the connected wallet. */
+  delegateInUse: boolean
 }
 
 export function LoanSummary({
@@ -34,6 +45,7 @@ export function LoanSummary({
   tokenConfig,
   collateralSymbol,
   hasInsufficientLmln,
+  hasInsufficientCollateral,
   hasInsufficientLiquidity,
   userLmlnBalance,
   operationError,
@@ -48,7 +60,13 @@ export function LoanSummary({
   needsCollateralApproval,
   needsApproval,
   isDashboard = false,
-  selectedLtvOption
+  selectedLtvOption,
+  originationPayerInput,
+  onOriginationPayerChange,
+  isPayerLocked,
+  onTogglePayerLock,
+  payerValidation,
+  delegateInUse
 }: LoanSummaryProps) {
   // Don't fall back to tokenConfig.nativeToken.symbol — that's the chain's
   // gas token (tLEMX, BNB, …), unrelated to the actual collateral the user is
@@ -220,17 +238,45 @@ export function LoanSummary({
         </div>
 
         {isDashboard && (
+          <div className='mt-6'>
+            <OriginationPayerField
+              value={originationPayerInput}
+              onChange={onOriginationPayerChange}
+              validation={payerValidation}
+              isLocked={isPayerLocked}
+              onToggleLock={onTogglePayerLock}
+              feeTokenSymbol={tokenConfig?.feeToken.symbol || 'LMLN'}
+              feeTokenDecimals={tokenConfig?.feeToken.decimals ?? 18}
+            />
+          </div>
+        )}
+
+        {isDashboard && (
           <div className='text-center mt-6'>
             {hasInsufficientLiquidity && (
               <p className='text-sm text-destructive mb-3'>
-                Insufficient pool liquidity for this loan amount. Please try a smaller amount.
+                Not enough liquidity in the pool for this loan amount. Try a smaller amount.
               </p>
             )}
-            {hasInsufficientLmln && !hasInsufficientLiquidity && (
+            {hasInsufficientCollateral && !hasInsufficientLiquidity && (
               <p className='text-sm text-destructive mb-3'>
-                Insufficient {tokenConfig?.feeToken.symbol || 'LMLN'} balance to cover the origination fee.
+                You don&apos;t have enough {collateralSymbol || 'collateral'} in your wallet to back this loan.
               </p>
             )}
+            {/* userLmlnBalance is the fee payer's balance (delegate or borrower).
+             *  When a delegate is in use but not yet authorized, the field's
+             *  own "not authorized" message is the actionable one — suppress
+             *  the balance warning until the auth check passes so the user
+             *  isn't shown two errors at once. */}
+            {hasInsufficientLmln &&
+              !hasInsufficientLiquidity &&
+              (!delegateInUse || payerValidation.isValid) && (
+                <p className='text-sm text-destructive mb-3'>
+                  {delegateInUse
+                    ? `The chosen delegate doesn't have enough ${tokenConfig?.feeToken.symbol || 'LMLN'} to cover the fee.`
+                    : `You don't have enough ${tokenConfig?.feeToken.symbol || 'LMLN'} to cover the fee.`}
+                </p>
+              )}
             <Button
               className='bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black font-semibold py-3 px-8 text-lg'
               disabled={!calculation.isValid}

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -18,6 +18,10 @@ interface LoanSummaryProps {
   hasInsufficientLiquidity: boolean
   userLmlnBalance: bigint | undefined
   operationError: any
+  /** Decoded message when calculateLoanDetails reverts (e.g. stale price
+   *  feed). Must render inline — the confirmation modal that shows
+   *  operationError can never open while the calculation is failing. */
+  calculationError?: string
   isApprovingCollateral: boolean
   isApprovingLoanFee: boolean
   isCreatingLoan: boolean
@@ -38,6 +42,10 @@ interface LoanSummaryProps {
   payerValidation: DelegateValidationResult
   /** True when the LMLN reads/CTA target a delegate, not the connected wallet. */
   delegateInUse: boolean
+  /** Native (gas-token) fee attached to initiateLoan, in wei */
+  initiateNativeFee?: bigint
+  /** Native currency symbol for the connected chain (e.g. TLEMX) */
+  nativeSymbol?: string
 }
 
 export function LoanSummary({
@@ -49,6 +57,7 @@ export function LoanSummary({
   hasInsufficientLiquidity,
   userLmlnBalance,
   operationError,
+  calculationError,
   isApprovingCollateral,
   isApprovingLoanFee,
   isCreatingLoan,
@@ -66,7 +75,9 @@ export function LoanSummary({
   isPayerLocked,
   onTogglePayerLock,
   payerValidation,
-  delegateInUse
+  delegateInUse,
+  initiateNativeFee,
+  nativeSymbol
 }: LoanSummaryProps) {
   // Don't fall back to tokenConfig.nativeToken.symbol — that's the chain's
   // gas token (tLEMX, BNB, …), unrelated to the actual collateral the user is
@@ -253,6 +264,11 @@ export function LoanSummary({
 
         {isDashboard && (
           <div className='text-center mt-6'>
+            {calculationError && (
+              <p className='text-sm text-destructive mb-3'>
+                {calculationError}
+              </p>
+            )}
             {hasInsufficientLiquidity && (
               <p className='text-sm text-destructive mb-3'>
                 Not enough liquidity in the pool for this loan amount. Try a smaller amount.
@@ -307,6 +323,8 @@ export function LoanSummary({
               handleApproveLoanFee={handleApproveLoanFee}
               needsCollateralApproval={needsCollateralApproval}
               needsApproval={needsApproval}
+              nativeFee={initiateNativeFee}
+              nativeSymbol={nativeSymbol}
             />
           </div>
         )}

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -33,6 +33,10 @@ interface LoanSummaryProps {
   handleApproveLoanFee: () => Promise<void>
   needsCollateralApproval: boolean
   needsApproval: boolean
+  /** Delegate is paying the fee but their LMLN allowance is short — blocks
+   *  creation with a message instead of offering a self-approval that would
+   *  credit the wrong wallet. */
+  delegateNeedsAllowance?: boolean
   isDashboard?: boolean
   selectedLtvOption?: { ltv: bigint; fee: bigint }
   // Origination-fee payer field (shown only in dashboard mode where the CTA exists).
@@ -69,6 +73,7 @@ export function LoanSummary({
   handleApproveLoanFee,
   needsCollateralApproval,
   needsApproval,
+  delegateNeedsAllowance = false,
   isDashboard = false,
   selectedLtvOption,
   originationPayerInput,
@@ -185,7 +190,7 @@ export function LoanSummary({
               <span
                 className={`font-medium ${!isDashboard ? 'text-yellow-400' : 'text-yellow-600'}`}
               >
-                {Math.round(calculation.apr)}%
+                {calculation.apr}%
               </span>
             </div>
 
@@ -328,6 +333,7 @@ export function LoanSummary({
               handleApproveLoanFee={handleApproveLoanFee}
               needsCollateralApproval={needsCollateralApproval}
               needsApproval={needsApproval}
+              delegateNeedsAllowance={delegateNeedsAllowance}
               nativeFee={initiateNativeFee}
               nativeSymbol={nativeSymbol}
             />

--- a/src/components/calculator/LoanSummary.tsx
+++ b/src/components/calculator/LoanSummary.tsx
@@ -3,6 +3,7 @@
 import { Button } from '../ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { Plus } from 'lucide-react'
+import { formatDuration } from '../../utils/format'
 import { useState } from 'react'
 import { DisclaimerModal } from '../common/DisclaimerModal'
 import { LoanConfirmationModal } from '../common/LoanConfirmationModal'
@@ -192,7 +193,9 @@ export function LoanSummary({
               <span
                 className={`${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'}`}
               >
-                Monthly Payment
+                {/* Labeled by the actual cycle, not "Monthly" — a 14-day
+                    cycle config would understate the real monthly cost 2×. */}
+                Payment per Cycle
               </span>
               <span
                 className={`font-medium ${!isDashboard ? 'text-white' : ''}`}
@@ -230,13 +233,15 @@ export function LoanSummary({
                 >
                   {calculation.loanCycles} {calculation.loanCycles === 1 ? 'cycle' : 'cycles'}
                 </span>
-                {calculation.loanCycleDuration && (
+                {calculation.loanCycleDuration ? (
                   <div
                     className={`text-xs ${!isDashboard ? 'text-gray-400' : 'text-muted-foreground'} mt-0.5`}
                   >
-                    {Math.round(Number(calculation.loanCycleDuration) / (24 * 60 * 60))} day loan cycles
+                    {/* formatDuration handles sub-day (testnet) cycles that
+                        used to render as "0 day loan cycles". */}
+                    {formatDuration(calculation.loanCycleDuration)} loan cycles
                   </div>
-                )}
+                ) : null}
               </div>
             </div>
           </div>

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -398,7 +398,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   // Compare against raw originationFee — the approval itself adds a buffer for the transfer tax.
   // Using the grossed-up amount as the threshold causes an infinite approval loop when the
   // LMLN price shifts, because the previously approved gross amount no longer meets the new gross threshold.
-  const needsApproval = useMemo(() => {
+  const allowanceShort = useMemo(() => {
     const originationFee = loanOperations.calculationData?.originationFee
     if (!originationFee) return false
     if (loanOperations.currentLmlnAllowance === undefined) return true
@@ -407,6 +407,14 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     loanOperations.calculationData?.originationFee,
     loanOperations.currentLmlnAllowance
   ])
+
+  // The Approve button sends the approval FROM THE CONNECTED WALLET, but with
+  // a delegate set the allowance read targets the delegate — approving would
+  // credit the wrong wallet and loop forever. Only offer self-approval; a
+  // short delegate allowance is surfaced as a blocking message instead
+  // (mirrors the extension flow's handling in ActiveLoans).
+  const needsApproval = allowanceShort && !effectiveOriginationPayer
+  const delegateNeedsAllowance = allowanceShort && !!effectiveOriginationPayer
 
   // Handle collateral ERC20 approval (WLEMX → CollateralManager)
   const handleApproveCollateral = async () => {
@@ -512,7 +520,10 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     )
   }
 
-  if (initialHookData.error || !initialHookData.loanConfig) {
+  // Only a CONFIG failure blocks the calculator — a per-loan read error
+  // (surfaced via initialHookData.error) affects the dashboard lists, not
+  // the ability to create a new loan.
+  if (initialHookData.configError || !initialHookData.loanConfig) {
     return (
       <div className='text-center py-8'>
         <p className='text-red-600'>Error loading loan configuration</p>
@@ -562,6 +573,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         handleApproveLoanFee={handleApproveLoanFee}
         needsCollateralApproval={needsCollateralApproval}
         needsApproval={needsApproval}
+        delegateNeedsAllowance={delegateNeedsAllowance}
         isDashboard={isDashboard}
         selectedLtvOption={selectedLtvOption}
         originationPayerInput={originationPayerInput}

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -15,6 +15,7 @@ import { LoanParameters } from '../calculator/LoanParameters'
 import { LoanSummary } from '../calculator/LoanSummary'
 import {
   handleContractError,
+  extractErrorMessage,
   isUserRejection,
   type ContractError
 } from '../../utils/errorHandling'
@@ -120,7 +121,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   // Get contract token configuration
   const { tokenConfig } = useContractTokenConfiguration()
   const { toast } = useToast()
-  const { address } = useAccount()
+  const { address, chain } = useAccount()
 
   // Collateral manager — the user always picks explicitly via the selector in LoanParameters,
   // even when only one token is configured. No auto-selection.
@@ -251,6 +252,18 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     loanOperations.error && !isUserRejection(loanOperations.error)
       ? loanOperations.error
       : null
+
+  // When calculateLoanDetails itself reverts (stale price feed, invalid
+  // duration/LTV), the calculator would otherwise go inert: em-dash on the
+  // collateral row, permanently disabled button, and the decoded reason
+  // trapped inside a modal that can't open. Surface it inline instead.
+  const calculationErrorMessage =
+    operationError &&
+    loanRequest &&
+    !loanOperations.calculationData &&
+    !loanOperations.isSimulating
+      ? extractErrorMessage(operationError as unknown as ContractError)
+      : undefined
 
   // Pick the APR tier whose duration band covers the current slider position.
   // Decouples the displayed APR from the amount input — sliding LTV / Duration
@@ -537,6 +550,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         hasInsufficientLiquidity={loanOperations.hasInsufficientLiquidity}
         userLmlnBalance={loanOperations.userLmlnBalance}
         operationError={operationError}
+        calculationError={calculationErrorMessage}
         isApprovingCollateral={isApprovingCollateral}
         isApprovingLoanFee={isApprovingLoanFee}
         isCreatingLoan={isCreatingLoan}
@@ -563,6 +577,8 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         }}
         payerValidation={payerValidation}
         delegateInUse={!!effectiveOriginationPayer}
+        initiateNativeFee={loanOperations.initiateNativeFee}
+        nativeSymbol={chain?.nativeCurrency.symbol}
       />
     </div>
   )

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
+import { useAccount } from 'wagmi'
 import { Button } from '../../components/ui/button'
 import { useLoans } from '../../hooks/useLoans'
 import type { UseLoansReturn } from '../../hooks/types'
@@ -19,6 +20,8 @@ import {
 } from '../../utils/errorHandling'
 import { useCollateralManager } from '../../hooks/useCollateralManager'
 import { useLoanConfig } from '../../hooks/loans/useLoanConfig'
+import { useDelegateValidation } from '../../hooks/loans/useDelegateValidation'
+import { DelegationManager } from './DelegationManager'
 
 const SECONDS_PER_DAY = 24 * 60 * 60
 
@@ -117,6 +120,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   // Get contract token configuration
   const { tokenConfig } = useContractTokenConfiguration()
   const { toast } = useToast()
+  const { address } = useAccount()
 
   // Collateral manager — the user always picks explicitly via the selector in LoanParameters,
   // even when only one token is configured. No auto-selection.
@@ -140,6 +144,19 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   const [loanAmount, setLoanAmount] = useState(0)
   const [duration, setDuration] = useState<number>(0)
   const [ltv, setLtv] = useState(0)
+
+  // Origination-fee payer field — defaults to the connected wallet (locked).
+  // The user can unlock to delegate the fee to another wallet, which must
+  // have authorized them via setOriginationDelegate(borrower, true).
+  const [originationPayerInput, setOriginationPayerInput] = useState('')
+  const [isPayerLocked, setIsPayerLocked] = useState(true)
+  // Sync the input to the connected wallet whenever the wallet changes and
+  // the field is still locked. Don't clobber a user-typed delegate.
+  useEffect(() => {
+    if (isPayerLocked) {
+      setOriginationPayerInput(address ?? '')
+    }
+  }, [address, isPayerLocked])
 
   // Get initial loan config and options - moved up to avoid initialization error
   const initialHookData: UseLoansReturn = useLoans()
@@ -209,10 +226,24 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     )
   }, [perAssetConfig.ltvOptions, ltv, tokenConfig])
 
-  // Get the loan operations with the calculated request
+  // Validate the typed payer address (format + on-chain delegation). Balance
+  // and allowance shortfalls are surfaced by LoanSummary's existing
+  // hasInsufficientLmln warning, which auto-targets whoever pays.
+  const payerValidation = useDelegateValidation(originationPayerInput)
+
+  // Re-target LMLN reads + initiateLoan args to the delegate as soon as the
+  // user has unlocked the field and typed a non-self address that parses —
+  // even before the delegation check completes — so balance/allowance reads
+  // start firing against the right wallet immediately.
+  const effectiveOriginationPayer =
+    !isPayerLocked && payerValidation.normalizedAddress && !payerValidation.isSelf
+      ? payerValidation.normalizedAddress
+      : undefined
+
   const loanOperations = useLoans({
     loanRequest,
-    selectedLtvOption
+    selectedLtvOption,
+    originationPayer: effectiveOriginationPayer
   })
 
   // Filter out user rejections from operation errors - don't show them in UI
@@ -295,7 +326,9 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
       !loanOperations.isSimulating &&
       !!loanOperations.calculationData &&
       !loanOperations.hasInsufficientLmln &&
-      !loanOperations.hasInsufficientLiquidity
+      !loanOperations.hasInsufficientCollateral &&
+      !loanOperations.hasInsufficientLiquidity &&
+      payerValidation.isValid
 
     const priceError = buildPriceError(
       loanOperations.isSimulating,
@@ -328,7 +361,9 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     loanOperations.hasInsufficientLmln,
     loanOperations.hasInsufficientLiquidity,
     perAssetConfig.interestAprConfigs,
-    loanOperations.userLmlnBalance
+    loanOperations.userLmlnBalance,
+    loanOperations.hasInsufficientCollateral,
+    payerValidation.isValid
   ])
 
   // Check if collateral ERC20 approval is needed (WLEMX → CollateralManager)
@@ -495,6 +530,7 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         tokenConfig={tokenConfig}
         collateralSymbol={selectedCollateral?.symbol}
         hasInsufficientLmln={loanOperations.hasInsufficientLmln}
+        hasInsufficientCollateral={loanOperations.hasInsufficientCollateral}
         hasInsufficientLiquidity={loanOperations.hasInsufficientLiquidity}
         userLmlnBalance={loanOperations.userLmlnBalance}
         operationError={operationError}
@@ -510,12 +546,31 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         needsApproval={needsApproval}
         isDashboard={isDashboard}
         selectedLtvOption={selectedLtvOption}
+        originationPayerInput={originationPayerInput}
+        onOriginationPayerChange={setOriginationPayerInput}
+        isPayerLocked={isPayerLocked}
+        onTogglePayerLock={() => {
+          // Re-locking always snaps back to the connected wallet.
+          setIsPayerLocked((wasLocked) => {
+            if (!wasLocked) {
+              setOriginationPayerInput(address ?? '')
+            }
+            return !wasLocked
+          })
+        }}
+        payerValidation={payerValidation}
+        delegateInUse={!!effectiveOriginationPayer}
       />
     </div>
   )
 
   if (isDashboard) {
-    return calculatorContent
+    return (
+      <div>
+        {calculatorContent}
+        <DelegationManager />
+      </div>
+    )
   }
 
   return (

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -191,14 +191,28 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     return BigInt(Math.floor(duration))
   }, [duration])
 
-  // Create loan request for simulation
+  // Get origination fee for selected LTV. Match by the same formatted value
+  // the slider was populated from — reconstructing the contract bigint via
+  // parseUnits((ltv/100).toString()) breaks for any tier whose percentage
+  // doesn't survive the float round-trip, and a mismatched find() meant the
+  // on-chain call was sent an LTV that doesn't exist in the fee table.
+  const selectedLtvOption = useMemo(() => {
+    if (!tokenConfig) return undefined
+    return perAssetConfig.ltvOptions.find(
+      (option) =>
+        Number(formatPercentage(option.ltv, tokenConfig.ltvDecimals)) === ltv
+    )
+  }, [perAssetConfig.ltvOptions, ltv, tokenConfig])
+
+  // Create loan request for simulation — always send the tier's EXACT
+  // contract LTV value, never a value reconstructed from the display number.
   const loanRequest = useMemo(() => {
     if (
       !selectedCollateral ||
       !loanAmount ||
       !selectedDuration ||
       selectedDuration === 0n ||
-      !ltv ||
+      !selectedLtvOption ||
       !tokenConfig
     )
       return undefined
@@ -210,22 +224,9 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
         tokenConfig.loanToken.decimals
       ),
       duration: selectedDuration,
-      ltv: parseUnits((ltv / 100).toString(), tokenConfig.ltvDecimals)
+      ltv: selectedLtvOption.ltv
     }
-  }, [selectedCollateral, loanAmount, selectedDuration, ltv, tokenConfig])
-
-  // Get origination fee for selected LTV
-  const selectedLtvOption = useMemo(() => {
-    if (!tokenConfig) return undefined
-
-    // Convert ltv percentage (50) to decimal (0.5) then to contract format
-    const ltvDecimal = (ltv / 100).toString()
-    const ltvInContractFormat = parseUnits(ltvDecimal, tokenConfig.ltvDecimals)
-
-    return perAssetConfig.ltvOptions.find(
-      (option) => option.ltv === ltvInContractFormat
-    )
-  }, [perAssetConfig.ltvOptions, ltv, tokenConfig])
+  }, [selectedCollateral, loanAmount, selectedDuration, selectedLtvOption, tokenConfig])
 
   // Validate the typed payer address (format + on-chain delegation). Balance
   // and allowance shortfalls are surfaced by LoanSummary's existing

--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -280,11 +280,14 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     // typed, below-min, etc.).
     const baseWithDials = { ...base, apr: aprFromDuration }
 
-    // Check if we're still loading contract configuration
+    // Pre-conditions for collateral calculation aren't met yet — either the
+    // contract config is still loading or the user hasn't picked a collateral.
+    // Either way, render a neutral em-dash to match the "no calc yet" branch
+    // below; the form surfaces actionable validation elsewhere.
     if (!tokenConfig || !selectedCollateral || perAssetConfig.interestAprConfigs.length === 0) {
       return {
         ...baseWithDials,
-        priceError: 'Loading contract data...'
+        priceError: '—'
       }
     }
 

--- a/src/components/common/DelegationManager.tsx
+++ b/src/components/common/DelegationManager.tsx
@@ -83,8 +83,9 @@ export function DelegationManager() {
         // try again without retyping the borrower address.
         return
       }
+      // Standard modal contract: stay open on failure so the user can
+      // retry without retyping the borrower address.
       handleContractError(e, toast, "Couldn't delegate")
-      setIsConfirmOpen(false)
     }
   }
 
@@ -100,8 +101,8 @@ export function DelegationManager() {
     } catch (err) {
       const e = err as ContractError
       if (isUserRejection(e)) return
+      // Stay open on failure (standard modal contract).
       handleContractError(e, toast, "Couldn't revoke")
-      setIsConfirmOpen(false)
     }
   }
 

--- a/src/components/common/DelegationManager.tsx
+++ b/src/components/common/DelegationManager.tsx
@@ -1,0 +1,297 @@
+'use client'
+
+import { useState } from 'react'
+import { useAccount } from 'wagmi'
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+  HandCoins
+} from 'lucide-react'
+import { Button } from '../ui/button'
+import { Card, CardContent } from '../ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { useToast } from '../../hooks/use-toast'
+import { useDelegationManager } from '../../hooks/loans/useDelegationManager'
+import { truncateAddress } from '../../utils/format'
+import {
+  handleContractError,
+  isUserRejection,
+  type ContractError
+} from '../../utils/errorHandling'
+
+type Tone = 'error' | 'info' | 'success' | 'muted'
+
+const TONE_CLASS: Record<Tone, string> = {
+  error: 'text-red-500',
+  success: 'text-green-600',
+  info: 'text-blue-600',
+  muted: 'text-muted-foreground'
+}
+
+/**
+ * Collapsible "Become a delegator" section.
+ *
+ * The card hosts a borrower-address input and a Delegate / Revoke button
+ * that flips based on the on-chain status. Clicking the button opens a
+ * confirmation modal containing the risk/revoke disclosure plus the wallet
+ * step indicators — that's where the actual transactions are dispatched.
+ */
+export function DelegationManager() {
+  const { address } = useAccount()
+  const { toast } = useToast()
+  const [isOpen, setIsOpen] = useState(false)
+  const [borrowerInput, setBorrowerInput] = useState('')
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+
+  const {
+    state,
+    normalizedBorrower,
+    delegate,
+    revoke,
+    isProcessing,
+    isApprovingLmln,
+    isWritingDelegation,
+    hasMaxLmlnAllowance
+  } = useDelegationManager(borrowerInput)
+
+  const isRevokeFlow = state === 'delegated'
+
+  const onConfirmDelegate = async () => {
+    if (!normalizedBorrower) return
+    try {
+      await delegate(normalizedBorrower)
+      toast({
+        title: '✅ Delegation set up',
+        description: "You'll now pay origination fees for this borrower."
+      })
+      setIsConfirmOpen(false)
+    } catch (err) {
+      const e = err as ContractError
+      if (isUserRejection(e)) {
+        // User cancelled in their wallet — keep the modal open so they can
+        // try again without retyping the borrower address.
+        return
+      }
+      handleContractError(e, toast, "Couldn't delegate")
+      setIsConfirmOpen(false)
+    }
+  }
+
+  const onConfirmRevoke = async () => {
+    if (!normalizedBorrower) return
+    try {
+      await revoke(normalizedBorrower)
+      toast({
+        title: 'Delegation revoked',
+        description: "You'll no longer pay fees for this borrower."
+      })
+      setIsConfirmOpen(false)
+    } catch (err) {
+      const e = err as ContractError
+      if (isUserRejection(e)) return
+      handleContractError(e, toast, "Couldn't revoke")
+      setIsConfirmOpen(false)
+    }
+  }
+
+  if (!address) return null
+
+  let helperMessage: { text: string; tone: Tone } | null = null
+  if (state === 'invalid-format') {
+    helperMessage = { text: 'Not a valid wallet address.', tone: 'error' }
+  } else if (state === 'self') {
+    helperMessage = { text: "You can't delegate to yourself.", tone: 'error' }
+  } else if (state === 'loading') {
+    helperMessage = { text: 'Checking…', tone: 'info' }
+  } else if (state === 'delegated') {
+    helperMessage = {
+      text: "You're authorized to pay this borrower's fees.",
+      tone: 'success'
+    }
+  } else if (state === 'not-delegated') {
+    helperMessage = {
+      text: 'Click Delegate to authorize yourself for this borrower.',
+      tone: 'muted'
+    }
+  }
+
+  const canSubmit = state === 'delegated' || state === 'not-delegated'
+  const primaryLabel = isRevokeFlow ? 'Revoke Delegation' : 'Delegate'
+
+  const stepLabel = isApprovingLmln
+    ? 'Approving LMLN…'
+    : isWritingDelegation
+    ? isRevokeFlow
+      ? 'Revoking…'
+      : 'Authorizing…'
+    : null
+
+  return (
+    <>
+      <Card className='mt-6'>
+        <CardContent className='p-0'>
+          <button
+            type='button'
+            onClick={() => setIsOpen((prev) => !prev)}
+            className='w-full flex items-center justify-between px-4 py-3 text-left'
+            aria-expanded={isOpen}
+          >
+            <span className='flex items-center gap-2 text-sm font-medium'>
+              <HandCoins className='h-4 w-4 text-muted-foreground' />
+              Become a delegator
+              <span className='text-xs font-normal text-muted-foreground'>
+                · Pay origination fees on behalf of another wallet
+              </span>
+            </span>
+            {isOpen ? (
+              <ChevronUp className='h-4 w-4 text-muted-foreground' />
+            ) : (
+              <ChevronDown className='h-4 w-4 text-muted-foreground' />
+            )}
+          </button>
+
+          {isOpen && (
+            <div className='border-t px-4 py-4 space-y-4'>
+              <div className='space-y-1.5'>
+                <Label htmlFor='delegation-borrower' className='text-sm'>
+                  Borrower wallet to delegate for
+                </Label>
+                <Input
+                  id='delegation-borrower'
+                  type='text'
+                  value={borrowerInput}
+                  onChange={(e) => setBorrowerInput(e.target.value)}
+                  placeholder='0x…'
+                  spellCheck={false}
+                  autoComplete='off'
+                  disabled={isProcessing}
+                />
+                {helperMessage && (
+                  <p className={`text-xs ${TONE_CLASS[helperMessage.tone]}`}>
+                    {helperMessage.text}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <Button
+                  onClick={() => setIsConfirmOpen(true)}
+                  disabled={!canSubmit || isProcessing}
+                  variant={isRevokeFlow ? 'destructive' : 'default'}
+                >
+                  {primaryLabel}
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={isConfirmOpen}
+        onOpenChange={(open) => {
+          // Block closing while a tx is mid-flight so the user can't dismiss
+          // a wallet popup that's already prompted.
+          if (!open && isProcessing) return
+          setIsConfirmOpen(open)
+        }}
+      >
+        <DialogContent className='sm:max-w-md'>
+          <DialogHeader>
+            <DialogTitle>
+              {isRevokeFlow ? 'Revoke delegation' : 'Confirm delegation'}
+            </DialogTitle>
+            <DialogDescription>
+              {isRevokeFlow
+                ? 'Stop paying origination fees for this borrower.'
+                : 'Authorize yourself to pay this borrower’s origination fees.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className='space-y-4'>
+            {/* Address summary */}
+            <div className='rounded-md border bg-muted p-3 text-sm'>
+              <p className='text-xs text-muted-foreground mb-1'>
+                Borrower wallet
+              </p>
+              <p className='font-mono break-all'>
+                {normalizedBorrower
+                  ? `${normalizedBorrower.slice(0, 6)}…${normalizedBorrower.slice(-4)}`
+                  : truncateAddress(borrowerInput)}
+              </p>
+            </div>
+
+            {/* Disclosure / explanation */}
+            {isRevokeFlow ? (
+              <div className='flex gap-2 rounded-md border bg-muted p-3'>
+                <AlertTriangle className='h-4 w-4 text-muted-foreground shrink-0 mt-0.5' />
+                <div className='text-xs text-muted-foreground space-y-1'>
+                  <p>
+                    Revoking stops your LMLN from paying this borrower&apos;s
+                    origination fees. They can still take out loans, but
+                    they&apos;ll need to pay the fee themselves or set up a
+                    new delegator.
+                  </p>
+                  <p>You can re-delegate later if you change your mind.</p>
+                </div>
+              </div>
+            ) : (
+              <div className='flex gap-2 rounded-md border border-amber-300 bg-amber-50 dark:border-amber-900 dark:bg-amber-950 p-3'>
+                <AlertTriangle className='h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5' />
+                <div className='text-xs text-amber-900 dark:text-amber-200 space-y-1'>
+                  <p>
+                    After you delegate, this borrower can take out or extend
+                    loans, and your LMLN pays the fee each time without an
+                    extra wallet prompt.
+                  </p>
+                  <p>You can revoke any time.</p>
+                  {!hasMaxLmlnAllowance && (
+                    <p className='font-medium'>
+                      First-time setup includes a one-time max LMLN approval.
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Active-step copy while transactions run */}
+            {stepLabel && (
+              <p className='text-xs text-muted-foreground'>
+                {isApprovingLmln
+                  ? 'Confirm the approval in your wallet — a second prompt will follow to record the delegation.'
+                  : 'Confirm the transaction in your wallet.'}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className='gap-2 sm:gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setIsConfirmOpen(false)}
+              disabled={isProcessing}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={isRevokeFlow ? onConfirmRevoke : onConfirmDelegate}
+              disabled={!canSubmit || isProcessing}
+              variant={isRevokeFlow ? 'destructive' : 'default'}
+            >
+              {stepLabel ?? (isRevokeFlow ? 'Confirm Revoke' : 'Confirm Delegate')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/common/DelegationManager.tsx
+++ b/src/components/common/DelegationManager.tsx
@@ -6,7 +6,8 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronUp,
-  HandCoins
+  HandCoins,
+  Loader2
 } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
@@ -287,7 +288,7 @@ export function DelegationManager() {
               disabled={!canSubmit || isProcessing}
               variant={isRevokeFlow ? 'destructive' : 'default'}
             >
-              {stepLabel ?? (isRevokeFlow ? 'Confirm Revoke' : 'Confirm Delegate')}
+              {isProcessing ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> {stepLabel ?? 'Processing…'}</>) : (stepLabel ?? (isRevokeFlow ? 'Confirm Revoke' : 'Confirm Delegate'))}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/common/LoanCompletionModal.tsx
+++ b/src/components/common/LoanCompletionModal.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { Button } from '../ui/button'
-import { CheckCircle, Trophy } from 'lucide-react'
+import { CheckCircle, Trophy, Loader2 } from 'lucide-react'
 import { formatAmountWithSymbol } from '../../utils/format'
 
 interface LoanCompletionModalProps {
@@ -37,7 +37,13 @@ export function LoanCompletionModal({
   if (!loan) return null
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        // Standard modal contract: no dismissal while the tx is running.
+        if (!open && !isWithdrawing) onClose()
+      }}
+    >
       <DialogContent className='sm:max-w-md'>
         <DialogHeader>
           <DialogTitle className='flex items-center gap-3 text-xl'>
@@ -106,7 +112,7 @@ export function LoanCompletionModal({
             disabled={isWithdrawing}
             className='bg-gradient-to-r from-green-600 to-green-500 hover:from-green-700 hover:to-green-600 text-white'
           >
-            {isWithdrawing ? 'Withdrawing...' : 'Confirm & Withdraw Collateral'}
+            {isWithdrawing ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Withdrawing…</>) : ('Confirm & Withdraw Collateral')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/common/LoanConfirmationModal.tsx
+++ b/src/components/common/LoanConfirmationModal.tsx
@@ -28,6 +28,11 @@ interface LoanConfirmationModalProps {
   handleApproveLoanFee: () => Promise<void>
   needsCollateralApproval: boolean
   needsApproval: boolean
+  /** Delegate pays the fee but their LMLN allowance to the Loans contract is
+   *  short. The Approve button would approve from the CONNECTED wallet (the
+   *  borrower) and can never clear this, so creation is blocked with a
+   *  message instead. */
+  delegateNeedsAllowance?: boolean
   /** Native (gas-token) fee attached to initiateLoan, in wei */
   nativeFee?: bigint
   /** Native currency symbol for the connected chain (e.g. TLEMX) */
@@ -49,6 +54,7 @@ export function LoanConfirmationModal({
   handleApproveLoanFee,
   needsCollateralApproval,
   needsApproval,
+  delegateNeedsAllowance = false,
   nativeFee,
   nativeSymbol
 }: LoanConfirmationModalProps) {
@@ -95,7 +101,7 @@ export function LoanConfirmationModal({
             </div>
             <div className='flex justify-between'>
               <span className='font-medium'>APR:</span>
-              <span>{Math.round(calculation.apr)}%</span>
+              <span>{calculation.apr}%</span>
             </div>
             <div className='flex justify-between'>
               <span className='font-medium'>Collateral Required:</span>
@@ -165,6 +171,15 @@ export function LoanConfirmationModal({
             })()}
           </div>
 
+          {delegateNeedsAllowance && (
+            <div className='text-red-600 text-sm p-2 bg-red-50 rounded'>
+              The delegate hasn&apos;t approved enough {tokenConfig?.feeToken.symbol || 'LMLN'} to
+              the Loans contract. They need to grant approval (the Delegation
+              Manager does this when authorizing) before you can create this
+              loan.
+            </div>
+          )}
+
           {operationError && (
             <div className='text-red-600 text-sm p-2 bg-red-50 rounded'>
               {extractErrorMessage(operationError)}
@@ -199,7 +214,7 @@ export function LoanConfirmationModal({
           ) : (
             <Button
               onClick={handleCreateLoan}
-              disabled={isBusy || !calculation.isValid}
+              disabled={isBusy || !calculation.isValid || delegateNeedsAllowance}
               className='bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black'
             >
               {isCreatingLoan ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Creating Loan…</>) : ('Confirm & Create Loan')}

--- a/src/components/common/LoanConfirmationModal.tsx
+++ b/src/components/common/LoanConfirmationModal.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { Button } from '../ui/button'
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
 import { formatEther } from 'viem'
 import { extractErrorMessage } from '../../utils/errorHandling'
 
@@ -161,7 +161,7 @@ export function LoanConfirmationModal({
               disabled={isBusy || !calculation.isValid}
               className='bg-gradient-to-r from-blue-500 to-blue-400 hover:from-blue-600 hover:to-blue-500 text-white'
             >
-              {isApprovingCollateral ? 'Approving...' : `Approve ${collateral}`}
+              {isApprovingCollateral ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Approving…</>) : (`Approve ${collateral}`)}
             </Button>
           ) : needsApproval ? (
             <Button
@@ -169,7 +169,7 @@ export function LoanConfirmationModal({
               disabled={isBusy || !calculation.isValid}
               className='bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black'
             >
-              {isApprovingLoanFee ? 'Approving...' : `Approve ${tokenConfig?.feeToken.symbol || 'LMLN'} Fee`}
+              {isApprovingLoanFee ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Approving…</>) : (`Approve ${tokenConfig?.feeToken.symbol || 'LMLN'} Fee`)}
             </Button>
           ) : (
             <Button
@@ -177,7 +177,7 @@ export function LoanConfirmationModal({
               disabled={isBusy || !calculation.isValid}
               className='bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black'
             >
-              {isCreatingLoan ? 'Creating Loan...' : 'Confirm & Create Loan'}
+              {isCreatingLoan ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Creating Loan…</>) : ('Confirm & Create Loan')}
             </Button>
           )}
         </DialogFooter>

--- a/src/components/common/LoanConfirmationModal.tsx
+++ b/src/components/common/LoanConfirmationModal.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { Button } from '../ui/button'
-import { AlertTriangle, Loader2 } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react'
 import { formatEther } from 'viem'
 import { extractErrorMessage } from '../../utils/errorHandling'
 
@@ -127,18 +127,43 @@ export function LoanConfirmationModal({
             )}
           </div>
 
-          {(needsCollateralApproval || needsApproval) && (
-            <div className='text-xs text-muted-foreground bg-muted rounded p-3 space-y-1'>
-              <p className='font-medium'>Approval steps required:</p>
-              <p className={needsCollateralApproval ? 'text-foreground' : 'line-through opacity-50'}>
-                1. Approve {collateral} for collateral
-              </p>
-              <p className={needsApproval ? 'text-foreground' : 'line-through opacity-50'}>
-                2. Approve {tokenConfig?.feeToken.symbol || 'LMLN'} origination fee
-              </p>
-              <p className='opacity-50'>3. Create loan</p>
-            </div>
-          )}
+          {/* Always visible so the user keeps their bearings after the
+              approvals land — completed steps get a check mark, the active
+              step is highlighted, upcoming steps are dimmed. */}
+          <div className='text-xs text-muted-foreground bg-muted rounded p-3 space-y-1'>
+            <p className='font-medium'>Loan creation steps:</p>
+            {(() => {
+              const steps = [
+                {
+                  label: `1. Approve ${collateral} for collateral`,
+                  done: !needsCollateralApproval
+                },
+                {
+                  label: `2. Approve ${tokenConfig?.feeToken.symbol || 'LMLN'} origination fee`,
+                  done: !needsApproval
+                },
+                { label: '3. Create loan', done: false }
+              ]
+              const activeIndex = steps.findIndex((s) => !s.done)
+              return steps.map((step, i) => (
+                <p
+                  key={step.label}
+                  className={`flex items-center gap-1.5 ${
+                    step.done
+                      ? ''
+                      : i === activeIndex
+                        ? 'text-foreground font-medium'
+                        : 'opacity-50'
+                  }`}
+                >
+                  {step.done && (
+                    <CheckCircle2 className='h-3.5 w-3.5 text-green-600 shrink-0' />
+                  )}
+                  {step.label}
+                </p>
+              ))
+            })()}
+          </div>
 
           {operationError && (
             <div className='text-red-600 text-sm p-2 bg-red-50 rounded'>

--- a/src/components/common/LoanConfirmationModal.tsx
+++ b/src/components/common/LoanConfirmationModal.tsx
@@ -10,6 +10,8 @@ import {
 } from '../ui/dialog'
 import { Button } from '../ui/button'
 import { AlertTriangle } from 'lucide-react'
+import { formatEther } from 'viem'
+import { extractErrorMessage } from '../../utils/errorHandling'
 
 interface LoanConfirmationModalProps {
   isOpen: boolean
@@ -26,6 +28,10 @@ interface LoanConfirmationModalProps {
   handleApproveLoanFee: () => Promise<void>
   needsCollateralApproval: boolean
   needsApproval: boolean
+  /** Native (gas-token) fee attached to initiateLoan, in wei */
+  nativeFee?: bigint
+  /** Native currency symbol for the connected chain (e.g. TLEMX) */
+  nativeSymbol?: string
 }
 
 export function LoanConfirmationModal({
@@ -42,13 +48,22 @@ export function LoanConfirmationModal({
   handleApproveCollateral,
   handleApproveLoanFee,
   needsCollateralApproval,
-  needsApproval
+  needsApproval,
+  nativeFee,
+  nativeSymbol
 }: LoanConfirmationModalProps) {
   const collateral = collateralSymbol || 'Collateral'
   const isBusy = isApprovingCollateral || isApprovingLoanFee || isCreatingLoan
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        // Don't let ESC / outside-click dismiss the modal mid-transaction —
+        // the user would lose all progress context while the tx is pending.
+        if (!open && !isBusy) onClose()
+      }}
+    >
       <DialogContent className='sm:max-w-md'>
         <DialogHeader>
           <DialogTitle className='flex items-center gap-2'>
@@ -99,6 +114,17 @@ export function LoanConfirmationModal({
                 {tokenConfig?.feeToken.symbol || 'Token'}
               </span>
             </div>
+            {nativeFee !== undefined && nativeFee > 0n && (
+              <div className='flex justify-between'>
+                <span className='font-medium'>Network Fee:</span>
+                <span>
+                  {Number(formatEther(nativeFee)).toLocaleString('en-US', {
+                    maximumFractionDigits: 4
+                  })}{' '}
+                  {nativeSymbol || 'native token'}
+                </span>
+              </div>
+            )}
           </div>
 
           {(needsCollateralApproval || needsApproval) && (
@@ -116,7 +142,7 @@ export function LoanConfirmationModal({
 
           {operationError && (
             <div className='text-red-600 text-sm p-2 bg-red-50 rounded'>
-              {operationError.message}
+              {extractErrorMessage(operationError)}
             </div>
           )}
         </div>

--- a/src/components/common/OriginationPayerField.tsx
+++ b/src/components/common/OriginationPayerField.tsx
@@ -4,6 +4,7 @@ import { Lock, Unlock } from 'lucide-react'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { formatTokenAmount } from '../../utils/decimals'
+import { floorToDecimals } from '../../utils/format'
 import type { DelegateValidationResult } from '../../hooks/loans/useDelegateValidation'
 
 export interface OriginationPayerFieldProps {
@@ -19,7 +20,8 @@ export interface OriginationPayerFieldProps {
 }
 
 const formatLmln = (amount: bigint, decimals: number) => {
-  const num = Number(formatTokenAmount(amount, decimals))
+  // Floor — this is a balance display; rounding up overstates funds.
+  const num = floorToDecimals(Number(formatTokenAmount(amount, decimals)), 4)
   return num.toLocaleString('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 4

--- a/src/components/common/OriginationPayerField.tsx
+++ b/src/components/common/OriginationPayerField.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { Lock, Unlock } from 'lucide-react'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { formatTokenAmount } from '../../utils/decimals'
+import type { DelegateValidationResult } from '../../hooks/loans/useDelegateValidation'
+
+export interface OriginationPayerFieldProps {
+  value: string
+  onChange: (value: string) => void
+  validation: DelegateValidationResult
+  isLocked: boolean
+  onToggleLock: () => void
+  feeTokenSymbol: string
+  feeTokenDecimals: number
+  /** Optional id to associate label and input. */
+  id?: string
+}
+
+const formatLmln = (amount: bigint, decimals: number) => {
+  const num = Number(formatTokenAmount(amount, decimals))
+  return num.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4
+  })
+}
+
+type Tone = 'error' | 'info' | 'success' | 'muted'
+
+const messageForState = (
+  validation: DelegateValidationResult,
+  feeTokenSymbol: string,
+  feeTokenDecimals: number
+): { text: string; tone: Tone } | null => {
+  switch (validation.state) {
+    case 'empty':
+      return { text: 'Enter a wallet address.', tone: 'error' }
+    case 'invalid-format':
+      return { text: 'Not a valid wallet address.', tone: 'error' }
+    case 'self':
+      return { text: 'Your wallet will pay the fee.', tone: 'muted' }
+    case 'loading':
+      return { text: 'Checking authorization…', tone: 'info' }
+    case 'not-delegated':
+      return {
+        text: "That wallet hasn't authorized you to use it for fees.",
+        tone: 'error'
+      }
+    case 'valid': {
+      const balance =
+        validation.delegateLmlnBalance !== undefined
+          ? formatLmln(validation.delegateLmlnBalance, feeTokenDecimals)
+          : '—'
+      return {
+        text: `Authorized. Their ${feeTokenSymbol} balance: ${balance}.`,
+        tone: 'success'
+      }
+    }
+    default:
+      return null
+  }
+}
+
+const TONE_CLASS: Record<Tone, string> = {
+  error: 'text-red-500',
+  success: 'text-green-600',
+  info: 'text-blue-600',
+  muted: 'text-muted-foreground'
+}
+
+export function OriginationPayerField({
+  value,
+  onChange,
+  validation,
+  isLocked,
+  onToggleLock,
+  feeTokenSymbol,
+  feeTokenDecimals,
+  id = 'origination-payer'
+}: OriginationPayerFieldProps) {
+  // Suppress the muted "Your wallet will pay the fee." line when locked —
+  // that's the default and the lock icon already conveys it.
+  const message =
+    isLocked && validation.isSelf
+      ? null
+      : messageForState(validation, feeTokenSymbol, feeTokenDecimals)
+
+  const label =
+    !isLocked && validation.state === 'valid' && !validation.isSelf
+      ? 'Origination fee payer (delegator)'
+      : 'Origination fee payer'
+
+  return (
+    <div className='space-y-1.5'>
+      <div className='flex items-center justify-between gap-2'>
+        <Label htmlFor={id} className='text-sm'>
+          {label}
+        </Label>
+        <button
+          type='button'
+          onClick={onToggleLock}
+          className='inline-flex items-center gap-1 text-xs font-medium text-yellow-600 hover:text-yellow-500'
+          aria-pressed={!isLocked}
+          aria-label={isLocked ? 'Delegate fee — unlock to edit' : 'Lock to use connected wallet'}
+        >
+          {isLocked ? (
+            <>
+              <Lock className='h-3 w-3' />
+              Delegate fee?
+            </>
+          ) : (
+            <>
+              <Unlock className='h-3 w-3' />
+              Use my wallet
+            </>
+          )}
+        </button>
+      </div>
+      <Input
+        id={id}
+        type='text'
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={isLocked}
+        spellCheck={false}
+        autoComplete='off'
+        placeholder='0x…'
+      />
+      {message && (
+        <p className={`text-xs ${TONE_CLASS[message.tone]}`}>{message.text}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/common/ProtocolStatusBanner.tsx
+++ b/src/components/common/ProtocolStatusBanner.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useReadContract } from 'wagmi'
+import { useReadLoansPaused, liquidityPoolAbi } from '@/src/generated'
+import { useProtocolAddresses } from '@/src/hooks/useProtocolAddresses'
+import { usePricing } from '@/src/hooks/usePricing'
+import {
+  extractErrorMessage,
+  type ContractError
+} from '@/src/utils/errorHandling'
+import { AlertTriangle, PauseCircle } from 'lucide-react'
+
+/**
+ * Global protocol health banner. Every fee-bearing write depends on the
+ * contracts being unpaused and the price feed being fresh — without this
+ * banner those states only surface as opaque per-transaction failures deep
+ * in a flow (approve succeeds, then the real tx reverts).
+ */
+export function ProtocolStatusBanner() {
+  const { data: loansPaused } = useReadLoansPaused({
+    query: { refetchInterval: 30_000 }
+  })
+
+  const { liquidityPool: lpAddress } = useProtocolAddresses()
+  const { data: lpPaused } = useReadContract({
+    address: lpAddress,
+    abi: liquidityPoolAbi,
+    functionName: 'paused',
+    query: { enabled: !!lpAddress, refetchInterval: 30_000 }
+  })
+
+  // The price reads revert with PriceStale/NoPriceAvailable when the feed
+  // needs updating — decode and surface that here instead of letting each
+  // transaction fail with it individually.
+  const { error: pricingError } = usePricing()
+  const priceMessage = pricingError
+    ? extractErrorMessage(pricingError as unknown as ContractError)
+    : undefined
+  const showPriceWarning =
+    !!priceMessage && /price|stale/i.test(priceMessage)
+
+  const isPaused = Boolean(loansPaused) || Boolean(lpPaused)
+
+  if (!isPaused && !showPriceWarning) return null
+
+  return (
+    <div className='space-y-2'>
+      {isPaused && (
+        <div className='flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950/40 p-4'>
+          <PauseCircle className='h-5 w-5 shrink-0 text-red-600 dark:text-red-400 mt-0.5' />
+          <div>
+            <p className='text-sm font-semibold text-red-800 dark:text-red-300'>
+              Protocol paused
+            </p>
+            <p className='text-sm text-red-700 dark:text-red-400'>
+              {loansPaused && lpPaused
+                ? 'Loans and liquidity operations are temporarily paused.'
+                : loansPaused
+                  ? 'Loan operations are temporarily paused.'
+                  : 'Liquidity pool operations are temporarily paused.'}{' '}
+              Transactions will fail until the protocol is unpaused — please
+              check back later.
+            </p>
+          </div>
+        </div>
+      )}
+      {showPriceWarning && (
+        <div className='flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950/40 p-4'>
+          <AlertTriangle className='h-5 w-5 shrink-0 text-yellow-600 dark:text-yellow-400 mt-0.5' />
+          <div>
+            <p className='text-sm font-semibold text-yellow-800 dark:text-yellow-300'>
+              Price feed issue
+            </p>
+            <p className='text-sm text-yellow-700 dark:text-yellow-400'>
+              {priceMessage} Operations that depend on pricing (loans,
+              deposits, claims) may fail until the feed updates.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/common/ProtocolStatusBanner.tsx
+++ b/src/components/common/ProtocolStatusBanner.tsx
@@ -1,14 +1,18 @@
 'use client'
 
-import { useReadContract } from 'wagmi'
-import { useReadLoansPaused, liquidityPoolAbi } from '@/src/generated'
+import { useAccount, useChainId, useReadContract, useSwitchChain } from 'wagmi'
+import {
+  useReadLoansPaused,
+  liquidityPoolAbi,
+  loansAddress
+} from '@/src/generated'
 import { useProtocolAddresses } from '@/src/hooks/useProtocolAddresses'
 import { usePricing } from '@/src/hooks/usePricing'
 import {
   extractErrorMessage,
   type ContractError
 } from '@/src/utils/errorHandling'
-import { AlertTriangle, PauseCircle } from 'lucide-react'
+import { AlertTriangle, PauseCircle, Network } from 'lucide-react'
 
 /**
  * Global protocol health banner. Every fee-bearing write depends on the
@@ -17,6 +21,25 @@ import { AlertTriangle, PauseCircle } from 'lucide-react'
  * in a flow (approve succeeds, then the real tx reverts).
  */
 export function ProtocolStatusBanner() {
+  const { isConnected } = useAccount()
+  const chainId = useChainId()
+  const { switchChain, chains } = useSwitchChain()
+
+  // Wrong / unsupported network: without a Loans address every config read
+  // silently never resolves, and the only cue was the tiny wallet-button
+  // pill. Detect it here and offer a one-click switch. Widen to string —
+  // the generated literal types make a zero-address comparison a TS error,
+  // but at runtime an unconfigured env var really does yield the zero addr.
+  const hasLoansAddress = (id: number): boolean => {
+    const addr = loansAddress[id as keyof typeof loansAddress] as
+      | string
+      | undefined
+    return !!addr && addr !== '0x0000000000000000000000000000000000000000'
+  }
+  const isUnsupportedNetwork = isConnected && !hasLoansAddress(chainId)
+  const fallbackChain = chains.find((c) => hasLoansAddress(c.id))
+
+  // @ts-ignore - wagmi deep type instantiation
   const { data: loansPaused } = useReadLoansPaused({
     query: { refetchInterval: 30_000 }
   })
@@ -41,10 +64,32 @@ export function ProtocolStatusBanner() {
 
   const isPaused = Boolean(loansPaused) || Boolean(lpPaused)
 
-  if (!isPaused && !showPriceWarning) return null
+  if (!isPaused && !showPriceWarning && !isUnsupportedNetwork) return null
 
   return (
     <div className='space-y-2'>
+      {isUnsupportedNetwork && (
+        <div className='flex items-start gap-3 rounded-lg border border-orange-300 bg-orange-50 dark:border-orange-900 dark:bg-orange-950/40 p-4'>
+          <Network className='h-5 w-5 shrink-0 text-orange-600 dark:text-orange-400 mt-0.5' />
+          <div className='flex-1'>
+            <p className='text-sm font-semibold text-orange-800 dark:text-orange-300'>
+              Unsupported network
+            </p>
+            <p className='text-sm text-orange-700 dark:text-orange-400'>
+              Your wallet is connected to a network this app doesn&apos;t
+              support, so no data can load.
+            </p>
+          </div>
+          {fallbackChain && (
+            <button
+              onClick={() => switchChain({ chainId: fallbackChain.id })}
+              className='shrink-0 rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700 transition-colors'
+            >
+              Switch to {fallbackChain.name}
+            </button>
+          )}
+        </div>
+      )}
       {isPaused && (
         <div className='flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950/40 p-4'>
           <PauseCircle className='h-5 w-5 shrink-0 text-red-600 dark:text-red-400 mt-0.5' />

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useAccount } from 'wagmi'
+import { formatEther } from 'viem'
 import {
   Card,
   CardContent,
@@ -66,7 +67,8 @@ interface ActiveLoansProps {
 }
 
 export function ActiveLoans({ compact = false }: ActiveLoansProps) {
-  const { address } = useAccount()
+  const { address, chain } = useAccount()
+  const nativeSymbol = chain?.nativeCurrency.symbol ?? 'native token'
 
   // Extension origination-payer field — re-targets LMLN balance/allowance
   // reads in useLoans below when the borrower has unlocked it and supplied a
@@ -94,6 +96,7 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
     extendLoan,
     approveLoanFee,
     isLoading,
+    error: loansError,
     refetch,
     currentAllowance,
     currentLmlnAllowance,
@@ -103,6 +106,10 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
     userLmlnBalance,
     loanConfig,
     interestAprConfigs,
+    paymentFeeBps,
+    bpsDenominator,
+    getGrossPaymentAmount,
+    paymentNativeFee,
   } = useLoans({ originationPayer: effectiveExtensionPayer })
   const { tokenConfig } = useContractTokenConfiguration()
   const { getCollateralByAddress } = useCollateralManager()
@@ -366,11 +373,15 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         tokenConfig.loanToken.decimals
       )
 
-      // Check if user has sufficient token balance
-      if (userLoanTokenBalance && paymentWei > userLoanTokenBalance) {
+      // Check if user has sufficient token balance for the gross debit
+      // (payment + protocol fee) the contract will pull.
+      if (
+        userLoanTokenBalance !== undefined &&
+        getGrossPaymentAmount(paymentWei) > userLoanTokenBalance
+      ) {
         toast({
           title: 'Insufficient Balance',
-          description: `You need ${currentPaymentAmount} ${tokenConfig?.loanToken.symbol} but only have ${formatTokenAmount(userLoanTokenBalance, tokenConfig.loanToken.decimals)} ${tokenConfig?.loanToken.symbol}`,
+          description: `Including the protocol fee you need ${formatTokenAmount(getGrossPaymentAmount(paymentWei), tokenConfig.loanToken.decimals)} ${tokenConfig?.loanToken.symbol} but only have ${formatTokenAmount(userLoanTokenBalance, tokenConfig.loanToken.decimals)} ${tokenConfig?.loanToken.symbol}`,
           variant: 'destructive'
         })
         setIsProcessingPayment(false)
@@ -415,6 +426,36 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
     } finally {
       setIsProcessingPayment(false)
     }
+  }
+
+  // Loading takes 2+ sequential RPC rounds (loan IDs, then per-loan data) —
+  // without this gate every page load flashes "No Active Loans" at borrowers
+  // who do have loans, including overdue ones.
+  if (activeLoans.length === 0 && isLoading) {
+    return (
+      <div className='text-center py-8'>
+        <CreditCard className='h-12 w-12 mx-auto mb-4 text-muted-foreground animate-pulse' />
+        <p className='text-sm text-muted-foreground'>Loading your loans…</p>
+      </div>
+    )
+  }
+
+  // A load failure must never masquerade as "no loans" — a borrower could
+  // believe an overdue loan is gone.
+  if (activeLoans.length === 0 && loansError) {
+    return (
+      <div className='text-center py-8'>
+        <AlertCircle className='h-12 w-12 mx-auto mb-4 text-destructive' />
+        <h3 className='text-lg font-medium mb-2'>Couldn&apos;t load your loans</h3>
+        <p className='text-sm text-muted-foreground mb-4'>
+          Something went wrong while fetching your loan data. Your loans are
+          unaffected — please retry.
+        </p>
+        <Button variant='outline' onClick={() => refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
   }
 
   if (activeLoans.length === 0) {
@@ -864,13 +905,68 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                               />
                             </div>
                           )}
+
+                          {/* Fee disclosure — the contract debits payment +
+                              protocol fee, and payable ops charge a native
+                              network fee. Both must be visible pre-sign. */}
+                          {(() => {
+                            const currentPaymentAmount = getPaymentAmount(loan)
+                            const paymentWei =
+                              currentPaymentAmount && tokenConfig?.loanToken.decimals
+                                ? parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
+                                : 0n
+                            if (paymentWei <= 0n) return null
+                            const grossWei = getGrossPaymentAmount(paymentWei)
+                            const feePercent =
+                              Number((paymentFeeBps * 10000n) / bpsDenominator) / 100
+                            return (
+                              <div className='rounded-md bg-muted p-3 text-sm space-y-1'>
+                                <div className='flex justify-between'>
+                                  <span className='text-muted-foreground'>
+                                    Protocol fee ({feePercent}%)
+                                  </span>
+                                  <span>
+                                    {formatAmountWithSymbol(
+                                      grossWei - paymentWei,
+                                      tokenConfig?.loanToken.symbol || 'Token'
+                                    )}
+                                  </span>
+                                </div>
+                                <div className='flex justify-between font-medium'>
+                                  <span>Total debit</span>
+                                  <span>
+                                    {formatAmountWithSymbol(
+                                      grossWei,
+                                      tokenConfig?.loanToken.symbol || 'Token'
+                                    )}
+                                  </span>
+                                </div>
+                                {paymentNativeFee !== undefined &&
+                                  paymentNativeFee > 0n && (
+                                    <div className='flex justify-between'>
+                                      <span className='text-muted-foreground'>
+                                        Network fee
+                                      </span>
+                                      <span>
+                                        {Number(
+                                          formatEther(paymentNativeFee)
+                                        ).toLocaleString('en-US', {
+                                          maximumFractionDigits: 4
+                                        })}{' '}
+                                        {nativeSymbol}
+                                      </span>
+                                    </div>
+                                  )}
+                              </div>
+                            )
+                          })()}
                         </div>
                         <div className='flex gap-2'>
                           {(() => {
                             // Check if approval is needed. The contract pulls
-                            // amount + protocol fee (FEE_BPS = 25 → 0.25%) on
-                            // makeLoanPayment, so the allowance must cover the
-                            // gross — otherwise this button silently shows
+                            // amount + protocol fee (FEE_BPS, read from chain)
+                            // on makeLoanPayment, so the allowance must cover
+                            // the gross — otherwise this button silently shows
                             // "Confirm Payment" and the tx reverts with
                             // insufficient allowance.
                             const currentPaymentAmount = getPaymentAmount(loan)
@@ -878,12 +974,9 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                               currentPaymentAmount && tokenConfig?.loanToken.decimals
                                 ? parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
                                 : 0n
-                            // approval target adds a 1% buffer; balance check
-                            // uses the exact contract pull (0.25% protocol fee).
-                            const grossPaymentWei = paymentWei + paymentWei / 100n
-                            const contractPullWei = paymentWei + (paymentWei * 25n) / 10000n
+                            const contractPullWei = getGrossPaymentAmount(paymentWei)
                             const needsApproval =
-                              !currentAllowance || currentAllowance < grossPaymentWei
+                              !currentAllowance || currentAllowance < contractPullWei
                             const hasValidAmount =
                               currentPaymentAmount &&
                               parseFloat(currentPaymentAmount) > 0

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -528,8 +528,8 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         const isInGracePeriod = isLoanInGracePeriod(loan)
 
         // Countdown target — derived entirely from absolute timestamps on the
-        // loan struct (and loanConfig.balloonPaymentGraceDuration) so the value
-        // does not shift when the component re-renders. Three phases:
+        // loan struct so the value does not shift when the component
+        // re-renders. Three phases:
         //
         //   1. Interest NOT fully paid:
         //      count to the next cycle's payment deadline (capped at the loan
@@ -545,9 +545,15 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         // expected, since this is sized for mainnet cycle lengths.
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
         const loanEndMs = Number(loan.dueTimestamp) * 1000
-        const graceDurationMs = loanConfig?.balloonPaymentGraceDuration
-          ? Number(loanConfig.balloonPaymentGraceDuration) * 1000
-          : 0
+        // Per-loan grace snapshot (fixed at creation) so a config change
+        // can't shift existing loans' default countdowns; pre-upgrade loans
+        // have no snapshot (0) and fall back to the global config.
+        const graceDurationMs =
+          loan.balloonGraceSnapshot > 0n
+            ? Number(loan.balloonGraceSnapshot) * 1000
+            : loanConfig?.balloonPaymentGraceDuration
+              ? Number(loanConfig.balloonPaymentGraceDuration) * 1000
+              : 0
         const pastLoanEnd = isOverdue // isLoanOverdue === "now >= loanEndMs"
 
         // End of the next cycle the user must pay, accounting for prepayments.

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useAccount } from 'wagmi'
 import {
   Card,
   CardContent,
@@ -25,6 +26,8 @@ import { RadioGroup, RadioGroupItem } from '@/src/components/ui/radio-group'
 import { Loan, useLoans, useLoanPayment } from '@/src/hooks/useLoans'
 import { CountdownTimer } from '@/src/components/ui/countdown-timer'
 import { useContractTokenConfiguration } from '@/src/hooks/useContractTokenConfiguration'
+import { useDelegateValidation } from '@/src/hooks/loans/useDelegateValidation'
+import { OriginationPayerField } from '@/src/components/common/OriginationPayerField'
 import {
   formatAmountWithSymbol,
   formatDuration,
@@ -63,6 +66,27 @@ interface ActiveLoansProps {
 }
 
 export function ActiveLoans({ compact = false }: ActiveLoansProps) {
+  const { address } = useAccount()
+
+  // Extension origination-payer field — re-targets LMLN balance/allowance
+  // reads in useLoans below when the borrower has unlocked it and supplied a
+  // verified delegate. Default = connected wallet, locked.
+  const [extensionPayerInput, setExtensionPayerInput] = useState('')
+  const [isExtensionPayerLocked, setIsExtensionPayerLocked] = useState(true)
+  useEffect(() => {
+    if (isExtensionPayerLocked) {
+      setExtensionPayerInput(address ?? '')
+    }
+  }, [address, isExtensionPayerLocked])
+
+  const extensionPayerValidation = useDelegateValidation(extensionPayerInput)
+  const effectiveExtensionPayer =
+    !isExtensionPayerLocked &&
+    extensionPayerValidation.normalizedAddress &&
+    !extensionPayerValidation.isSelf
+      ? extensionPayerValidation.normalizedAddress
+      : undefined
+
   const {
     activeLoans,
     payLoan,
@@ -79,7 +103,7 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
     userLmlnBalance,
     loanConfig,
     interestAprConfigs,
-  } = useLoans()
+  } = useLoans({ originationPayer: effectiveExtensionPayer })
   const { tokenConfig } = useContractTokenConfiguration()
   const { getCollateralByAddress } = useCollateralManager()
   const {
@@ -844,21 +868,42 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                         <div className='flex gap-2'>
                           {(() => {
                             // Check if approval is needed. The contract pulls
-                            // amount + protocol fee on makeLoanPayment, so the
-                            // allowance must cover the gross — otherwise this
-                            // button silently shows "Confirm Payment" and the
-                            // tx reverts with insufficient allowance.
+                            // amount + protocol fee (FEE_BPS = 25 → 0.25%) on
+                            // makeLoanPayment, so the allowance must cover the
+                            // gross — otherwise this button silently shows
+                            // "Confirm Payment" and the tx reverts with
+                            // insufficient allowance.
                             const currentPaymentAmount = getPaymentAmount(loan)
                             const paymentWei =
                               currentPaymentAmount && tokenConfig?.loanToken.decimals
                                 ? parseTokenAmount(currentPaymentAmount, tokenConfig.loanToken.decimals)
                                 : 0n
+                            // approval target adds a 1% buffer; balance check
+                            // uses the exact contract pull (0.25% protocol fee).
                             const grossPaymentWei = paymentWei + paymentWei / 100n
+                            const contractPullWei = paymentWei + (paymentWei * 25n) / 10000n
                             const needsApproval =
                               !currentAllowance || currentAllowance < grossPaymentWei
                             const hasValidAmount =
                               currentPaymentAmount &&
                               parseFloat(currentPaymentAmount) > 0
+                            const hasInsufficientPaymentBalance =
+                              userLoanTokenBalance !== undefined &&
+                              hasValidAmount &&
+                              paymentWei > 0n &&
+                              userLoanTokenBalance < contractPullWei
+
+                            if (hasInsufficientPaymentBalance) {
+                              return (
+                                <div className='flex-1 text-sm text-destructive flex items-center gap-2'>
+                                  <AlertCircle className='h-4 w-4' />
+                                  <span>
+                                    You don&apos;t have enough{' '}
+                                    {tokenConfig?.loanToken.symbol || 'tokens'} for this payment.
+                                  </span>
+                                </div>
+                              )
+                            }
 
                             if (
                               needsApproval &&
@@ -876,7 +921,7 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                                   className='flex-1'
                                 >
                                   {isApprovingPayment
-                                    ? 'Approving...'
+                                    ? 'Approving…'
                                     : 'Approve Tokens'}
                                 </Button>
                               )
@@ -893,7 +938,7 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                                   className='flex-1'
                                 >
                                   {isProcessingPayment
-                                    ? 'Processing...'
+                                    ? 'Processing…'
                                     : 'Confirm Payment'}
                                 </Button>
                               )
@@ -971,8 +1016,16 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                         const ltvPct = tokenConfig
                           ? formatPercentage(loan.ltv, tokenConfig.ltvDecimals) + '%'
                           : '—'
+                        // currentLmlnAllowance + userLmlnBalance are auto-redirected to the
+                        // delegate's wallet when one is unlocked + valid (see useLoans options
+                        // wired up at top of this component). Same comparisons work either way.
                         const needsApproval = !currentLmlnAllowance || currentLmlnAllowance < loan.originationFee
                         const hasInsufficientBalance = userLmlnBalance !== undefined && userLmlnBalance < loan.originationFee
+                        // Block the CTA if the borrower has unlocked the field but
+                        // hasn't supplied a verified delegate yet (red text in the
+                        // OriginationPayerField surfaces the reason).
+                        const payerBlocks =
+                          !isExtensionPayerLocked && !extensionPayerValidation.isValid
 
                         return (
                           <div className='space-y-5'>
@@ -1032,28 +1085,73 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                               )}
                             </div>
 
-                            {/* Actions */}
+                            {/* Origination-fee payer (default = self; unlock to delegate). */}
+                            <OriginationPayerField
+                              value={extensionPayerInput}
+                              onChange={setExtensionPayerInput}
+                              validation={extensionPayerValidation}
+                              isLocked={isExtensionPayerLocked}
+                              onToggleLock={() => {
+                                setIsExtensionPayerLocked((wasLocked) => {
+                                  if (!wasLocked) {
+                                    setExtensionPayerInput(address ?? '')
+                                  }
+                                  return !wasLocked
+                                })
+                              }}
+                              feeTokenSymbol={tokenConfig?.feeToken.symbol || 'LMLN'}
+                              feeTokenDecimals={tokenConfig?.feeToken.decimals ?? 18}
+                              id={`extend-payer-${loan.id}`}
+                            />
+
+                            {/* Actions. hasInsufficientBalance / needsApproval reflect the
+                             *  *fee payer's* wallet — borrower when locked or self, delegate
+                             *  otherwise. The Approve LMLN button only shows when the user
+                             *  is paying their own fee; a delegate is expected to have
+                             *  pre-approved max LMLN when authorizing themselves.
+                             *
+                             *  We suppress the balance warning while a delegate is unlocked
+                             *  but unauthorized — the field's "not authorized" message is
+                             *  the actionable error to show first. */}
                             <div className='flex gap-2'>
-                              {hasInsufficientBalance ? (
+                              {hasInsufficientBalance &&
+                              (isExtensionPayerLocked ||
+                                extensionPayerValidation.isValid) ? (
                                 <div className='flex-1 text-sm text-destructive flex items-center gap-2'>
                                   <AlertCircle className='h-4 w-4' />
-                                  <span>Insufficient LMLN balance for extension fee</span>
+                                  <span>
+                                    {!isExtensionPayerLocked && !extensionPayerValidation.isSelf
+                                      ? `The chosen delegate doesn't have enough ${tokenConfig?.feeToken.symbol || 'LMLN'} for the extension fee.`
+                                      : `You don't have enough ${tokenConfig?.feeToken.symbol || 'LMLN'} for the extension fee.`}
+                                  </span>
                                 </div>
-                              ) : needsApproval && loan.originationFee > 0n ? (
+                              ) : needsApproval &&
+                                loan.originationFee > 0n &&
+                                (isExtensionPayerLocked || extensionPayerValidation.isSelf) ? (
                                 <Button
                                   onClick={() => handleExtensionApproval(loan)}
                                   disabled={isApprovingExtension || isProcessingExtension}
                                   className='flex-1'
                                 >
-                                  {isApprovingExtension ? 'Approving...' : 'Approve LMLN'}
+                                  {isApprovingExtension ? 'Approving…' : 'Approve LMLN'}
                                 </Button>
                               ) : (
                                 <Button
                                   onClick={() => handleExtension(loan)}
-                                  disabled={isProcessingExtension || extensionDuration === 0}
+                                  disabled={
+                                    isProcessingExtension ||
+                                    extensionDuration === 0 ||
+                                    payerBlocks ||
+                                    // Delegate must have sufficient allowance too —
+                                    // currentLmlnAllowance is auto-targeted to them.
+                                    (!isExtensionPayerLocked &&
+                                      !extensionPayerValidation.isSelf &&
+                                      needsApproval &&
+                                      loan.originationFee > 0n)
+                                  }
                                   className='flex-1'
                                 >
-                                  {isProcessingExtension ? 'Processing...' : 'Confirm Extension'}
+                                  {isProcessingExtension ? 'Processing…' : 'Confirm Extension'}
                                 </Button>
                               )}
                               <Button

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -57,7 +57,8 @@ import {
   AlertCircle,
   Copy,
   Check,
-  Info
+  Info,
+  Loader2
 } from 'lucide-react'
 import { LoanCompletionModal } from '../common/LoanCompletionModal'
 import { useCollateralManager } from '@/src/hooks/useCollateralManager'
@@ -987,6 +988,23 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                           })()}
                         </div>
                         <div className='flex gap-2'>
+                          {/* Standard modal contract: Cancel left (disabled
+                              mid-tx), confirm right with spinner. */}
+                          <Button
+                            variant='outline'
+                            disabled={isApprovingPayment || isProcessingPayment}
+                            onClick={() => {
+                              setPaymentAmount('')
+                              setSelectedLoan(null)
+                              setPaymentType('minimum')
+                              setCustomAmount('')
+                              setIsApprovingPayment(false)
+                              setIsProcessingPayment(false)
+                              setIsPaymentDialogOpen(false)
+                            }}
+                          >
+                            Cancel
+                          </Button>
                           {(() => {
                             // Check if approval is needed. The contract pulls
                             // amount + protocol fee (FEE_BPS, read from chain)
@@ -1038,9 +1056,11 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                                   }
                                   className='flex-1'
                                 >
-                                  {isApprovingPayment
-                                    ? 'Approving…'
-                                    : 'Approve Tokens'}
+                                  {isApprovingPayment ? (
+                                    <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Approving…</>
+                                  ) : (
+                                    'Approve Tokens'
+                                  )}
                                 </Button>
                               )
                             } else {
@@ -1055,27 +1075,15 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                                   }
                                   className='flex-1'
                                 >
-                                  {isProcessingPayment
-                                    ? 'Processing…'
-                                    : 'Confirm Payment'}
+                                  {isProcessingPayment ? (
+                                    <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Processing…</>
+                                  ) : (
+                                    'Confirm Payment'
+                                  )}
                                 </Button>
                               )
                             }
                           })()}
-                          <Button
-                            variant='outline'
-                            onClick={() => {
-                              setPaymentAmount('')
-                              setSelectedLoan(null)
-                              setPaymentType('minimum')
-                              setCustomAmount('')
-                              setIsApprovingPayment(false)
-                              setIsProcessingPayment(false)
-                              setIsPaymentDialogOpen(false)
-                            }}
-                          >
-                            Cancel
-                          </Button>
                         </div>
                       </div>
                     </DialogContent>
@@ -1259,6 +1267,18 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                                 </p>
                               )}
                             <div className='flex gap-2'>
+                              <Button
+                                variant='outline'
+                                disabled={isApprovingExtension || isProcessingExtension}
+                                onClick={() => {
+                                  setSelectedLoanForExtension(null)
+                                  setIsApprovingExtension(false)
+                                  setIsProcessingExtension(false)
+                                  setIsExtensionDialogOpen(false)
+                                }}
+                              >
+                                Cancel
+                              </Button>
                               {hasInsufficientBalance &&
                               (isExtensionPayerLocked ||
                                 extensionPayerValidation.isValid) ? (
@@ -1278,7 +1298,7 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                                   disabled={isApprovingExtension || isProcessingExtension}
                                   className='flex-1'
                                 >
-                                  {isApprovingExtension ? 'Approving…' : 'Approve LMLN'}
+                                  {isApprovingExtension ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Approving…</>) : ('Approve LMLN')}
                                 </Button>
                               ) : (
                                 <Button
@@ -1296,20 +1316,9 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                                   }
                                   className='flex-1'
                                 >
-                                  {isProcessingExtension ? 'Processing…' : 'Confirm Extension'}
+                                  {isProcessingExtension ? (<><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Processing…</>) : ('Confirm Extension')}
                                 </Button>
                               )}
-                              <Button
-                                variant='outline'
-                                onClick={() => {
-                                  setSelectedLoanForExtension(null)
-                                  setIsApprovingExtension(false)
-                                  setIsProcessingExtension(false)
-                                  setIsExtensionDialogOpen(false)
-                                }}
-                              >
-                                Cancel
-                              </Button>
                             </div>
                           </div>
                         )

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -161,6 +161,17 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
       tokenConfig.loanToken.decimals
     )
     const rounded = Math.ceil(parseFloat(minPayment) * 10) / 10
+    // Rounding a cost up is the safe direction, but near payoff the rounded
+    // minimum can exceed the remaining balance — and the payment guard then
+    // rejects the app's own default suggestion with "Payment Too Large".
+    // Clamp to the exact remaining balance in that case.
+    const remaining = formatTokenAmount(
+      loan.remainingBalance,
+      tokenConfig.loanToken.decimals
+    )
+    if (rounded > parseFloat(remaining)) {
+      return remaining
+    }
     return rounded.toFixed(1)
   }
 
@@ -723,8 +734,11 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                   </span>
                   <span>
                     {isInGracePeriod ? 'Principal' : 'Remaining'}:{' '}
+                    {/* remainingBalance in both phases — showing the original
+                        loanAmount here overstated the debt for borrowers who
+                        prepaid part of the principal before the grace window. */}
                     {formatAmountWithSymbol(
-                      isInGracePeriod ? loan.loanAmount : loan.remainingBalance,
+                      loan.remainingBalance,
                       tokenConfig?.loanToken.symbol || 'Token'
                     )}
                   </span>
@@ -796,6 +810,11 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                   <Dialog
                     open={isPaymentDialogOpen && selectedLoan === loan.id}
                     onOpenChange={(open) => {
+                      // Don't let ESC / outside-click dismiss mid-transaction —
+                      // the user would lose the pending-payment context.
+                      if (!open && (isApprovingPayment || isProcessingPayment)) {
+                        return
+                      }
                       setIsPaymentDialogOpen(open)
                       if (!open) {
                         setSelectedLoan(null)
@@ -1071,6 +1090,13 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                       selectedLoanForExtension === loan.id
                     }
                     onOpenChange={(open) => {
+                      // Don't dismiss mid-transaction (see payment dialog).
+                      if (
+                        !open &&
+                        (isApprovingExtension || isProcessingExtension)
+                      ) {
+                        return
+                      }
                       setIsExtensionDialogOpen(open)
                       if (!open) {
                         setSelectedLoanForExtension(null)
@@ -1212,6 +1238,26 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
                              *  We suppress the balance warning while a delegate is unlocked
                              *  but unauthorized — the field's "not authorized" message is
                              *  the actionable error to show first. */}
+                            {/* A verified delegate with insufficient allowance used to
+                                leave "Confirm Extension" inexplicably dead while the
+                                field showed green — say why and what to do. */}
+                            {!isExtensionPayerLocked &&
+                              !extensionPayerValidation.isSelf &&
+                              extensionPayerValidation.isValid &&
+                              needsApproval &&
+                              loan.originationFee > 0n &&
+                              !hasInsufficientBalance && (
+                                <p className='text-sm text-destructive flex items-center gap-2'>
+                                  <AlertCircle className='h-4 w-4 shrink-0' />
+                                  <span>
+                                    The delegate hasn&apos;t approved enough{' '}
+                                    {tokenConfig?.feeToken.symbol || 'LMLN'} to the
+                                    Loans contract. They need to grant approval (the
+                                    Delegation Manager does this when authorizing)
+                                    before you can extend.
+                                  </span>
+                                </p>
+                              )}
                             <div className='flex gap-2'>
                               {hasInsufficientBalance &&
                               (isExtensionPayerLocked ||

--- a/src/components/dashboard/ActiveLoans.tsx
+++ b/src/components/dashboard/ActiveLoans.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/src/utils/decimals'
 import { useToast } from '@/src/hooks/use-toast'
 import { LOAN_STATUS } from '@/src/constants'
+import { resolveGraceDuration } from '@/src/utils/loanStatus'
 import {
   handleContractError,
   type ContractError
@@ -558,14 +559,16 @@ export function ActiveLoans({ compact = false }: ActiveLoansProps) {
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
         const loanEndMs = Number(loan.dueTimestamp) * 1000
         // Per-loan grace snapshot (fixed at creation) so a config change
-        // can't shift existing loans' default countdowns; pre-upgrade loans
-        // have no snapshot (0) and fall back to the global config.
+        // can't shift existing loans' default countdowns; the shared util
+        // handles the pre-upgrade fallback to the global config and keeps
+        // this countdown in lockstep with useLoans' status override.
         const graceDurationMs =
-          loan.balloonGraceSnapshot > 0n
-            ? Number(loan.balloonGraceSnapshot) * 1000
-            : loanConfig?.balloonPaymentGraceDuration
-              ? Number(loanConfig.balloonPaymentGraceDuration) * 1000
-              : 0
+          Number(
+            resolveGraceDuration(
+              loan.balloonGraceSnapshot,
+              loanConfig?.balloonPaymentGraceDuration ?? 0n
+            )
+          ) * 1000
         const pastLoanEnd = isOverdue // isLoanOverdue === "now >= loanEndMs"
 
         // End of the next cycle the user must pay, accounting for prepayments.

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -24,6 +24,7 @@ import { ActiveLoans } from '@/src/components/dashboard/ActiveLoans'
 import { LoanHistory } from '@/src/components/dashboard/LoanHistory'
 import { Web3ErrorBoundary } from '@/src/components/error/Web3ErrorBoundary'
 import { PriceDataBanner } from '@/src/components/dashboard/PriceDataBanner'
+import { ProtocolStatusBanner } from '@/src/components/common/ProtocolStatusBanner'
 import { Plus, History, CreditCard, Calculator, DollarSign } from 'lucide-react'
 
 export function Dashboard() {
@@ -56,6 +57,11 @@ export function Dashboard() {
 
   return (
     <div className='space-y-6'>
+      {/* Protocol health — paused contracts / stale price feed */}
+      <Web3ErrorBoundary>
+        <ProtocolStatusBanner />
+      </Web3ErrorBoundary>
+
       {/* Header */}
       <div className='flex items-center justify-between'>
         <div>

--- a/src/components/dashboard/LoanHistory.tsx
+++ b/src/components/dashboard/LoanHistory.tsx
@@ -36,7 +36,7 @@ interface LoanHistoryProps {
 }
 
 export function LoanHistory({ compact = false }: LoanHistoryProps) {
-  const { loanHistory } = useLoans()
+  const { loanHistory, isLoading } = useLoans()
   const { tokenConfig } = useContractTokenConfiguration()
   const [copiedLoanId, setCopiedLoanId] = useState<string | null>(null)
 
@@ -64,6 +64,16 @@ export function LoanHistory({ compact = false }: LoanHistoryProps) {
       <Badge variant={getLoanStatusVariant(status)}>
         {getLoanStatusLabel(status)}
       </Badge>
+    )
+  }
+
+  // Don't flash "No Loan History" while the multi-round loan fetch is running.
+  if (loanHistory.length === 0 && isLoading) {
+    return (
+      <div className='text-center py-8'>
+        <History className='h-12 w-12 mx-auto mb-4 text-muted-foreground animate-pulse' />
+        <p className='text-sm text-muted-foreground'>Loading loan history…</p>
+      </div>
     )
   }
 

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useMemo } from 'react'
 import { useAccount, useReadContract, useReadContracts } from 'wagmi'
-import { erc20Abi } from 'viem'
+import { erc20Abi, formatEther } from 'viem'
 import {
   Card,
   CardContent,
@@ -73,7 +73,8 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
   const [selectedAssetIndex, setSelectedAssetIndex] = useState<number | null>(null)
   const [selectedTierIndex, setSelectedTierIndex] = useState<number | null>(null)
   const { toast } = useToast()
-  const { address } = useAccount()
+  const { address, chain } = useAccount()
+  const nativeCurrencySymbol = chain?.nativeCurrency.symbol ?? 'native token'
 
   const {
     stableTokenAddress,
@@ -82,6 +83,7 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
     feeConfig,
     approveToken,
     deposit,
+    depositNativeFee,
     refetch,
   } = liquidityPool
 
@@ -501,6 +503,17 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
                   <> — ~<span className='font-semibold text-foreground'>{depositFeeTokens} {symbol}</span> will be taken on top of the deposit amount</>
                 )}
                 .
+              </p>
+            )}
+            {depositNativeFee !== undefined && depositNativeFee > 0n && (
+              <p className='text-sm text-muted-foreground'>
+                A network fee of ~<span className='font-semibold text-foreground'>
+                  {Number(formatEther(depositNativeFee)).toLocaleString('en-US', {
+                    maximumFractionDigits: 4
+                  })}{' '}
+                  {nativeCurrencySymbol}
+                </span>{' '}
+                is charged on deposit.
               </p>
             )}
             {requiresSwap && (

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -314,9 +314,10 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
     setShowConfirmDialog(true)
   }
 
+  // Standard modal contract: stays open while the tx runs (spinner on the
+  // confirm button, dismissal blocked) and closes only on success.
   const handleConfirmDeposit = async () => {
     if (!tokenAmount || !selectedAsset) return
-    setShowConfirmDialog(false)
     setIsProcessing(true)
     try {
       await deposit(selectedAsset, tokenAmount, selectedLockDuration, isNonEarning)
@@ -325,6 +326,7 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
         description: `Deposited $${amount} (${tokenEquivalent} ${symbol})${isNonEarning ? ' as non-earning liquidity' : ' into the liquidity pool'}.`,
       })
       setAmount('')
+      setShowConfirmDialog(false)
       await refetchBalance()
       await refetchAllowance()
       await refetch()
@@ -505,7 +507,13 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
         </div>
       </CardContent>
 
-      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+      <Dialog
+        open={showConfirmDialog}
+        onOpenChange={(open) => {
+          if (!open && isProcessing) return
+          setShowConfirmDialog(open)
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Confirm Deposit</DialogTitle>
@@ -555,14 +563,20 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
             <Button
               variant='outline'
               onClick={() => setShowConfirmDialog(false)}
+              disabled={isProcessing}
             >
               Cancel
             </Button>
             <Button
               onClick={handleConfirmDeposit}
+              disabled={isProcessing}
               className='bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black font-semibold'
             >
-              Confirm Deposit
+              {isProcessing ? (
+                <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Depositing…</>
+              ) : (
+                'Confirm Deposit'
+              )}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -450,6 +450,30 @@ export function AddLiquidityCard({ liquidityPool }: AddLiquidityCardProps) {
               Insufficient balance. You need ~{tokenEquivalent} {symbol} but your balance is only worth ${balanceInUsd ?? '0'} USD.
             </p>
           )}
+          {/* The Deposit button used to sit inexplicably disabled when a
+              required choice was missing (or no tiers are enabled, in which
+              case the tier section doesn't render at all) — say why. */}
+          {amount && selectedAsset === undefined && (
+            <p className='text-sm text-muted-foreground'>
+              Select a token above to continue.
+            </p>
+          )}
+          {selectedAsset !== undefined && enabledTiers.length === 0 && (
+            <p className='text-sm text-destructive'>
+              No lock durations are currently enabled for this token — deposits
+              are unavailable.
+            </p>
+          )}
+          {amount &&
+            selectedAsset !== undefined &&
+            enabledTiers.length > 0 &&
+            selectedTier === undefined &&
+            !isBelowMinimum &&
+            !insufficientBalance && (
+              <p className='text-sm text-muted-foreground'>
+                Select a lock duration to continue.
+              </p>
+            )}
         </div>
 
         <div>

--- a/src/components/liquidity/LiquidityDashboard.tsx
+++ b/src/components/liquidity/LiquidityDashboard.tsx
@@ -4,12 +4,18 @@ import { AddLiquidityCard } from './AddLiquidityCard'
 import { RemoveLiquidityCard } from './RemoveLiquidityCard'
 import { LiquidityPerformance } from './LiquidityPerformance'
 import { Web3ErrorBoundary } from '@/src/components/error/Web3ErrorBoundary'
+import { ProtocolStatusBanner } from '@/src/components/common/ProtocolStatusBanner'
 
 export function LiquidityDashboard() {
   const liquidityPool = useLiquidityPool()
 
   return (
     <div className='space-y-6'>
+      {/* Protocol health — paused contracts / stale price feed */}
+      <Web3ErrorBoundary>
+        <ProtocolStatusBanner />
+      </Web3ErrorBoundary>
+
       <div>
         <h1 className='text-3xl font-bold text-gray-900'>
           Become a LemLoans Liquidity Provider

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -233,12 +233,14 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     return [...depositEntries].sort((a, b) => Number(a.lockDuration - b.lockDuration))
   }, [depositEntries])
 
-  // Action handlers
+  // Action handlers. Returns true on success so confirm modals \u2014 which stay
+  // OPEN while the tx runs (standard modal contract: spinner on the confirm
+  // button, dismissal blocked) \u2014 know when to close.
   const handleAction = async (
     actionName: string,
     action: () => Promise<unknown>,
     successMsg: string
-  ) => {
+  ): Promise<boolean> => {
     setIsProcessing(actionName)
     try {
       await action()
@@ -248,8 +250,10 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
       const title = actionName.replace(/([a-z])([A-Z])/g, '$1 $2')
       toast({ title: `\u2705 ${title} Successful`, description: successMsg })
       await refetch()
+      return true
     } catch (err: unknown) {
       handleContractError(err as ContractError, toast, `${actionName} Failed`)
+      return false
     } finally {
       setIsProcessing(null)
     }
@@ -578,7 +582,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     {/* Compound Earnings Modal */}
     <Dialog
       open={compoundModal.open}
-      onOpenChange={(open) => !open && setCompoundModal({ open: false, selectedTierIndex: null })}
+      onOpenChange={(open) => { if (!open && isProcessing !== null) return; if (!open) setCompoundModal({ open: false, selectedTierIndex: null }) }}
     >
       <DialogContent>
         <DialogHeader>
@@ -615,23 +619,27 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           )}
         </div>
         <DialogFooter>
-          <Button variant='outline' onClick={() => setCompoundModal({ open: false, selectedTierIndex: null })}>
+          <Button
+            variant='outline'
+            onClick={() => setCompoundModal({ open: false, selectedTierIndex: null })}
+            disabled={isProcessing !== null}
+          >
             Cancel
           </Button>
           <Button
             disabled={compoundModal.selectedTierIndex === null || isProcessing !== null}
             onClick={async () => {
               const tier = stableLockTiers[compoundModal.selectedTierIndex!]
-              setCompoundModal({ open: false, selectedTierIndex: null })
-              await handleAction(
+              const ok = await handleAction(
                 'Compound',
                 () => compoundEarnings(tier.duration),
                 'Earnings compounded into new shares.'
               )
+              if (ok) setCompoundModal({ open: false, selectedTierIndex: null })
             }}
           >
             {isProcessing === 'Compound' ? (
-              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Compounding...</>
+              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Compounding…</>
             ) : (
               'Confirm'
             )}
@@ -643,7 +651,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     {/* Transfer Account Modal */}
     <Dialog
       open={transferAccountModal.open}
-      onOpenChange={(open) => !open && setTransferAccountModal(emptyAccountModal)}
+      onOpenChange={(open) => { if (!open && isProcessing !== null) return; if (!open) setTransferAccountModal(emptyAccountModal) }}
     >
       <DialogContent>
         <DialogHeader>
@@ -685,7 +693,11 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           </div>
         </div>
         <DialogFooter>
-          <Button variant='outline' onClick={() => setTransferAccountModal(emptyAccountModal)}>
+          <Button
+            variant='outline'
+            onClick={() => setTransferAccountModal(emptyAccountModal)}
+            disabled={isProcessing !== null}
+          >
             Cancel
           </Button>
           <Button
@@ -697,16 +709,16 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
             }
             onClick={async () => {
               const to = transferAccountModal.address as `0x${string}`
-              setTransferAccountModal(emptyAccountModal)
-              await handleAction(
+              const ok = await handleAction(
                 'TransferAccount',
                 () => transferAccount(to),
                 'Account transferred successfully.'
               )
+              if (ok) setTransferAccountModal(emptyAccountModal)
             }}
           >
             {isProcessing === 'TransferAccount' ? (
-              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Transferring...</>
+              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Transferring…</>
             ) : (
               'Confirm Transfer'
             )}
@@ -718,7 +730,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     {/* Confirmation Modal */}
     <Dialog
       open={confirmModal.open}
-      onOpenChange={(open) => !open && setConfirmModal((m) => ({ ...m, open: false }))}
+      onOpenChange={(open) => { if (!open && isProcessing !== null) return; if (!open) setConfirmModal((m) => ({ ...m, open: false })) }}
     >
       <DialogContent>
         <DialogHeader>
@@ -728,19 +740,23 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           <p className='text-sm text-muted-foreground'>{confirmModal.description}</p>
         </div>
         <DialogFooter>
-          <Button variant='outline' onClick={() => setConfirmModal((m) => ({ ...m, open: false }))}>
+          <Button
+            variant='outline'
+            onClick={() => setConfirmModal((m) => ({ ...m, open: false }))}
+            disabled={isProcessing !== null}
+          >
             Cancel
           </Button>
           <Button
             disabled={isProcessing !== null}
             onClick={async () => {
               const { actionName, action, successMsg } = confirmModal
-              setConfirmModal((m) => ({ ...m, open: false }))
-              await handleAction(actionName, action, successMsg)
+              const ok = await handleAction(actionName, action, successMsg)
+              if (ok) setConfirmModal((m) => ({ ...m, open: false }))
             }}
           >
             {isProcessing === confirmModal.actionName ? (
-              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Processing...</>
+              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Processing…</>
             ) : (
               'Confirm'
             )}

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -242,7 +242,11 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     setIsProcessing(actionName)
     try {
       await action()
-      toast({ title: '\u2705 Success', description: successMsg })
+      // Title the toast with the actual action ("\u2705 Claim Earnings Successful")
+      // instead of a generic "\u2705 Success" shared by five different operations.
+      // Split camelCase names ("TransferAccount" \u2192 "Transfer Account").
+      const title = actionName.replace(/([a-z])([A-Z])/g, '$1 $2')
+      toast({ title: `\u2705 ${title} Successful`, description: successMsg })
       await refetch()
     } catch (err: unknown) {
       handleContractError(err as ContractError, toast, `${actionName} Failed`)

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/src/components/ui/dialog'
 import { useToast } from '@/src/hooks/use-toast'
 import { formatTokenAmount } from '@/src/utils/decimals'
+import { floorToDecimals } from '@/src/utils/format'
 import {
   BarChart3,
   TrendingUp,
@@ -55,12 +56,14 @@ function StatItem({ label, value, warning }: { label: string; value: string; war
 }
 
 function formatCurrency(value: bigint, decimals: number, symbol: string): string {
-  const formatted = parseFloat(formatTokenAmount(value, decimals))
+  // Floor, never round up — these are balances/claimable amounts, and a
+  // rounded-up display overstates what the user can actually withdraw.
+  const formatted = floorToDecimals(parseFloat(formatTokenAmount(value, decimals)), 4)
   return `${formatted.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 })} ${symbol}`
 }
 
 function formatShares(value: bigint, decimals: number): string {
-  const formatted = parseFloat(formatTokenAmount(value, decimals))
+  const formatted = floorToDecimals(parseFloat(formatTokenAmount(value, decimals)), 4)
   return formatted.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
 }
 
@@ -140,6 +143,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     poolStatus,
     feeConfig,
     liquidityStatus,
+    currentUtilization,
     depositEntries,
     hasPosition,
     totalLoansIssued,
@@ -198,13 +202,16 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     return Number(feeConfig.feeBps) / 100
   }, [feeConfig])
 
+  // Use the pool's own utilization getter (returned in basis points) — the
+  // previous local formula divided by deposited−withdrawn, which ignores the
+  // principal deficit and permanently understates utilization once any loan
+  // has defaulted (verified live: contract 33.10% vs local formula 38.02%…
+  // and diverging the other way as deficits grow).
   const poolUtilization = useMemo(() => {
-    if (!liquidityStatus) return 0
-    const totalDeposited = liquidityStatus.principalDeposited - liquidityStatus.principalWithdrawn
-    if (totalDeposited === 0n) return 0
-    const util = (Number(liquidityStatus.principalInLoans) / Number(totalDeposited)) * 100
+    if (currentUtilization === undefined) return 0
+    const util = Number(currentUtilization) / 100
     return Math.min(Math.max(util, 0), 100)
-  }, [liquidityStatus])
+  }, [currentUtilization])
 
   const canDistributeEarnings = useMemo(() => {
     if (!poolStatus) return false

--- a/src/components/liquidity/RemoveLiquidityCard.tsx
+++ b/src/components/liquidity/RemoveLiquidityCard.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/src/components/ui/dialog'
 import { useToast } from '@/src/hooks/use-toast'
 import { formatTokenAmount, parseTokenAmount } from '@/src/utils/decimals'
+import { floorToDecimals } from '@/src/utils/format'
 import { Minus, Loader2, Clock, CheckCircle2, ArrowDownToLine } from 'lucide-react'
 import {
   handleContractError,
@@ -108,7 +109,8 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
   const netReceiveDisplay = useMemo(() => {
     if (!withdrawalFeePct || !parsedAmount || !feeConfig) return undefined
     const net = parsedAmount - (parsedAmount * feeConfig.feeBps) / 10000n
-    return parseFloat(formatTokenAmount(net, decimals)).toLocaleString('en-US', {
+    // Floor — never overstate what the user will receive.
+    return floorToDecimals(parseFloat(formatTokenAmount(net, decimals)), 2).toLocaleString('en-US', {
       maximumFractionDigits: 2,
     })
   }, [withdrawalFeePct, parsedAmount, feeConfig, decimals])
@@ -188,7 +190,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
               className='hover:text-foreground transition-colors'
             >
               Unlocked:{' '}
-              {parseFloat(formattedWithdrawable).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
+              {floorToDecimals(parseFloat(formattedWithdrawable), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
               {symbol}
             </button>
           </div>
@@ -197,7 +199,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
         {insufficientBalance && (
           <p className='text-sm text-destructive'>
             Insufficient unlocked balance. You can request up to{' '}
-            {parseFloat(formattedWithdrawable).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
+            {floorToDecimals(parseFloat(formattedWithdrawable), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })}{' '}
             {symbol}.
           </p>
         )}
@@ -261,7 +263,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
 
                   {isFullyFunded && withdrawalFeePct && (
                     <p className='text-xs text-muted-foreground'>
-                      {withdrawalFeePct}% fee on claim · ~{parseFloat(formatTokenAmount(req.amount - (req.amount * feeConfig!.feeBps) / 10000n, decimals)).toLocaleString('en-US', { maximumFractionDigits: 2 })} {symbol} net
+                      {withdrawalFeePct}% fee on claim · ~{floorToDecimals(parseFloat(formatTokenAmount(req.amount - (req.amount * feeConfig!.feeBps) / 10000n, decimals)), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })} {symbol} net
                     </p>
                   )}
 

--- a/src/components/liquidity/RemoveLiquidityCard.tsx
+++ b/src/components/liquidity/RemoveLiquidityCard.tsx
@@ -1,5 +1,7 @@
 'use client'
 import { useState, useMemo } from 'react'
+import { useAccount } from 'wagmi'
+import { formatEther } from 'viem'
 import {
   Card,
   CardContent,
@@ -37,7 +39,14 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
   const [isProcessing, setIsProcessing] = useState<string | null>(null)
   const [fundQueueModal, setFundQueueModal] = useState(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+  const [claimModal, setClaimModal] = useState<{
+    open: boolean
+    requestId: bigint | null
+    amount: bigint
+  }>({ open: false, requestId: null, amount: 0n })
   const { toast } = useToast()
+  const { chain } = useAccount()
+  const nativeCurrencySymbol = chain?.nativeCurrency.symbol ?? 'native token'
 
   const {
     stableTokenSymbol,
@@ -47,6 +56,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
     requestWithdrawal,
     claimWithdrawal,
     fundWithdrawalQueue,
+    withdrawNativeFee,
     withdrawalRequests,
     refetch,
   } = liquidityPool
@@ -87,9 +97,11 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
     setShowConfirmDialog(true)
   }
 
+  // Standard modal contract (all confirm modals in the app): the modal stays
+  // OPEN while the transaction runs — spinner on the confirm button, cancel
+  // disabled, dismissal blocked — and closes only on success.
   const handleConfirmWithdrawal = async () => {
     if (!parsedAmount) return
-    setShowConfirmDialog(false)
     setIsProcessing('request')
     try {
       await requestWithdrawal(parsedAmount)
@@ -98,6 +110,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
         description: `Requested withdrawal of ${amount} ${symbol}. Your shares have been burned and the request has been queued.`,
       })
       setAmount('')
+      setShowConfirmDialog(false)
       await refetch()
     } catch (err: unknown) {
       handleContractError(err as ContractError, toast, 'Withdrawal Request Failed')
@@ -115,14 +128,31 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
     })
   }, [withdrawalFeePct, parsedAmount, feeConfig, decimals])
 
-  const handleClaimWithdrawal = async (requestId: bigint) => {
-    setIsProcessing(`claim-${requestId}`)
+  // Net amount for the claim confirm modal (requested − protocol fee), floored.
+  const claimNetDisplay = useMemo(() => {
+    if (claimModal.amount === 0n) return '0'
+    const net = feeConfig
+      ? claimModal.amount - (claimModal.amount * feeConfig.feeBps) / 10000n
+      : claimModal.amount
+    return floorToDecimals(parseFloat(formatTokenAmount(net, decimals)), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })
+  }, [claimModal.amount, feeConfig, decimals])
+
+  const claimFeeDisplay = useMemo(() => {
+    if (claimModal.amount === 0n || !feeConfig || feeConfig.feeBps === 0n) return undefined
+    const fee = (claimModal.amount * feeConfig.feeBps) / 10000n
+    return parseFloat(formatTokenAmount(fee, decimals)).toLocaleString('en-US', { maximumFractionDigits: 4 })
+  }, [claimModal.amount, feeConfig, decimals])
+
+  const handleConfirmClaim = async () => {
+    if (claimModal.requestId === null) return
+    setIsProcessing(`claim-${claimModal.requestId}`)
     try {
-      await claimWithdrawal(requestId)
+      await claimWithdrawal(claimModal.requestId)
       toast({
         title: 'Withdrawal Claimed',
-        description: `Successfully claimed your withdrawal.`,
+        description: `${claimNetDisplay} ${symbol} sent to your wallet.`,
       })
+      setClaimModal({ open: false, requestId: null, amount: 0n })
       await refetch()
     } catch (err: unknown) {
       handleContractError(err as ContractError, toast, 'Claim Failed')
@@ -139,6 +169,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
         title: 'Queue Funded',
         description: `Withdrawal queue has been funded with available principal.`,
       })
+      setFundQueueModal(false)
       await refetch()
     } catch (err: unknown) {
       handleContractError(err as ContractError, toast, 'Fund Queue Failed')
@@ -227,11 +258,7 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
                 onClick={() => setFundQueueModal(true)}
                 disabled={isProcessing !== null}
               >
-                {isProcessing === 'fund' ? (
-                  <><Loader2 className='h-3 w-3 mr-1 animate-spin' /> Funding...</>
-                ) : (
-                  <><ArrowDownToLine className='h-3 w-3 mr-1' /> Fund Queue</>
-                )}
+                <ArrowDownToLine className='h-3 w-3 mr-1' /> Fund Queue
               </Button>
             </div>
             {withdrawalRequests.requests.map((req, idx) => {
@@ -261,12 +288,6 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
                     )}
                   </div>
 
-                  {isFullyFunded && withdrawalFeePct && (
-                    <p className='text-xs text-muted-foreground'>
-                      {withdrawalFeePct}% fee on claim · ~{floorToDecimals(parseFloat(formatTokenAmount(req.amount - (req.amount * feeConfig!.feeBps) / 10000n, decimals)), 2).toLocaleString('en-US', { maximumFractionDigits: 2 })} {symbol} net
-                    </p>
-                  )}
-
                   {/* Funding progress bar */}
                   {!isFullyFunded && (
                     <div className='w-full bg-muted rounded-full h-1.5'>
@@ -281,15 +302,13 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
                     {isFullyFunded && (
                       <Button
                         size='sm'
-                        onClick={() => handleClaimWithdrawal(requestId)}
+                        onClick={() =>
+                          setClaimModal({ open: true, requestId, amount: req.amount })
+                        }
                         disabled={isProcessing !== null}
                         className='flex-1 bg-green-600 hover:bg-green-700 text-white'
                       >
-                        {isProcessing === `claim-${requestId}` ? (
-                          <><Loader2 className='h-3 w-3 mr-1 animate-spin' /> Claiming...</>
-                        ) : (
-                          <><CheckCircle2 className='h-3 w-3 mr-1' /> Claim</>
-                        )}
+                        <CheckCircle2 className='h-3 w-3 mr-1' /> Claim
                       </Button>
                     )}
                   </div>
@@ -301,7 +320,13 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
       </CardContent>
 
       {/* Confirm Withdrawal Modal */}
-      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+      <Dialog
+        open={showConfirmDialog}
+        onOpenChange={(open) => {
+          if (!open && isProcessing !== null) return
+          setShowConfirmDialog(open)
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Confirm Withdrawal Request</DialogTitle>
@@ -324,14 +349,23 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
             </p>
           </div>
           <DialogFooter className='gap-2 sm:gap-0'>
-            <Button variant='outline' onClick={() => setShowConfirmDialog(false)}>
+            <Button
+              variant='outline'
+              onClick={() => setShowConfirmDialog(false)}
+              disabled={isProcessing !== null}
+            >
               Cancel
             </Button>
             <Button
               onClick={handleConfirmWithdrawal}
+              disabled={isProcessing !== null}
               className='bg-gradient-to-r from-yellow-500 to-yellow-400 hover:from-yellow-600 hover:to-yellow-500 text-black font-semibold'
             >
-              Confirm Withdrawal
+              {isProcessing === 'request' ? (
+                <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Requesting…</>
+              ) : (
+                'Confirm Withdrawal'
+              )}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -340,7 +374,10 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
       {/* Fund Queue Modal */}
       <Dialog
         open={fundQueueModal}
-        onOpenChange={(open) => { if (!open) setFundQueueModal(false) }}
+        onOpenChange={(open) => {
+          if (!open && isProcessing !== null) return
+          if (!open) setFundQueueModal(false)
+        }}
       >
         <DialogContent>
           <DialogHeader>
@@ -355,20 +392,90 @@ export function RemoveLiquidityCard({ liquidityPool }: RemoveLiquidityCardProps)
             </p>
           </div>
           <DialogFooter>
-            <Button variant='outline' onClick={() => setFundQueueModal(false)}>
+            <Button
+              variant='outline'
+              onClick={() => setFundQueueModal(false)}
+              disabled={isProcessing !== null}
+            >
+              Cancel
+            </Button>
+            <Button disabled={isProcessing !== null} onClick={handleFundQueue}>
+              {isProcessing === 'fund' ? (
+                <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Funding…</>
+              ) : (
+                'Confirm'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Claim Withdrawal Modal */}
+      <Dialog
+        open={claimModal.open}
+        onOpenChange={(open) => {
+          if (!open && isProcessing !== null) return
+          if (!open) setClaimModal({ open: false, requestId: null, amount: 0n })
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Claim</DialogTitle>
+            <DialogDescription>
+              Your funded withdrawal will be sent to your wallet.
+            </DialogDescription>
+          </DialogHeader>
+          <div className='space-y-2 py-2 text-sm'>
+            <div className='flex justify-between'>
+              <span className='text-muted-foreground'>Requested amount</span>
+              <span className='font-medium'>
+                {parseFloat(formatTokenAmount(claimModal.amount, decimals)).toLocaleString('en-US', { maximumFractionDigits: 2 })} {symbol}
+              </span>
+            </div>
+            {withdrawalFeePct && claimFeeDisplay && (
+              <div className='flex justify-between'>
+                <span className='text-muted-foreground'>
+                  Protocol fee ({withdrawalFeePct}%)
+                </span>
+                <span className='font-medium'>
+                  −{claimFeeDisplay} {symbol}
+                </span>
+              </div>
+            )}
+            <div className='flex justify-between border-t pt-2'>
+              <span className='text-muted-foreground'>You receive</span>
+              <span className='font-semibold'>
+                ~{claimNetDisplay} {symbol}
+              </span>
+            </div>
+            {withdrawNativeFee !== undefined && withdrawNativeFee > 0n && (
+              <div className='flex justify-between'>
+                <span className='text-muted-foreground'>Network fee</span>
+                <span className='font-medium'>
+                  {Number(formatEther(withdrawNativeFee)).toLocaleString('en-US', { maximumFractionDigits: 4 })}{' '}
+                  {nativeCurrencySymbol}
+                </span>
+              </div>
+            )}
+          </div>
+          <DialogFooter className='gap-2 sm:gap-0'>
+            <Button
+              variant='outline'
+              onClick={() => setClaimModal({ open: false, requestId: null, amount: 0n })}
+              disabled={isProcessing !== null}
+            >
               Cancel
             </Button>
             <Button
+              onClick={handleConfirmClaim}
               disabled={isProcessing !== null}
-              onClick={async () => {
-                setFundQueueModal(false)
-                await handleFundQueue()
-              }}
+              className='bg-green-600 hover:bg-green-700 text-white'
             >
-              {isProcessing === 'fund' ? (
-                <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Funding...</>
+              {claimModal.requestId !== null &&
+              isProcessing === `claim-${claimModal.requestId}` ? (
+                <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Claiming…</>
               ) : (
-                'Confirm'
+                'Confirm Claim'
               )}
             </Button>
           </DialogFooter>

--- a/src/hooks/liquidity/useLiquidityOperations.ts
+++ b/src/hooks/liquidity/useLiquidityOperations.ts
@@ -32,6 +32,10 @@ export interface UseLiquidityOperationsReturn {
   approveToken: (amount: bigint, tokenAddress: `0x${string}`, spender: `0x${string}`) => Promise<`0x${string}` | undefined>
   depositFeeUSD: bigint | undefined
   withdrawFeeUSD: bigint | undefined
+  /** Native (gas-token) fee for deposit/compound, in wei — for display */
+  depositNativeFee: bigint | undefined
+  /** Native (gas-token) fee for claims/withdrawals, in wei — for display */
+  withdrawNativeFee: bigint | undefined
   isTransacting: boolean
   error: Error | null
 }
@@ -141,53 +145,82 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
     [publicClient, invalidateAll]
   )
 
+  /**
+   * Resolve the native (gas-token) fee for a payable LP operation fresh from
+   * chain. Fee = USD amount (LP contract) converted to native wei via
+   * Loans.getNativeFee(), which depends on a live price feed. Sending a stale
+   * or unresolved value reverts on-chain with InsufficientNativeFee after the
+   * user has already paid gas — so when the fee can't be determined, throw the
+   * underlying reason (often PriceStale) instead of guessing.
+   */
+  const resolveNativeFee = useCallback(
+    async (feeKind: 'deposit' | 'withdraw') => {
+      const hookValue = feeKind === 'deposit' ? depositNativeFee : withdrawNativeFee
+      const loansAddr = loansAddress[chainId as keyof typeof loansAddress]
+      if (!publicClient || !loansAddr || !lpAddress) return hookValue ?? 0n
+      try {
+        const feeUSD = await publicClient.readContract({
+          address: lpAddress,
+          abi: liquidityPoolAbi,
+          functionName: feeKind === 'deposit' ? 'depositFeeUSD' : 'withdrawFeeUSD',
+        }) as bigint
+        if (feeUSD === 0n) return 0n
+        return await publicClient.readContract({
+          address: loansAddr,
+          abi: loansAbi,
+          functionName: 'getNativeFee',
+          args: [feeUSD],
+        }) as bigint
+      } catch (feeError) {
+        // A recently-fetched hook value is an acceptable fallback; having no
+        // value at all is not — surface the real reason rather than sending
+        // a transaction destined to revert.
+        if (hookValue !== undefined && hookValue > 0n) return hookValue
+        throw feeError
+      }
+    },
+    [chainId, lpAddress, publicClient, depositNativeFee, withdrawNativeFee]
+  )
+
+  /**
+   * Estimate gas with a 20% buffer. Runs against the full LiquidityPool ABI,
+   * so a revert here carries the decoded custom error — thrown to the caller
+   * so the user sees the real reason BEFORE the wallet prompt, instead of
+   * paying gas for a doomed transaction.
+   */
+  const estimateGasWithBuffer = useCallback(
+    async (
+      functionName: string,
+      args: readonly unknown[] | undefined,
+      value: bigint
+    ): Promise<bigint | undefined> => {
+      if (!publicClient || !lpAddress || !address) return undefined
+      const estimated = await publicClient.estimateContractGas({
+        address: lpAddress,
+        abi: liquidityPoolAbi,
+        functionName,
+        args,
+        value,
+        account: address,
+      } as any)
+      return (estimated * 120n) / 100n
+    },
+    [publicClient, lpAddress, address]
+  )
+
   const deposit = useCallback(
     async (token: `0x${string}`, amount: bigint, lockDuration: bigint, nonEarning: boolean) => {
       if (!address) throw new Error('Wallet not connected')
       if (!lpAddress) throw new Error('LiquidityPool address not resolved')
 
-      // Always resolve the native fee fresh from chain to avoid stale hook state.
-      // The deposit() function on LiquidityPool is payable and requires TLEMX fee.
-      let nativeFee = depositNativeFee ?? 0n
-      if (publicClient) {
-        try {
-          const loansAddr = loansAddress[chainId as keyof typeof loansAddress]
-          if (loansAddr) {
-            const feeUSD = await publicClient.readContract({
-              address: lpAddress,
-              abi: liquidityPoolAbi,
-              functionName: 'depositFeeUSD',
-            }) as bigint
-            if (feeUSD > 0n) {
-              nativeFee = await publicClient.readContract({
-                address: loansAddr,
-                abi: loansAbi,
-                functionName: 'getNativeFee',
-                args: [feeUSD],
-              }) as bigint
-            }
-          }
-        } catch {
-          // fee read failed — fall back to hook value
-        }
-      }
+      // deposit() is payable — resolve the required native fee fresh from chain.
+      const nativeFee = await resolveNativeFee('deposit')
 
-      let gasEstimate: bigint | undefined
-      if (publicClient) {
-        try {
-          const estimated = await publicClient.estimateContractGas({
-            address: lpAddress,
-            abi: liquidityPoolAbi,
-            functionName: 'deposit',
-            args: [token, amount, lockDuration, nonEarning],
-            value: nativeFee,
-            account: address,
-          })
-          gasEstimate = (estimated * 120n) / 100n // 20% buffer
-        } catch {
-          // gas estimation failed — send without gas override and let wallet decide
-        }
-      }
+      const gasEstimate = await estimateGasWithBuffer(
+        'deposit',
+        [token, amount, lockDuration, nonEarning],
+        nativeFee
+      )
 
       const txHash = await depositFn({
         address: lpAddress,
@@ -198,7 +231,7 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, chainId, lpAddress, depositFn, depositNativeFee, publicClient, waitAndInvalidate]
+    [address, lpAddress, depositFn, resolveNativeFee, estimateGasWithBuffer, waitAndInvalidate]
   )
 
   const requestWithdrawal = useCallback(
@@ -215,29 +248,34 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
   const claimEarnings = useCallback(async () => {
     if (!address) throw new Error('Wallet not connected')
     if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+    const nativeFee = await resolveNativeFee('withdraw')
+    const gasEstimate = await estimateGasWithBuffer('claimEarnings', undefined, nativeFee)
     const txHash = await claimEarningsFn({
       address: lpAddress,
-      value: withdrawNativeFee ?? 0n,
-      gas: 300_000n,
+      value: nativeFee,
+      ...(gasEstimate !== undefined ? { gas: gasEstimate } : {}),
     })
     await waitAndInvalidate(txHash)
     return txHash
-  }, [address, lpAddress, claimEarningsFn, withdrawNativeFee, waitAndInvalidate])
+  }, [address, lpAddress, claimEarningsFn, resolveNativeFee, estimateGasWithBuffer, waitAndInvalidate])
 
   const compoundEarnings = useCallback(
     async (lockDuration: bigint) => {
       if (!address) throw new Error('Wallet not connected')
       if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+      // Compounding creates a deposit entry, so it charges the deposit fee.
+      const nativeFee = await resolveNativeFee('deposit')
+      const gasEstimate = await estimateGasWithBuffer('compoundEarnings', [lockDuration], nativeFee)
       const txHash = await compoundEarningsFn({
         address: lpAddress,
         args: [lockDuration],
-        value: depositNativeFee ?? 0n,
-        gas: 500_000n,
+        value: nativeFee,
+        ...(gasEstimate !== undefined ? { gas: gasEstimate } : {}),
       })
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, lpAddress, compoundEarningsFn, depositNativeFee, waitAndInvalidate]
+    [address, lpAddress, compoundEarningsFn, resolveNativeFee, estimateGasWithBuffer, waitAndInvalidate]
   )
 
   const pullEarnings = useCallback(async () => {
@@ -262,16 +300,18 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
     async (requestId: bigint) => {
       if (!address) throw new Error('Wallet not connected')
       if (!lpAddress) throw new Error('LiquidityPool address not resolved')
+      const nativeFee = await resolveNativeFee('withdraw')
+      const gasEstimate = await estimateGasWithBuffer('claimWithdrawal', [requestId], nativeFee)
       const txHash = await claimWithdrawalFn({
         address: lpAddress,
         args: [requestId],
-        value: withdrawNativeFee ?? 0n,
-        gas: 300_000n,
+        value: nativeFee,
+        ...(gasEstimate !== undefined ? { gas: gasEstimate } : {}),
       })
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, lpAddress, claimWithdrawalFn, withdrawNativeFee, waitAndInvalidate]
+    [address, lpAddress, claimWithdrawalFn, resolveNativeFee, estimateGasWithBuffer, waitAndInvalidate]
   )
 
   const fundWithdrawalQueue = useCallback(async () => {
@@ -301,7 +341,12 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
         args: [spender, amount],
       })
       if (publicClient) {
-        await publicClient.waitForTransactionReceipt({ hash: txHash })
+        const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash })
+        if (receipt.status === 'reverted') {
+          throw new Error(
+            'Approval transaction was reverted on-chain. No changes were made — please try again.'
+          )
+        }
       }
       await queryClient.invalidateQueries()
       return txHash
@@ -334,6 +379,8 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
     approveToken,
     depositFeeUSD,
     withdrawFeeUSD,
+    depositNativeFee,
+    withdrawNativeFee,
     isTransacting,
     error: null,
   }

--- a/src/hooks/liquidity/useLiquidityOperations.ts
+++ b/src/hooks/liquidity/useLiquidityOperations.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useAccount, useChainId, usePublicClient, useReadContract, useWriteContract } from 'wagmi'
 import { useQueryClient } from '@tanstack/react-query'
-import { erc20Abi } from 'viem'
+import { erc20Abi, BaseError, HttpRequestError, TimeoutError } from 'viem'
 import {
   useWriteLiquidityPoolDeposit,
   useWriteLiquidityPoolRequestWithdrawal,
@@ -172,10 +172,11 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
           args: [feeUSD],
         }) as bigint
       } catch (feeError) {
-        // A recently-fetched hook value is an acceptable fallback; having no
-        // value at all is not — surface the real reason rather than sending
-        // a transaction destined to revert.
-        if (hookValue !== undefined && hookValue > 0n) return hookValue
+        // A recently-fetched hook value is an acceptable fallback — including
+        // a legitimately-zero fee on chains with the native fee disabled.
+        // Having no value at all is not: surface the real reason rather than
+        // sending a transaction destined to revert.
+        if (hookValue !== undefined) return hookValue
         throw feeError
       }
     },
@@ -195,15 +196,29 @@ export function useLiquidityOperations(): UseLiquidityOperationsReturn {
       value: bigint
     ): Promise<bigint | undefined> => {
       if (!publicClient || !lpAddress || !address) return undefined
-      const estimated = await publicClient.estimateContractGas({
-        address: lpAddress,
-        abi: liquidityPoolAbi,
-        functionName,
-        args,
-        value,
-        account: address,
-      } as any)
-      return (estimated * 120n) / 100n
+      try {
+        const estimated = await publicClient.estimateContractGas({
+          address: lpAddress,
+          abi: liquidityPoolAbi,
+          functionName,
+          args,
+          value,
+          account: address,
+        } as any)
+        return (estimated * 120n) / 100n
+      } catch (estimationError) {
+        // A transport failure (RPC timeout / rate-limit) is not a revert —
+        // fall back to the wallet's own estimation instead of hard-blocking
+        // a transaction that would succeed. Genuine reverts still throw so
+        // the user sees the decoded reason before the wallet prompt.
+        const isTransport =
+          estimationError instanceof BaseError &&
+          estimationError.walk(
+            (e) => e instanceof HttpRequestError || e instanceof TimeoutError
+          ) !== null
+        if (isTransport) return undefined
+        throw estimationError
+      }
     },
     [publicClient, lpAddress, address]
   )

--- a/src/hooks/liquidity/useLiquidityPool.ts
+++ b/src/hooks/liquidity/useLiquidityPool.ts
@@ -19,6 +19,8 @@ export function useLiquidityPool() {
     approveToken: operations.approveToken,
     depositFeeUSD: operations.depositFeeUSD,
     withdrawFeeUSD: operations.withdrawFeeUSD,
+    depositNativeFee: operations.depositNativeFee,
+    withdrawNativeFee: operations.withdrawNativeFee,
     isTransacting: operations.isTransacting,
   }
 }

--- a/src/hooks/loans/useDelegateValidation.ts
+++ b/src/hooks/loans/useDelegateValidation.ts
@@ -31,9 +31,12 @@ export interface DelegateValidationResult {
  *
  * - 'self' (always valid): the candidate equals the connected wallet. The
  *   contract skips the delegation check when `originationPayer == msg.sender`.
- * - 'valid': the candidate has authorized the borrower as a delegate, in
- *   either storage direction (the ABI doesn't name the mapping args, so we
- *   read both `[a][b]` and `[b][a]` and accept whichever returns true).
+ * - 'valid': the candidate (payer) has authorized the connected wallet
+ *   (borrower). The mapping is `originationDelegations[payer][borrower]` —
+ *   `setOriginationDelegate(borrower, true)` is called BY the payer, storing
+ *   `[msg.sender][borrower]`. Reading the reverse direction too (as this hook
+ *   once did) validated payers who never delegated, and the resulting
+ *   initiateLoan reverted only after the UI said the payer was authorized.
  * - Balance/allowance shortfalls are surfaced separately by LoanSummary's
  *   existing "insufficient LMLN balance" warning, which already reads the
  *   delegate's wallet whenever `originationPayer` is wired through useLoans.
@@ -58,28 +61,20 @@ export function useDelegateValidation(
 
   const enable = !!normalizedAddress && !!connectedAddress && !isSelf
 
-  const { data: readA, isLoading: isLoadingA } = useReadContract({
-    address: loansContractAddress,
-    abi: loansAbi,
-    functionName: 'originationDelegations',
-    args:
-      enable && connectedAddress && normalizedAddress
-        ? [connectedAddress, normalizedAddress]
-        : undefined,
-    query: { enabled: enable && !!loansContractAddress }
-  })
-  const { data: readB, isLoading: isLoadingB } = useReadContract({
-    address: loansContractAddress,
-    abi: loansAbi,
-    functionName: 'originationDelegations',
-    args:
-      enable && connectedAddress && normalizedAddress
-        ? [normalizedAddress, connectedAddress]
-        : undefined,
-    query: { enabled: enable && !!loansContractAddress }
-  })
-  const isCheckingDelegation = isLoadingA || isLoadingB
-  const isAuthorized = Boolean(readA) || Boolean(readB)
+  // originationDelegations[payer][borrower] — candidate is the payer, the
+  // connected wallet is the borrower being paid for.
+  const { data: delegationRead, isLoading: isCheckingDelegation } =
+    useReadContract({
+      address: loansContractAddress,
+      abi: loansAbi,
+      functionName: 'originationDelegations',
+      args:
+        enable && connectedAddress && normalizedAddress
+          ? [normalizedAddress, connectedAddress]
+          : undefined,
+      query: { enabled: enable && !!loansContractAddress }
+    })
+  const isAuthorized = Boolean(delegationRead)
 
   // Delegate's LMLN balance — shown for context once verified. Useful for
   // the borrower to see their delegate has funds before submitting.

--- a/src/hooks/loans/useDelegateValidation.ts
+++ b/src/hooks/loans/useDelegateValidation.ts
@@ -1,0 +1,156 @@
+import { useMemo } from 'react'
+import { useAccount, useChainId, useReadContract } from 'wagmi'
+import { erc20Abi, isAddress, getAddress } from 'viem'
+import {
+  loansAbi,
+  loansAddress,
+  useReadLoansOriginationFeeToken
+} from '@/src/generated'
+
+export type DelegateValidationState =
+  | 'empty'
+  | 'invalid-format'
+  | 'self'
+  | 'loading'
+  | 'not-delegated'
+  | 'valid'
+
+export interface DelegateValidationResult {
+  state: DelegateValidationState
+  isValid: boolean
+  /** Normalized checksummed address, or undefined if not parseable. */
+  normalizedAddress: `0x${string}` | undefined
+  /** True when the candidate equals the connected wallet. */
+  isSelf: boolean
+  /** Delegate wallet's LMLN balance (used by the field for an info line). */
+  delegateLmlnBalance: bigint | undefined
+}
+
+/**
+ * Validates a candidate origination-fee payer.
+ *
+ * - 'self' (always valid): the candidate equals the connected wallet. The
+ *   contract skips the delegation check when `originationPayer == msg.sender`.
+ * - 'valid': the candidate has authorized the borrower as a delegate, in
+ *   either storage direction (the ABI doesn't name the mapping args, so we
+ *   read both `[a][b]` and `[b][a]` and accept whichever returns true).
+ * - Balance/allowance shortfalls are surfaced separately by LoanSummary's
+ *   existing "insufficient LMLN balance" warning, which already reads the
+ *   delegate's wallet whenever `originationPayer` is wired through useLoans.
+ */
+export function useDelegateValidation(
+  candidate: string
+): DelegateValidationResult {
+  const { address: connectedAddress } = useAccount()
+  const chainId = useChainId()
+  const loansContractAddress = loansAddress[chainId as keyof typeof loansAddress]
+  const { data: feeTokenAddress } = useReadLoansOriginationFeeToken()
+
+  const trimmed = candidate.trim()
+  const formatValid = trimmed.length > 0 && isAddress(trimmed)
+  const normalizedAddress = formatValid
+    ? (getAddress(trimmed) as `0x${string}`)
+    : undefined
+  const isSelf =
+    !!normalizedAddress &&
+    !!connectedAddress &&
+    normalizedAddress.toLowerCase() === connectedAddress.toLowerCase()
+
+  const enable = !!normalizedAddress && !!connectedAddress && !isSelf
+
+  const { data: readA, isLoading: isLoadingA } = useReadContract({
+    address: loansContractAddress,
+    abi: loansAbi,
+    functionName: 'originationDelegations',
+    args:
+      enable && connectedAddress && normalizedAddress
+        ? [connectedAddress, normalizedAddress]
+        : undefined,
+    query: { enabled: enable && !!loansContractAddress }
+  })
+  const { data: readB, isLoading: isLoadingB } = useReadContract({
+    address: loansContractAddress,
+    abi: loansAbi,
+    functionName: 'originationDelegations',
+    args:
+      enable && connectedAddress && normalizedAddress
+        ? [normalizedAddress, connectedAddress]
+        : undefined,
+    query: { enabled: enable && !!loansContractAddress }
+  })
+  const isCheckingDelegation = isLoadingA || isLoadingB
+  const isAuthorized = Boolean(readA) || Boolean(readB)
+
+  // Delegate's LMLN balance — shown for context once verified. Useful for
+  // the borrower to see their delegate has funds before submitting.
+  const { data: delegateLmlnBalance } = useReadContract({
+    address: feeTokenAddress,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: enable && normalizedAddress ? [normalizedAddress] : undefined,
+    query: { enabled: enable && !!feeTokenAddress }
+  })
+
+  return useMemo<DelegateValidationResult>(() => {
+    if (trimmed.length === 0) {
+      return {
+        state: 'empty',
+        isValid: false,
+        normalizedAddress: undefined,
+        isSelf: false,
+        delegateLmlnBalance: undefined
+      }
+    }
+    if (!formatValid || !normalizedAddress) {
+      return {
+        state: 'invalid-format',
+        isValid: false,
+        normalizedAddress: undefined,
+        isSelf: false,
+        delegateLmlnBalance: undefined
+      }
+    }
+    if (isSelf) {
+      return {
+        state: 'self',
+        isValid: true,
+        normalizedAddress,
+        isSelf: true,
+        delegateLmlnBalance: undefined
+      }
+    }
+    if (isCheckingDelegation) {
+      return {
+        state: 'loading',
+        isValid: false,
+        normalizedAddress,
+        isSelf: false,
+        delegateLmlnBalance
+      }
+    }
+    if (!isAuthorized) {
+      return {
+        state: 'not-delegated',
+        isValid: false,
+        normalizedAddress,
+        isSelf: false,
+        delegateLmlnBalance
+      }
+    }
+    return {
+      state: 'valid',
+      isValid: true,
+      normalizedAddress,
+      isSelf: false,
+      delegateLmlnBalance
+    }
+  }, [
+    trimmed,
+    formatValid,
+    normalizedAddress,
+    isSelf,
+    isAuthorized,
+    isCheckingDelegation,
+    delegateLmlnBalance
+  ])
+}

--- a/src/hooks/loans/useDelegateValidation.ts
+++ b/src/hooks/loans/useDelegateValidation.ts
@@ -74,7 +74,12 @@ export function useDelegateValidation(
           : undefined,
       query: { enabled: enable && !!loansContractAddress }
     })
-  const isAuthorized = Boolean(delegationRead)
+  // undefined means the check hasn't RUN (disabled query on an unsupported
+  // network, or the wallet briefly disconnected) — that must surface as
+  // 'loading', never as a definitive "hasn't authorized you" error.
+  // Mirrors useDelegationManager's handling of the same read.
+  const isAuthorized =
+    delegationRead === undefined ? undefined : Boolean(delegationRead)
 
   // Delegate's LMLN balance — shown for context once verified. Useful for
   // the borrower to see their delegate has funds before submitting.
@@ -114,7 +119,7 @@ export function useDelegateValidation(
         delegateLmlnBalance: undefined
       }
     }
-    if (isCheckingDelegation) {
+    if (isCheckingDelegation || isAuthorized === undefined) {
       return {
         state: 'loading',
         isValid: false,

--- a/src/hooks/loans/useDelegationManager.ts
+++ b/src/hooks/loans/useDelegationManager.ts
@@ -130,6 +130,21 @@ export function useDelegationManager(
   const [isApprovingLmln, setIsApprovingLmln] = useState(false)
   const [isWritingDelegation, setIsWritingDelegation] = useState(false)
 
+  // Wait for a tx to land and throw if it reverted — a reverted approval or
+  // delegation write must never surface as a success toast.
+  const waitForSuccess = useCallback(
+    async (hash: `0x${string}`, label: string) => {
+      if (!publicClient) return
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status === 'reverted') {
+        throw new Error(
+          `${label} transaction was reverted on-chain. No changes were made — please try again.`
+        )
+      }
+    },
+    [publicClient]
+  )
+
   const refreshAfterTx = useCallback(async () => {
     // Drop all originationDelegations cache entries so any other consumer
     // (e.g. the borrower-side OriginationPayerField) refetches on next read,
@@ -165,9 +180,7 @@ export function useDelegationManager(
             functionName: 'approve',
             args: [loansContractAddress, maxUint256]
           })
-          if (publicClient) {
-            await publicClient.waitForTransactionReceipt({ hash: approvalHash })
-          }
+          await waitForSuccess(approvalHash, 'LMLN approval')
           await refetchAllowance()
         } finally {
           setIsApprovingLmln(false)
@@ -177,9 +190,7 @@ export function useDelegationManager(
       setIsWritingDelegation(true)
       try {
         const hash = await setDelegate({ args: [borrower, true] })
-        if (publicClient) {
-          await publicClient.waitForTransactionReceipt({ hash })
-        }
+        await waitForSuccess(hash, 'Delegation')
         await refreshAfterTx()
       } finally {
         setIsWritingDelegation(false)
@@ -191,7 +202,7 @@ export function useDelegationManager(
       feeTokenAddress,
       hasMaxLmlnAllowance,
       approveLmln,
-      publicClient,
+      waitForSuccess,
       refetchAllowance,
       setDelegate,
       refreshAfterTx
@@ -204,15 +215,13 @@ export function useDelegationManager(
       setIsWritingDelegation(true)
       try {
         const hash = await setDelegate({ args: [borrower, false] })
-        if (publicClient) {
-          await publicClient.waitForTransactionReceipt({ hash })
-        }
+        await waitForSuccess(hash, 'Revocation')
         await refreshAfterTx()
       } finally {
         setIsWritingDelegation(false)
       }
     },
-    [address, setDelegate, publicClient, refreshAfterTx]
+    [address, setDelegate, waitForSuccess, refreshAfterTx]
   )
 
   const state: DelegationFormState =

--- a/src/hooks/loans/useDelegationManager.ts
+++ b/src/hooks/loans/useDelegationManager.ts
@@ -64,28 +64,17 @@ export function useDelegationManager(
 
   const enable = !!normalizedBorrower && !!address && !isSelf
 
-  // The ABI doesn't name the `originationDelegations` mapping args, so we
-  // read both directions and accept whichever returns true. Raw
-  // useReadContract avoids a TS2589 deep-instantiation error that occurs
-  // when both the typed read and the typed write are imported in this file.
+  // originationDelegations[payer][borrower] — the connected wallet is the
+  // payer here (it calls setOriginationDelegate), candidate is the borrower.
+  // Reading both arg orders and OR-ing (as this hook once did) made the UI
+  // claim "delegated" when only the reverse direction existed, hiding the
+  // delegate CTA the user actually needed. Raw useReadContract avoids a
+  // TS2589 deep-instantiation error that occurs when both the typed read and
+  // the typed write are imported in this file.
   const {
-    data: readA,
-    isLoading: isLoadingA,
-    refetch: refetchA
-  } = useReadContract({
-    address: loansContractAddress,
-    abi: loansAbi,
-    functionName: 'originationDelegations',
-    args:
-      enable && normalizedBorrower && address
-        ? [normalizedBorrower, address]
-        : undefined,
-    query: { enabled: enable && !!loansContractAddress }
-  })
-  const {
-    data: readB,
-    isLoading: isLoadingB,
-    refetch: refetchB
+    data: delegationRead,
+    isLoading: isCheckingDelegation,
+    refetch: refetchDelegation
   } = useReadContract({
     address: loansContractAddress,
     abi: loansAbi,
@@ -96,11 +85,8 @@ export function useDelegationManager(
         : undefined,
     query: { enabled: enable && !!loansContractAddress }
   })
-  const isCheckingDelegation = isLoadingA || isLoadingB
-  const bothUndefined = readA === undefined && readB === undefined
-  const isAlreadyDelegated = bothUndefined
-    ? undefined
-    : Boolean(readA) || Boolean(readB)
+  const isAlreadyDelegated =
+    delegationRead === undefined ? undefined : Boolean(delegationRead)
 
   // Connected wallet's LMLN allowance to the Loans contract — drives the
   // "skip approval" path on delegate().
@@ -162,8 +148,8 @@ export function useDelegationManager(
               'originationDelegations'
         )
     })
-    await Promise.all([refetchA(), refetchB()])
-  }, [queryClient, refetchA, refetchB])
+    await refetchDelegation()
+  }, [queryClient, refetchDelegation])
 
   const delegate = useCallback(
     async (borrower: `0x${string}`) => {

--- a/src/hooks/loans/useDelegationManager.ts
+++ b/src/hooks/loans/useDelegationManager.ts
@@ -1,0 +1,241 @@
+import { useCallback, useState } from 'react'
+import {
+  useAccount,
+  useChainId,
+  usePublicClient,
+  useReadContract,
+  useWriteContract
+} from 'wagmi'
+import { useQueryClient } from '@tanstack/react-query'
+import { erc20Abi, isAddress, getAddress, maxUint256 } from 'viem'
+import {
+  loansAbi,
+  loansAddress,
+  useReadLoansOriginationFeeToken,
+  useWriteLoansSetOriginationDelegate
+} from '@/src/generated'
+
+export type DelegationFormState =
+  | 'empty'
+  | 'invalid-format'
+  | 'self'
+  | 'loading'
+  | 'not-delegated'
+  | 'delegated'
+
+export interface UseDelegationManagerResult {
+  state: DelegationFormState
+  /** Normalized checksummed address (when format is valid). */
+  normalizedBorrower: `0x${string}` | undefined
+  /** True when the connected wallet's LMLN allowance is effectively unlimited. */
+  hasMaxLmlnAllowance: boolean
+  /** Approve max LMLN to the Loans contract (if needed), then setOriginationDelegate(borrower, true). */
+  delegate: (borrower: `0x${string}`) => Promise<void>
+  /** Call setOriginationDelegate(borrower, false). */
+  revoke: (borrower: `0x${string}`) => Promise<void>
+  isProcessing: boolean
+  isApprovingLmln: boolean
+  isWritingDelegation: boolean
+}
+
+// Treat "max-approved" as anything above half of maxUint256 — won't realistically
+// be exhausted by ordinary origination-fee transfers.
+const EFFECTIVE_MAX_THRESHOLD = maxUint256 / 2n
+
+export function useDelegationManager(
+  candidate: string
+): UseDelegationManagerResult {
+  const { address } = useAccount()
+  const chainId = useChainId()
+  const publicClient = usePublicClient()
+  const queryClient = useQueryClient()
+  const loansContractAddress = loansAddress[chainId as keyof typeof loansAddress]
+  const { data: feeTokenAddress } = useReadLoansOriginationFeeToken()
+
+  const trimmed = candidate.trim()
+  const formatValid = trimmed.length > 0 && isAddress(trimmed)
+  const normalizedBorrower = formatValid
+    ? (getAddress(trimmed) as `0x${string}`)
+    : undefined
+  const isSelf =
+    !!normalizedBorrower &&
+    !!address &&
+    normalizedBorrower.toLowerCase() === address.toLowerCase()
+
+  const enable = !!normalizedBorrower && !!address && !isSelf
+
+  // The ABI doesn't name the `originationDelegations` mapping args, so we
+  // read both directions and accept whichever returns true. Raw
+  // useReadContract avoids a TS2589 deep-instantiation error that occurs
+  // when both the typed read and the typed write are imported in this file.
+  const {
+    data: readA,
+    isLoading: isLoadingA,
+    refetch: refetchA
+  } = useReadContract({
+    address: loansContractAddress,
+    abi: loansAbi,
+    functionName: 'originationDelegations',
+    args:
+      enable && normalizedBorrower && address
+        ? [normalizedBorrower, address]
+        : undefined,
+    query: { enabled: enable && !!loansContractAddress }
+  })
+  const {
+    data: readB,
+    isLoading: isLoadingB,
+    refetch: refetchB
+  } = useReadContract({
+    address: loansContractAddress,
+    abi: loansAbi,
+    functionName: 'originationDelegations',
+    args:
+      enable && normalizedBorrower && address
+        ? [address, normalizedBorrower]
+        : undefined,
+    query: { enabled: enable && !!loansContractAddress }
+  })
+  const isCheckingDelegation = isLoadingA || isLoadingB
+  const bothUndefined = readA === undefined && readB === undefined
+  const isAlreadyDelegated = bothUndefined
+    ? undefined
+    : Boolean(readA) || Boolean(readB)
+
+  // Connected wallet's LMLN allowance to the Loans contract — drives the
+  // "skip approval" path on delegate().
+  const { data: myLmlnAllowance, refetch: refetchAllowance } = useReadContract({
+    address: feeTokenAddress,
+    abi: erc20Abi,
+    functionName: 'allowance',
+    args:
+      address && loansContractAddress
+        ? [address, loansContractAddress]
+        : undefined,
+    query: {
+      enabled: !!feeTokenAddress && !!address && !!loansContractAddress
+    }
+  })
+  const hasMaxLmlnAllowance =
+    myLmlnAllowance !== undefined && myLmlnAllowance >= EFFECTIVE_MAX_THRESHOLD
+
+  const { writeContractAsync: approveLmln } = useWriteContract({
+    mutation: { retry: false }
+  })
+  const { writeContractAsync: setDelegate } =
+    useWriteLoansSetOriginationDelegate({
+      mutation: { retry: false }
+    })
+
+  const [isApprovingLmln, setIsApprovingLmln] = useState(false)
+  const [isWritingDelegation, setIsWritingDelegation] = useState(false)
+
+  const refreshAfterTx = useCallback(async () => {
+    // Drop all originationDelegations cache entries so any other consumer
+    // (e.g. the borrower-side OriginationPayerField) refetches on next read,
+    // then explicitly refetch this hook's reads so the local CTA updates
+    // immediately.
+    queryClient.removeQueries({
+      predicate: (query) =>
+        Array.isArray(query.queryKey) &&
+        query.queryKey.some(
+          (part) =>
+            typeof part === 'object' &&
+            part !== null &&
+            'functionName' in part &&
+            (part as { functionName?: string }).functionName ===
+              'originationDelegations'
+        )
+    })
+    await Promise.all([refetchA(), refetchB()])
+  }, [queryClient, refetchA, refetchB])
+
+  const delegate = useCallback(
+    async (borrower: `0x${string}`) => {
+      if (!address) throw new Error('Connect a wallet first.')
+      if (!loansContractAddress) throw new Error('Loans contract not found.')
+      if (!feeTokenAddress) throw new Error('LMLN token not found.')
+
+      if (!hasMaxLmlnAllowance) {
+        setIsApprovingLmln(true)
+        try {
+          const approvalHash = await approveLmln({
+            address: feeTokenAddress,
+            abi: erc20Abi,
+            functionName: 'approve',
+            args: [loansContractAddress, maxUint256]
+          })
+          if (publicClient) {
+            await publicClient.waitForTransactionReceipt({ hash: approvalHash })
+          }
+          await refetchAllowance()
+        } finally {
+          setIsApprovingLmln(false)
+        }
+      }
+
+      setIsWritingDelegation(true)
+      try {
+        const hash = await setDelegate({ args: [borrower, true] })
+        if (publicClient) {
+          await publicClient.waitForTransactionReceipt({ hash })
+        }
+        await refreshAfterTx()
+      } finally {
+        setIsWritingDelegation(false)
+      }
+    },
+    [
+      address,
+      loansContractAddress,
+      feeTokenAddress,
+      hasMaxLmlnAllowance,
+      approveLmln,
+      publicClient,
+      refetchAllowance,
+      setDelegate,
+      refreshAfterTx
+    ]
+  )
+
+  const revoke = useCallback(
+    async (borrower: `0x${string}`) => {
+      if (!address) throw new Error('Connect a wallet first.')
+      setIsWritingDelegation(true)
+      try {
+        const hash = await setDelegate({ args: [borrower, false] })
+        if (publicClient) {
+          await publicClient.waitForTransactionReceipt({ hash })
+        }
+        await refreshAfterTx()
+      } finally {
+        setIsWritingDelegation(false)
+      }
+    },
+    [address, setDelegate, publicClient, refreshAfterTx]
+  )
+
+  const state: DelegationFormState =
+    trimmed.length === 0
+      ? 'empty'
+      : !formatValid
+      ? 'invalid-format'
+      : isSelf
+      ? 'self'
+      : isCheckingDelegation || isAlreadyDelegated === undefined
+      ? 'loading'
+      : isAlreadyDelegated
+      ? 'delegated'
+      : 'not-delegated'
+
+  return {
+    state,
+    normalizedBorrower,
+    hasMaxLmlnAllowance,
+    delegate,
+    revoke,
+    isProcessing: isApprovingLmln || isWritingDelegation,
+    isApprovingLmln,
+    isWritingDelegation
+  }
+}

--- a/src/hooks/loans/useLoanConfig.ts
+++ b/src/hooks/loans/useLoanConfig.ts
@@ -64,12 +64,12 @@ export const useLoanConfig = (asset?: `0x${string}`) => {
   const ltvOptions = useMemo(() => {
     if (!originationFeesRaw) return []
     const [ltvs = [], fees = []] = originationFeesRaw || []
-    return ltvs
-      .map((ltv, index) => ({
-        ltv,
-        fee: fees[index] ?? 0n
-      }))
-      .filter((option) => option.fee && option.fee > 0n)
+    // Every configured tier is selectable — a zero fee is a legitimate
+    // configuration (free origination at that LTV), not a missing entry.
+    return ltvs.map((ltv, index) => ({
+      ltv,
+      fee: fees[index] ?? 0n
+    }))
   }, [originationFeesRaw])
 
   const isLoading =

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -526,7 +526,9 @@ export const useLoanOperations = (
         throw new Error('Unable to calculate collateral amount. Please try again.')
       }
       
-      if (!originationFee || originationFee === 0n) {
+      // undefined means the calculation hasn't resolved; 0n is a legitimate
+      // zero-fee LTV tier and must not block creation.
+      if (originationFee === undefined) {
         throw new Error('Unable to calculate origination fee. Please try again.')
       }
 
@@ -676,13 +678,7 @@ export const useLoanOperations = (
 
       // Check if we need to approve tokens first
       if (!currentAllowance || currentAllowance < grossAmount) {
-        try {
-          // First approve the tokens
-          await approveTokenAllowance(amount)
-        } catch (error) {
-          // Re-throw the error to be handled by the calling component
-          throw error
-        }
+        await approveTokenAllowance(amount)
       }
 
       const nativeFee = paymentNativeFee ?? 0n

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -34,6 +34,11 @@ export interface LoanRequest {
 export interface UseLoanOperationsOptions {
   loanRequest?: LoanRequest
   selectedLtvOption?: { ltv: bigint; fee: bigint }
+  /** Address that will be charged the LMLN origination fee. Defaults to the
+   *  connected wallet (borrower self-pays). Pass a delegate address to route
+   *  LMLN balance/allowance reads to that wallet and to forward it as the
+   *  `originationPayer` arg on initiateLoan/extendLoan. */
+  originationPayer?: `0x${string}`
 }
 
 export interface UseLoanOperationsReturn {
@@ -59,6 +64,7 @@ export interface UseLoanOperationsReturn {
   // Loan creation data
   requiredCollateral: bigint | undefined
   hasInsufficientLmln: boolean
+  hasInsufficientCollateral: boolean
   grossOriginationFee: bigint | undefined
   calculationData:
     | {
@@ -77,6 +83,7 @@ export interface UseLoanOperationsReturn {
   // User balances
   userLmlnBalance: bigint | undefined
   userLoanTokenBalance: bigint | undefined
+  userCollateralBalance: bigint | undefined
   currentAllowance: bigint | undefined
   currentLmlnAllowance: bigint | undefined
   currentCollateralAllowance: bigint | undefined
@@ -94,8 +101,14 @@ export interface UseLoanOperationsReturn {
 export const useLoanOperations = (
   options?: UseLoanOperationsOptions
 ): UseLoanOperationsReturn => {
-  const { loanRequest, selectedLtvOption } = options || {}
+  const { loanRequest, selectedLtvOption, originationPayer } = options || {}
   const { address } = useAccount()
+  // The wallet that will pay the LMLN origination fee. Defaults to the
+  // connected wallet (borrower self-pays). When the borrower picks a
+  // delegate, balance/allowance reads and contract calls re-target this
+  // address — keeping `hasInsufficientLmln` and the allowance check honest
+  // regardless of who is paying.
+  const effectivePayer = originationPayer ?? address
   const chainId = useChainId()
   const publicClient = usePublicClient()
   const queryClient = useQueryClient()
@@ -121,14 +134,15 @@ export const useLoanOperations = (
   // Get the fee token address from contract
   const { data: feeTokenAddress } = useReadLoansOriginationFeeToken()
 
-  // Get user's LMLN balance
+  // LMLN balance for the fee payer (borrower self-pays by default; delegate
+  // when the borrower has unlocked the field and picked someone else).
   const { data: userLmlnBalance } = useReadContract({
     address: feeTokenAddress,
     abi: erc20Abi,
     functionName: 'balanceOf',
-    args: address ? [address] : undefined,
+    args: effectivePayer ? [effectivePayer] : undefined,
     query: {
-      enabled: !!feeTokenAddress && !!address
+      enabled: !!feeTokenAddress && !!effectivePayer
     }
   })
 
@@ -165,18 +179,18 @@ export const useLoanOperations = (
     }
   )
 
-  // Get current LMLN token allowance for origination fees
+  // LMLN allowance from the fee payer to the Loans contract.
   const { data: currentLmlnAllowance, refetch: refetchLmlnAllowance } =
     useReadContract({
       address: feeTokenAddress,
       abi: erc20Abi,
       functionName: 'allowance',
       args:
-        address && loansContractAddress
-          ? [address, loansContractAddress]
+        effectivePayer && loansContractAddress
+          ? [effectivePayer, loansContractAddress]
           : undefined,
       query: {
-        enabled: !!feeTokenAddress && !!address && !!loansContractAddress
+        enabled: !!feeTokenAddress && !!effectivePayer && !!loansContractAddress
       }
     })
 
@@ -199,6 +213,18 @@ export const useLoanOperations = (
         enabled: !!loanRequest?.collateralToken && !!address && !!cmAddress
       }
     })
+
+  // Borrower's collateral-token balance. Always the connected wallet — the
+  // borrower posts collateral regardless of who pays the origination fee.
+  const { data: userCollateralBalance } = useReadContract({
+    address: loanRequest?.collateralToken,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: address ? [address] : undefined,
+    query: {
+      enabled: !!loanRequest?.collateralToken && !!address
+    }
+  })
 
   // Get available liquidity from the Loans contract
   const { data: liquidityStatusRaw } = useReadLoansGetLiquidityStatus()
@@ -300,6 +326,14 @@ export const useLoanOperations = (
       ? userLmlnBalance < grossOriginationFee
       : selectedLtvOption && userLmlnBalance !== undefined
       ? userLmlnBalance < selectedLtvOption.fee
+      : false
+
+  // Check if borrower has enough collateral-token to back the loan. Without
+  // this guard, initiateLoan reaches the on-chain transferFrom and reverts
+  // with the (poorly-worded) WLEMX "amount < balance" message.
+  const hasInsufficientCollateral =
+    collateralAmount !== undefined && userCollateralBalance !== undefined
+      ? userCollateralBalance < collateralAmount
       : false
 
   // Function to approve LMLN tokens for loan creation or extension
@@ -422,7 +456,8 @@ export const useLoanOperations = (
   const createLoan = useCallback(
     async (loanRequest: LoanRequest) => {
       if (!address) throw new Error('Wallet not connected')
-      
+      const payer = originationPayer ?? address
+
       if (!collateralAmount || collateralAmount === 0n) {
         throw new Error('Unable to calculate collateral amount. Please try again.')
       }
@@ -462,7 +497,7 @@ export const useLoanOperations = (
           address: loansContractAddress,
           abi: loansAbi,
           functionName: 'initiateLoan',
-          args: [loanRequest.collateralToken, loanRequest.duration, loanRequest.loanAmount, loanRequest.ltv],
+          args: [loanRequest.collateralToken, loanRequest.duration, loanRequest.loanAmount, loanRequest.ltv, payer],
           value: nativeFee,
           account: address,
         })
@@ -470,7 +505,7 @@ export const useLoanOperations = (
 
       // Execute the transaction — collateral is pre-approved to CollateralManager via ERC20
       const txHash = await initiateLoan({
-        args: [loanRequest.collateralToken, loanRequest.duration, loanRequest.loanAmount, loanRequest.ltv],
+        args: [loanRequest.collateralToken, loanRequest.duration, loanRequest.loanAmount, loanRequest.ltv, payer],
         value: nativeFee,
       })
 
@@ -480,6 +515,7 @@ export const useLoanOperations = (
     },
     [
       address,
+      originationPayer,
       initiateLoan,
       collateralAmount,
       originationFee,
@@ -708,11 +744,12 @@ export const useLoanOperations = (
   const extendLoan = useCallback(
     async (loanId: `0x${string}`, extendTime: bigint) => {
       if (!address) throw new Error('Wallet not connected')
-      const txHash = await extendLoanContract({ args: [loanId, extendTime] })
+      const payer = originationPayer ?? address
+      const txHash = await extendLoanContract({ args: [loanId, extendTime, payer] })
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, extendLoanContract, waitAndInvalidate]
+    [address, originationPayer, extendLoanContract, waitAndInvalidate]
   )
 
   return {
@@ -737,6 +774,7 @@ export const useLoanOperations = (
     // Loan creation data
     requiredCollateral: collateralAmount,
     hasInsufficientLmln,
+    hasInsufficientCollateral,
     grossOriginationFee,
     calculationData: calculationData
       ? {
@@ -755,6 +793,7 @@ export const useLoanOperations = (
     // User balances
     userLmlnBalance,
     userLoanTokenBalance,
+    userCollateralBalance,
     currentAllowance,
     currentLmlnAllowance,
     currentCollateralAllowance,

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -11,6 +11,8 @@ import {
   useReadLoansInitiateLoanFeeUsd,
   useReadLoansLoanPaymentFeeUsd,
   useReadLoansGetNativeFee,
+  useReadLoansFeeBps,
+  useReadLoansBpsDenominator,
   loansAddress,
   loansAbi,
   useWriteLoansWithdrawCollateral,
@@ -19,10 +21,9 @@ import {
 } from '@/src/generated'
 import { useReadContract, useWriteContract, usePublicClient } from 'wagmi'
 import { config } from '@/src/config/wagmi'
-import { erc20Abi } from 'viem'
+import { erc20Abi, formatEther } from 'viem'
 import { useContractTokenConfiguration } from '../useContractTokenConfiguration'
 import { useProtocolAddresses } from '../useProtocolAddresses'
-import { loanKeys } from '../query/loanQueries'
 
 export interface LoanRequest {
   collateralToken: `0x${string}` // ERC20 collateral token address
@@ -92,6 +93,18 @@ export interface UseLoanOperationsReturn {
   availableLiquidity: bigint | undefined
   hasInsufficientLiquidity: boolean
 
+  // Protocol fees (read from chain)
+  /** makeLoanPayment protocol fee rate in basis points (FEE_BPS) */
+  paymentFeeBps: bigint
+  /** Basis-point denominator (BPS_DENOMINATOR) */
+  bpsDenominator: bigint
+  /** Gross amount the contract pulls for a payment: amount + protocol fee */
+  getGrossPaymentAmount: (amount: bigint) => bigint
+  /** Native (gas-token) fee attached to initiateLoan, in wei. 0n when unset. */
+  initiateNativeFee: bigint | undefined
+  /** Native (gas-token) fee attached to makeLoanPayment, in wei. 0n when unset. */
+  paymentNativeFee: bigint | undefined
+
   // Error state
   error: Error | null
 }
@@ -101,7 +114,7 @@ export interface UseLoanOperationsReturn {
 export const useLoanOperations = (
   options?: UseLoanOperationsOptions
 ): UseLoanOperationsReturn => {
-  const { loanRequest, selectedLtvOption, originationPayer } = options || {}
+  const { loanRequest, originationPayer } = options || {}
   const { address } = useAccount()
   // The wallet that will pay the LMLN origination fee. Defaults to the
   // connected wallet (borrower self-pays). When the borrower picks a
@@ -286,6 +299,26 @@ export const useLoanOperations = (
     query: { enabled: loanPaymentFeeUSD !== undefined && loanPaymentFeeUSD > 0n, refetchInterval: 30000 },
   })
 
+  // Protocol payment fee, read from chain so a governance change to FEE_BPS
+  // can't silently desync the UI's balance/allowance math from the contract.
+  const { data: feeBpsRaw } = useReadLoansFeeBps()
+  const { data: bpsDenominatorRaw } = useReadLoansBpsDenominator()
+  const paymentFeeBps = feeBpsRaw ?? 25n
+  const bpsDenominator = bpsDenominatorRaw ?? 10000n
+
+  // Gross amount the contract pulls on makeLoanPayment: amount + fee, with the
+  // fee rounded up so approvals/balance checks always cover the on-chain pull.
+  const getGrossPaymentAmount = useCallback(
+    (amount: bigint) =>
+      amount + (amount * paymentFeeBps + bpsDenominator - 1n) / bpsDenominator,
+    [paymentFeeBps, bpsDenominator]
+  )
+
+  // Native currency symbol for user-facing fee messages (TLEMX / LEMX / BNB).
+  const nativeSymbol =
+    config.chains.find((c) => c.id === chainId)?.nativeCurrency.symbol ??
+    'native token'
+
   // Calculate loan details using the view function (no token interactions)
   const {
     data: calculationData,
@@ -320,12 +353,13 @@ export const useLoanOperations = (
     ? originationFee + originationFee * LMLN_FEE_RATE_FALLBACK / LMLN_FEE_DENOMINATOR + originationFee / 10n
     : undefined
 
-  // Check if user has sufficient LMLN for origination fee (gross amount including transfer tax)
+  // Check if user has sufficient LMLN for origination fee (gross amount
+  // including transfer tax). Only meaningful once calculateLoanDetails has
+  // resolved — the raw LTV-tier fee is a USD amount, not LMLN, so comparing
+  // it against an LMLN wei balance would be nonsense.
   const hasInsufficientLmln =
     grossOriginationFee && userLmlnBalance !== undefined
       ? userLmlnBalance < grossOriginationFee
-      : selectedLtvOption && userLmlnBalance !== undefined
-      ? userLmlnBalance < selectedLtvOption.fee
       : false
 
   // Check if borrower has enough collateral-token to back the loan. Without
@@ -335,6 +369,39 @@ export const useLoanOperations = (
     collateralAmount !== undefined && userCollateralBalance !== undefined
       ? userCollateralBalance < collateralAmount
       : false
+
+  // Wait for a tx to land and throw if it reverted on-chain — a reverted
+  // approval must never surface as a success toast.
+  const waitForSuccess = useCallback(
+    async (txHash: `0x${string}`, label: string) => {
+      if (!publicClient) return
+      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash })
+      if (receipt.status === 'reverted') {
+        throw new Error(
+          `${label} transaction was reverted on-chain. No changes were made — please try again.`
+        )
+      }
+    },
+    [publicClient]
+  )
+
+  // Payable loan operations attach a native fee as msg.value. Nothing else in
+  // the UI checks the native balance, so without this guard a user with token
+  // balances but no gas token hits a raw wallet-level "insufficient funds".
+  const ensureNativeFeeBalance = useCallback(
+    async (nativeFee: bigint, account: `0x${string}`) => {
+      if (nativeFee === 0n || !publicClient) return
+      const nativeBalance = await publicClient.getBalance({ address: account })
+      if (nativeBalance < nativeFee) {
+        throw new Error(
+          `Insufficient ${nativeSymbol} for the network fee. This operation requires ` +
+            `${formatEther(nativeFee)} ${nativeSymbol} plus gas, but your balance is ` +
+            `${formatEther(nativeBalance)} ${nativeSymbol}.`
+        )
+      }
+    },
+    [publicClient, nativeSymbol]
+  )
 
   // Function to approve LMLN tokens for loan creation or extension
   const approveLoanFee = useCallback(
@@ -382,10 +449,8 @@ export const useLoanOperations = (
         args: [loansContractAddress, grossFee]
       })
 
-      // Wait for approval transaction to be confirmed
-      if (publicClient) {
-        await publicClient.waitForTransactionReceipt({ hash: approvalTxHash })
-      }
+      // Wait for approval to be confirmed and verify it didn't revert
+      await waitForSuccess(approvalTxHash, 'LMLN approval')
 
       // Refetch allowance after approval
       await refetchLmlnAllowance()
@@ -399,6 +464,7 @@ export const useLoanOperations = (
       loansContractAddress,
       approveToken,
       publicClient,
+      waitForSuccess,
       refetchLmlnAllowance
     ]
   )
@@ -415,15 +481,13 @@ export const useLoanOperations = (
         args: [cmAddress, amount]
       })
 
-      if (publicClient) {
-        await publicClient.waitForTransactionReceipt({ hash: txHash })
-      }
+      await waitForSuccess(txHash, 'Collateral approval')
 
       await refetchCollateralAllowance()
 
       return txHash
     },
-    [address, cmAddress, approveToken, publicClient, refetchCollateralAllowance]
+    [address, cmAddress, approveToken, waitForSuccess, refetchCollateralAllowance]
   )
 
   const waitAndInvalidate = useCallback(
@@ -489,6 +553,7 @@ export const useLoanOperations = (
       }
 
       const nativeFee = initiateNativeFee ?? 0n
+      await ensureNativeFeeBalance(nativeFee, address)
 
       // Pre-simulate using eth_call (not eth_estimateGas) — viem decodes custom errors properly.
       // This surfaces the real revert reason before the wallet prompt appears.
@@ -524,22 +589,23 @@ export const useLoanOperations = (
       loansContractAddress,
       publicClient,
       initiateNativeFee,
+      ensureNativeFeeBalance,
       waitAndInvalidate,
     ]
   )
 
   // Approve loan-token spending for payments. Spender is the Loans contract,
   // which is what makeLoanPayment's transferFrom pulls through. The contract
-  // pulls amount + protocol fee (FEE_BPS = 25 → 0.25%), so we gross the
-  // approval up by 1% to comfortably cover the fee — a "Pay Balance" with a
-  // bare-amount approval would otherwise revert with insufficient allowance.
+  // pulls amount + protocol fee (FEE_BPS, read from chain), so the approval
+  // must cover the gross — a "Pay Balance" with a bare-amount approval would
+  // otherwise revert with insufficient allowance.
   const approveTokenAllowance = useCallback(
     async (amount: bigint) => {
       if (!address || !loanTokenAddress || !loansContractAddress) {
         throw new Error('Missing required data for token approval')
       }
 
-      const grossAmount = amount + amount / 100n
+      const grossAmount = getGrossPaymentAmount(amount)
 
       const txHash = await approveToken({
         address: loanTokenAddress,
@@ -548,10 +614,8 @@ export const useLoanOperations = (
         args: [loansContractAddress, grossAmount]
       })
 
-      // Wait for transaction to be mined
-      if (publicClient) {
-        await publicClient.waitForTransactionReceipt({ hash: txHash })
-      }
+      // Wait for the approval to be mined and verify it didn't revert
+      await waitForSuccess(txHash, 'Token approval')
 
       // After transaction is confirmed, refetch the allowance
       await refetchAllowance()
@@ -563,8 +627,9 @@ export const useLoanOperations = (
       loanTokenAddress,
       loansContractAddress,
       approveToken,
-      refetchAllowance,
-      publicClient
+      getGrossPaymentAmount,
+      waitForSuccess,
+      refetchAllowance
     ]
   )
 
@@ -600,12 +665,12 @@ export const useLoanOperations = (
         throw new Error('Loans contract address not found')
       }
 
-      // Contract pulls amount + protocol fee (FEE_BPS = 25 → 0.25%) on
+      // Contract pulls amount + protocol fee (FEE_BPS, read from chain) on
       // makeLoanPayment, so balance and allowance must cover the gross.
-      const grossAmount = amount + amount / 100n
+      const grossAmount = getGrossPaymentAmount(amount)
 
       // Check if user has sufficient loan token balance
-      if (userLoanTokenBalance && userLoanTokenBalance < grossAmount) {
+      if (userLoanTokenBalance !== undefined && userLoanTokenBalance < grossAmount) {
         throw new Error(`Insufficient loan token balance`)
       }
 
@@ -620,6 +685,9 @@ export const useLoanOperations = (
         }
       }
 
+      const nativeFee = paymentNativeFee ?? 0n
+      await ensureNativeFeeBalance(nativeFee, address)
+
       // Pre-simulate via eth_call so contract reverts (e.g. LoanNotActive when a
       // time-based default has occurred but loanStatus() hasn't been written yet)
       // surface as decoded custom errors instead of the wallet's gas-estimation
@@ -631,49 +699,20 @@ export const useLoanOperations = (
           abi: loansAbi,
           functionName: 'makeLoanPayment',
           args: [loanId, amount],
-          value: paymentNativeFee ?? 0n,
+          value: nativeFee,
           account: address,
         })
       }
 
       const txHash = await makeLoanPayment({
         args: [loanId, amount],
-        value: paymentNativeFee ?? 0n,
+        value: nativeFee,
       })
 
-      // Wait for transaction to be confirmed
-      if (publicClient) {
-        await publicClient.waitForTransactionReceipt({ hash: txHash })
-      }
-
-      // If payment was successful, invalidate queries
-      if (txHash && address) {
-        await Promise.all([
-          // Invalidate wagmi-generated queries
-          queryClient.invalidateQueries({
-            predicate: (query) => {
-              const key = query.queryKey
-              return (
-                Array.isArray(key) &&
-                key.some(
-                  (part) =>
-                    typeof part === 'object' &&
-                    part !== null &&
-                    'args' in part &&
-                    Array.isArray(part.args) &&
-                    part.args[0] === address
-                )
-              )
-            }
-          }),
-          queryClient.invalidateQueries({ queryKey: loanKeys.all }),
-          queryClient.invalidateQueries({
-            predicate: (query) =>
-              Array.isArray(query.queryKey) && query.queryKey[0] === 'loan'
-          }),
-          queryClient.invalidateQueries()
-        ])
-      }
+      // Wait for confirmation, throw the decoded revert reason if the tx
+      // failed on-chain, and refresh all queries on success. A reverted
+      // payment must never surface as a success toast.
+      await waitAndInvalidate(txHash)
 
       return txHash
     },
@@ -685,9 +724,11 @@ export const useLoanOperations = (
       userLoanTokenBalance,
       currentAllowance,
       approveTokenAllowance,
+      getGrossPaymentAmount,
       paymentNativeFee,
+      ensureNativeFeeBalance,
       publicClient,
-      queryClient
+      waitAndInvalidate
     ]
   )
 
@@ -701,43 +742,13 @@ export const useLoanOperations = (
         args: [loanId]
       })
 
-      // Wait for transaction to be confirmed
-      if (publicClient) {
-        await publicClient.waitForTransactionReceipt({ hash: txHash })
-      }
-
-      // If withdrawal was successful, invalidate queries
-      if (txHash && address) {
-        await Promise.all([
-          // Invalidate wagmi-generated queries
-          queryClient.invalidateQueries({
-            predicate: (query) => {
-              const key = query.queryKey
-              return (
-                Array.isArray(key) &&
-                key.some(
-                  (part) =>
-                    typeof part === 'object' &&
-                    part !== null &&
-                    'args' in part &&
-                    Array.isArray(part.args) &&
-                    part.args[0] === address
-                )
-              )
-            }
-          }),
-          queryClient.invalidateQueries({ queryKey: loanKeys.all }),
-          queryClient.invalidateQueries({
-            predicate: (query) =>
-              Array.isArray(query.queryKey) && query.queryKey[0] === 'loan'
-          }),
-          queryClient.invalidateQueries()
-        ])
-      }
+      // Wait for confirmation, throw the decoded revert reason if the tx
+      // failed on-chain, and refresh all queries on success.
+      await waitAndInvalidate(txHash)
 
       return txHash
     },
-    [address, withdrawCollateral, publicClient, queryClient]
+    [address, withdrawCollateral, waitAndInvalidate]
   )
 
   // Function to extend a loan by max allowed extension
@@ -745,11 +756,25 @@ export const useLoanOperations = (
     async (loanId: `0x${string}`, extendTime: bigint) => {
       if (!address) throw new Error('Wallet not connected')
       const payer = originationPayer ?? address
+
+      // Pre-simulate so contract reverts (fee changed, loan state changed,
+      // delegate allowance short) surface as decoded errors before the wallet
+      // prompt — extendLoan was the only write without this.
+      if (publicClient && loansContractAddress) {
+        await publicClient.simulateContract({
+          address: loansContractAddress,
+          abi: loansAbi,
+          functionName: 'extendLoan',
+          args: [loanId, extendTime, payer],
+          account: address,
+        })
+      }
+
       const txHash = await extendLoanContract({ args: [loanId, extendTime, payer] })
       await waitAndInvalidate(txHash)
       return txHash
     },
-    [address, originationPayer, extendLoanContract, waitAndInvalidate]
+    [address, originationPayer, extendLoanContract, publicClient, loansContractAddress, waitAndInvalidate]
   )
 
   return {
@@ -801,6 +826,13 @@ export const useLoanOperations = (
     // Liquidity
     availableLiquidity,
     hasInsufficientLiquidity,
+
+    // Protocol fees
+    paymentFeeBps,
+    bpsDenominator,
+    getGrossPaymentAmount,
+    initiateNativeFee,
+    paymentNativeFee,
 
     // Error state
     error: calculationError || decimalsError

--- a/src/hooks/loans/useLoanOperations.ts
+++ b/src/hooks/loans/useLoanOperations.ts
@@ -22,6 +22,7 @@ import {
 import { useReadContract, useWriteContract, usePublicClient } from 'wagmi'
 import { config } from '@/src/config/wagmi'
 import { erc20Abi, formatEther } from 'viem'
+import { grossPaymentAmount } from '@/src/utils/fees'
 import { useContractTokenConfiguration } from '../useContractTokenConfiguration'
 import { useProtocolAddresses } from '../useProtocolAddresses'
 
@@ -309,8 +310,7 @@ export const useLoanOperations = (
   // Gross amount the contract pulls on makeLoanPayment: amount + fee, with the
   // fee rounded up so approvals/balance checks always cover the on-chain pull.
   const getGrossPaymentAmount = useCallback(
-    (amount: bigint) =>
-      amount + (amount * paymentFeeBps + bpsDenominator - 1n) / bpsDenominator,
+    (amount: bigint) => grossPaymentAmount(amount, paymentFeeBps, bpsDenominator),
     [paymentFeeBps, bpsDenominator]
   )
 

--- a/src/hooks/loans/useLoanPayment.ts
+++ b/src/hooks/loans/useLoanPayment.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { parseUnits } from 'viem'
 import type { Loan } from '../useLoans'
 import { LOAN_STATUS } from '@/src/constants'
 
@@ -28,12 +29,17 @@ export const useLoanPayment = (
     return loan?.remainingBalance ?? 0n
   }, [loan?.remainingBalance])
 
-  // Convert payment string to BigInt wei
+  // Convert payment string to BigInt wei. Must use parseUnits — float
+  // multiplication exceeds IEEE-754 precision at 18 decimals (1.1 * 1e18 =
+  // 1100000000000000128) and would produce a wrong payment amount.
   const parsePaymentAmount = useCallback(
     (paymentString: string): bigint => {
       if (!paymentString || isNaN(parseFloat(paymentString))) return 0n
-      const multiplier = 10 ** loanTokenDecimals
-      return BigInt(Math.floor(parseFloat(paymentString) * multiplier))
+      try {
+        return parseUnits(paymentString.trim(), loanTokenDecimals)
+      } catch {
+        return 0n
+      }
     },
     [loanTokenDecimals]
   )

--- a/src/hooks/loans/useUserLoans.ts
+++ b/src/hooks/loans/useUserLoans.ts
@@ -1,8 +1,8 @@
 import { useMemo, useCallback } from 'react'
 import { useAccount } from 'wagmi'
-import { useQueries } from '@tanstack/react-query'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import {
-  useReadLoansGetAccountLoanIds,
+  readLoansGetAccountLoanIds,
   readLoansLoans,
   readLoansLoanStatus,
   readLoansLoanPayment,
@@ -18,7 +18,6 @@ import { queryClient } from '../query/queryClient'
 import type { Loan } from '../useLoans'
 import { LOAN_STATUS, QUERY_CONFIG } from '@/src/constants'
 import { type LoanStructResponse, parseLoanStruct } from '@/src/types/contracts'
-import { usePublicClient } from 'wagmi'
 import { config } from '@/src/config/wagmi'
 
 export interface UseUserLoansReturn {
@@ -103,17 +102,45 @@ const combineLoanData = (
   }
 }
 
+const LOAN_IDS_PAGE_SIZE = 50n
+
 export const useUserLoans = (): UseUserLoansReturn => {
   const { address } = useAccount()
-  // Get user's loan IDs
+  // Get ALL of the user's loan IDs, paging through getAccountLoanIds until a
+  // short page. A single fixed-limit call would silently hide any loan past
+  // the 50th — invisible loans can't be paid and default unnoticed.
   const {
     data: loanIds,
     isLoading: loadingIds,
     error: idsError,
     refetch: refetchLoanIds
-  // @ts-ignore — wagmi codegen: "Type instantiation is excessively deep" with large ABI
-  } = useReadLoansGetAccountLoanIds({
-    args: address ? [address, 0n, 50n] : undefined
+  } = useQuery({
+    queryKey: ['accountLoanIds', address],
+    queryFn: async () => {
+      const all: `0x${string}`[] = []
+      let offset = 0n
+      for (;;) {
+        let page: readonly `0x${string}`[]
+        try {
+          page = await readLoansGetAccountLoanIds(config, {
+            args: [address!, offset, LOAN_IDS_PAGE_SIZE]
+          })
+        } catch (pageError) {
+          // The first page failing is a real error; a later page failing
+          // (e.g. out-of-range offset when the count is an exact multiple
+          // of the page size) means we've read everything.
+          if (offset === 0n) throw pageError
+          break
+        }
+        all.push(...page)
+        if (BigInt(page.length) < LOAN_IDS_PAGE_SIZE) break
+        offset += LOAN_IDS_PAGE_SIZE
+      }
+      return all
+    },
+    enabled: !!address && !!config,
+    staleTime: QUERY_CONFIG.STALE_TIME,
+    gcTime: QUERY_CONFIG.GC_TIME
   })
 
   // Create queries for each loan's data
@@ -123,7 +150,10 @@ export const useUserLoans = (): UseUserLoansReturn => {
       queryFn: async () => {
         if (!config) throw new Error('Wagmi config not available')
 
-        try {
+        // No try/catch here: a fetch failure must reach React Query so it
+        // retries and surfaces `error` — swallowing it made the loan silently
+        // vanish from the dashboard on any RPC hiccup.
+        {
           // First, get basic loan info and status (these should work for all loans)
           const [loanInfo, status] = await Promise.all([
             readLoansLoans(config, { args: [loanId] }),
@@ -180,21 +210,21 @@ export const useUserLoans = (): UseUserLoansReturn => {
             timeToDefault,
             elapsedTimeInCycle
           )
-        } catch (error) {
-          return null
         }
       },
       enabled: !!config && !!loanId,
+      retry: 2,
       staleTime: QUERY_CONFIG.STALE_TIME,
       cacheTime: QUERY_CONFIG.GC_TIME
     }))
   })
 
-  // Extract loans data
+  // Extract loans data — filter both null (loan struct missing) and
+  // undefined (query errored / still loading).
   const loans = useMemo(() => {
     return loanQueries
       .map((query) => query.data)
-      .filter((loan): loan is Loan => loan !== null)
+      .filter((loan): loan is Loan => loan != null)
   }, [loanQueries])
 
   // Aggregate loading and error states

--- a/src/hooks/loans/useUserLoans.ts
+++ b/src/hooks/loans/useUserLoans.ts
@@ -85,6 +85,7 @@ const combineLoanData = (
     collateralToken: loan.collateralToken,
     collateralAmount: loan.collateralAmount,
     loanCycleDuration: loan.loanCycleDuration,
+    balloonGraceSnapshot: loan.balloonGraceSnapshot,
 
     // Contract-derived values with defaults
     status: status ?? LOAN_STATUS.ACTIVE,

--- a/src/hooks/loans/useUserLoans.ts
+++ b/src/hooks/loans/useUserLoans.ts
@@ -1,5 +1,6 @@
 import { useMemo, useCallback } from 'react'
-import { useAccount } from 'wagmi'
+import { useAccount, useChainId } from 'wagmi'
+import { BaseError, ContractFunctionRevertedError } from 'viem'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import {
   readLoansGetAccountLoanIds,
@@ -107,6 +108,10 @@ const LOAN_IDS_PAGE_SIZE = 50n
 
 export const useUserLoans = (): UseUserLoansReturn => {
   const { address } = useAccount()
+  // Scope every cache key by chain — the wagmi-generated hooks did this
+  // automatically; without it a network switch serves the previous chain's
+  // loan IDs as fresh data against the new chain's contract.
+  const chainId = useChainId()
   // Get ALL of the user's loan IDs, paging through getAccountLoanIds until a
   // short page. A single fixed-limit call would silently hide any loan past
   // the 50th — invisible loans can't be paid and default unnoticed.
@@ -116,7 +121,7 @@ export const useUserLoans = (): UseUserLoansReturn => {
     error: idsError,
     refetch: refetchLoanIds
   } = useQuery({
-    queryKey: ['accountLoanIds', address],
+    queryKey: ['accountLoanIds', chainId, address],
     queryFn: async () => {
       const all: `0x${string}`[] = []
       let offset = 0n
@@ -128,9 +133,16 @@ export const useUserLoans = (): UseUserLoansReturn => {
           })
         } catch (pageError) {
           // The first page failing is a real error; a later page failing
-          // (e.g. out-of-range offset when the count is an exact multiple
-          // of the page size) means we've read everything.
+          // with a CONTRACT REVERT (out-of-range offset when the count is an
+          // exact multiple of the page size) means we've read everything.
+          // A transport error (RPC timeout/rate-limit) must fail the whole
+          // query so React Query retries — treating it as end-of-list would
+          // cache a silently truncated loan list as success.
           if (offset === 0n) throw pageError
+          const isRevert =
+            pageError instanceof BaseError &&
+            pageError.walk((e) => e instanceof ContractFunctionRevertedError) !== null
+          if (!isRevert) throw pageError
           break
         }
         all.push(...page)
@@ -147,7 +159,7 @@ export const useUserLoans = (): UseUserLoansReturn => {
   // Create queries for each loan's data
   const loanQueries = useQueries({
     queries: (loanIds || []).map((loanId) => ({
-      queryKey: ['loan', loanId, 'fullData'],
+      queryKey: ['loan', chainId, loanId, 'fullData'],
       queryFn: async () => {
         if (!config) throw new Error('Wagmi config not available')
 
@@ -264,12 +276,12 @@ export const useUserLoans = (): UseUserLoansReturn => {
       await Promise.all(
         loanIds.map((loanId) =>
           queryClient.invalidateQueries({
-            queryKey: ['loan', loanId, 'fullData']
+            queryKey: ['loan', chainId, loanId, 'fullData']
           })
         )
       )
     }
-  }, [refetchLoanIds, loanIds, queryClient])
+  }, [refetchLoanIds, loanIds, chainId, queryClient])
 
   return {
     loans,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -67,6 +67,13 @@ export interface UseLoansReturn {
   availableLiquidity: bigint | undefined
   hasInsufficientLiquidity: boolean
 
+  // Protocol fees (read from chain)
+  paymentFeeBps: bigint
+  bpsDenominator: bigint
+  getGrossPaymentAmount: (amount: bigint) => bigint
+  initiateNativeFee: bigint | undefined
+  paymentNativeFee: bigint | undefined
+
   // Contract addresses
   loansContractAddress: `0x${string}` | undefined
 

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -88,4 +88,7 @@ export interface UseLoansReturn {
 
   // Combined error state
   error: Error | null
+
+  // Loan-config-only error (excludes per-loan read failures)
+  configError: Error | null
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -7,6 +7,9 @@ import type {
 export interface UseLoansOptions {
   loanRequest?: LoanRequest
   selectedLtvOption?: { ltv: bigint; fee: bigint }
+  /** Address that will be charged the LMLN origination fee. Defaults to the
+   *  connected wallet (borrower self-pays). */
+  originationPayer?: `0x${string}`
 }
 
 export interface UseLoansReturn {
@@ -39,6 +42,7 @@ export interface UseLoansReturn {
   // Loan creation & simulation data
   requiredCollateral: bigint | undefined
   hasInsufficientLmln: boolean
+  hasInsufficientCollateral: boolean
   grossOriginationFee: bigint | undefined
   calculationData:
     | {
@@ -54,6 +58,7 @@ export interface UseLoansReturn {
   // User balance info
   userLmlnBalance: bigint | undefined
   userLoanTokenBalance: bigint | undefined
+  userCollateralBalance: bigint | undefined
   currentAllowance: bigint | undefined
   currentLmlnAllowance: bigint | undefined
   currentCollateralAllowance: bigint | undefined

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -162,7 +162,10 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
       userData.isLoading || operations.isTransacting || config.isLoading,
 
     // Combined error state
-    error: userData.error || operations.error || config.error
+    error: userData.error || operations.error || config.error,
+    // Config-only error — the calculator must not hard-fail on a per-loan
+    // read error (userData.error), which is unrelated to creating new loans.
+    configError: config.error
   }
 }
 

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -34,6 +34,7 @@ export interface Loan {
   // Computed helper properties (derived from contract data)
   originalDuration: bigint // Duration at loan creation (max allowed extension)
   loanCycleDuration: bigint // From loans struct — used for adaptive countdown buffer
+  balloonGraceSnapshot: bigint // Grace window captured at creation (0 for pre-upgrade loans)
   remainingBalance: bigint // Calculated from contract values, not manually
   dueTimestamp: bigint // Calculated from timeToDefault
 }
@@ -49,19 +50,26 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
   // though makeLoanPayment will revert with LoanNotActive. Compute an
   // effective status here so the UI reflects reality: badge as Defaulted,
   // drop from active list, and prevent the doomed payment flow.
-  const grace = config.loanConfig?.balloonPaymentGraceDuration ?? 0n
+  //
+  // Grace comes from the loan's own snapshot (fixed at creation) so an admin
+  // change to the global config can't retroactively re-badge existing loans.
+  // Loans created before the upgrade that added the snapshot read 0 — fall
+  // back to the global config for those.
+  const globalGrace = config.loanConfig?.balloonPaymentGraceDuration ?? 0n
   const effectiveLoans = useMemo(() => {
     const nowSec = BigInt(Math.floor(Date.now() / 1000))
     return userData.loans.flatMap((loan) => {
       if (!loan) return []
       if (loan.status !== LOAN_STATUS.ACTIVE) return [loan]
+      const grace =
+        loan.balloonGraceSnapshot > 0n ? loan.balloonGraceSnapshot : globalGrace
       const defaultAt = loan.createdAt + loan.duration + grace
       if (nowSec >= defaultAt) {
         return [{ ...loan, status: LOAN_STATUS.DEFAULT }]
       }
       return [loan]
     })
-  }, [userData.loans, grace])
+  }, [userData.loans, globalGrace])
 
   const activeLoans = useMemo(
     () =>

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -111,12 +111,14 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
     // Loan creation & simulation data
     requiredCollateral: operations.requiredCollateral,
     hasInsufficientLmln: operations.hasInsufficientLmln,
+    hasInsufficientCollateral: operations.hasInsufficientCollateral,
     grossOriginationFee: operations.grossOriginationFee,
     calculationData: operations.calculationData,
 
     // User balance info
     userLmlnBalance: operations.userLmlnBalance,
     userLoanTokenBalance: operations.userLoanTokenBalance,
+    userCollateralBalance: operations.userCollateralBalance,
     currentAllowance: operations.currentAllowance,
     currentLmlnAllowance: operations.currentLmlnAllowance,
     currentCollateralAllowance: operations.currentCollateralAllowance,

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -127,6 +127,13 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
     availableLiquidity: operations.availableLiquidity,
     hasInsufficientLiquidity: operations.hasInsufficientLiquidity,
 
+    // Protocol fees
+    paymentFeeBps: operations.paymentFeeBps,
+    bpsDenominator: operations.bpsDenominator,
+    getGrossPaymentAmount: operations.getGrossPaymentAmount,
+    initiateNativeFee: operations.initiateNativeFee,
+    paymentNativeFee: operations.paymentNativeFee,
+
     // Contract addresses
     loansContractAddress: operations.loansContractAddress,
 

--- a/src/hooks/useLoans.ts
+++ b/src/hooks/useLoans.ts
@@ -3,6 +3,7 @@ import { useUserLoans } from './loans/useUserLoans'
 import { useLoanOperations } from './loans/useLoanOperations'
 import { useLoanConfig } from './loans/useLoanConfig'
 import { LOAN_STATUS } from '@/src/constants'
+import { isPastDefault } from '@/src/utils/loanStatus'
 import type { UseLoansOptions, UseLoansReturn } from './types'
 export type { LoanRequest } from './loans/useLoanOperations'
 
@@ -61,10 +62,15 @@ export const useLoans = (options?: UseLoansOptions): UseLoansReturn => {
     return userData.loans.flatMap((loan) => {
       if (!loan) return []
       if (loan.status !== LOAN_STATUS.ACTIVE) return [loan]
-      const grace =
-        loan.balloonGraceSnapshot > 0n ? loan.balloonGraceSnapshot : globalGrace
-      const defaultAt = loan.createdAt + loan.duration + grace
-      if (nowSec >= defaultAt) {
+      if (
+        isPastDefault(
+          loan.createdAt,
+          loan.duration,
+          loan.balloonGraceSnapshot,
+          globalGrace,
+          nowSec
+        )
+      ) {
         return [{ ...loan, status: LOAN_STATUS.DEFAULT }]
       }
       return [loan]

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -14,6 +14,7 @@ export interface LoanStructResponse {
   readonly [10]: bigint // originationFee
   readonly [11]: bigint // collateralAmount
   readonly [12]: bigint // loanCycleDuration
+  readonly [13]: bigint // balloonGraceSnapshot
 }
 
 export interface LoanConfigResponse {
@@ -46,7 +47,11 @@ export function parseLoanStruct(data: LoanStructResponse) {
     ltv: data[9],
     originationFee: data[10],
     collateralAmount: data[11],
-    loanCycleDuration: data[12]
+    loanCycleDuration: data[12],
+    // Grace window captured at loan creation. Loans created before the
+    // contract upgrade that added this field read 0 — callers must fall
+    // back to the global loanConfig.balloonPaymentGraceDuration for those.
+    balloonGraceSnapshot: data[13] ?? 0n
   }
 }
 

--- a/src/utils/decimals.ts
+++ b/src/utils/decimals.ts
@@ -39,10 +39,12 @@ export function formatPercentage(value: bigint, decimals: number): string {
   if (value < 0n) {
     throw new DecimalError('Percentage value cannot be negative')
   }
-  // Convert to decimal then multiply by 100 to get percentage
+  // Convert to decimal then multiply by 100 to get percentage. Keep up to
+  // two decimal places — rounding to a whole percent would display a 12.5%
+  // APR as 13% and break matching against non-integer LTV tiers.
   const decimal = formatUnits(value, decimals)
-  const percentage = Math.round(Number(decimal) * 100).toString()
-  return percentage
+  const percentage = Math.round(Number(decimal) * 10000) / 100
+  return percentage.toString()
 }
 
 /**

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -2,6 +2,20 @@
  * Utility functions for consistent error handling across the application
  */
 
+import { decodeErrorResult, toFunctionSelector } from 'viem'
+import type { Abi } from 'viem'
+
+/** The `error` entries of an ABI (viem doesn't re-export abitype's AbiError). */
+type AbiErrorItem = Extract<Abi[number], { type: 'error' }>
+import {
+  loansAbi,
+  liquidityPoolAbi,
+  priceDataFeedAbi,
+  priceHelperAbi,
+  collateralManagerAbi
+} from '@/src/generated'
+import defaultLiquidatorAbiJson from '@/src/abis/DefaultLiquidator.json'
+
 export interface ContractError {
   message: string
   reason?: string
@@ -36,13 +50,13 @@ const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   NativeFeeTransferFailed: 'Failed to transfer the required network fee.',
   NoEarningsAvailable: 'No earnings available to claim.',
   NotRequestOwner: 'You do not own this withdrawal request.',
-  PrincipalUnhealthy: 'Pool principal is unhealthy — the deficit must be resolved before this action is allowed.',
   Unauthorized: 'You are not authorized to perform this action.',
   UtilizationBelowThreshold: 'Pool utilization is below the required threshold for this action.',
   WithdrawalAlreadyClaimed: 'This withdrawal has already been claimed.',
   WithdrawalNotFullyFunded: 'Withdrawal has not been fully funded yet.',
   WithdrawalRequestNotFound: 'Withdrawal request not found.',
   // Loans
+  AlreadySet: 'This value has already been set.',
   ArrayMismatch: 'Input arrays must be the same length.',
   BadIndex: 'Invalid index provided.',
   BadPrice: 'Invalid price data received.',
@@ -54,26 +68,20 @@ const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   FirstPaymentTooLarge: 'First payment exceeds the allowed amount.',
   InsufficientBalance: 'Insufficient token balance.',
   InsufficientCollateral: 'Insufficient collateral — please check your LMLN balance.',
-  InsufficientLiquidity: 'Insufficient liquidity in the pool.',
   InvalidAPR: 'Invalid APR configuration.',
   InvalidConfiguration: 'Invalid contract configuration.',
   InvalidDecimals: 'Invalid token decimal configuration.',
   InvalidDuration: 'Invalid loan duration selected.',
-  InvalidLoanId: 'Invalid loan ID.',
   InvalidLTV: 'Invalid LTV selected.',
   InvalidMarketValue: 'Invalid market value — the price feed may be returning an unexpected value.',
   InvalidRange: 'Invalid range configuration.',
-  LoanAlreadyExists: 'A loan with this ID already exists.',
-  LoanAlreadyWithdrawn: 'Collateral for this loan has already been withdrawn.',
   LoanAmountExceedsMax: 'Loan amount exceeds the maximum allowed.',
   LoanLocked: 'This loan is currently locked and cannot be modified.',
   LoanNotActive: 'This loan is no longer active — it may have defaulted or already been paid off.',
-  LoanNotDefaulted: 'This loan has not defaulted.',
   LoanNotFound: 'Loan not found.',
   NoFeePrice: 'No fee price is configured.',
   NotDivisible: 'Amount must be evenly divisible by the payment cycle.',
   OriginationDelegateNotAuthorized: "That wallet hasn't authorized you to pay its fees.",
-  PaymentTooLow: 'Payment amount is too low.',
   RangeOverlap: 'Configuration ranges must not overlap.',
   SameAddress: 'Source and destination addresses must be different.',
   TooLarge: 'Value exceeds the maximum allowed.',
@@ -81,89 +89,103 @@ const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   UnauthorizedUser: 'You are not authorized to perform this action.',
   ZeroCycles: 'Loan must have at least one payment cycle.',
   // PriceDataFeed
+  InsufficientHistoryData: 'The price feed does not have enough history yet — please try again later.',
+  InvalidHistoricalData: 'The price feed returned invalid historical data.',
+  InvalidPriceData: 'The price feed returned invalid price data.',
+  PriceDeviationTooHigh: 'The price moved too much between updates — please wait for the next price update.',
   PriceStale: 'Price data is stale — the LMLN price feed needs to be updated before this operation can proceed.',
+  SeedingPeriodEnded: 'The price feed seeding period has ended.',
   TokenNotSupported: 'This token is not supported by the price feed.',
+  UpdateTooFrequent: 'Price updates are happening too frequently — please wait a moment.',
+  // PriceHelper
+  NoPriceAvailable: 'No price is available for this token — the price feed may need updating.',
+  // CollateralManager
+  AmountExceedsRecord: 'Amount exceeds the recorded collateral for this loan.',
+  AssetNotAllowed: 'This token is not accepted as collateral.',
+  LoanRecordInactive: 'The collateral record for this loan is no longer active.',
+  LoanRecordNotFound: 'No collateral record found for this loan.',
+  OnlyDefaultLiquidator: 'This action can only be performed by the liquidator contract.',
+  OnlyPriceHelperConfigured: 'Collateral pricing is not configured yet.',
   // DefaultLiquidator
-  BufferTooHigh: 'Liquidation buffer is set too high.',
-  EmptySlot: 'Swap slot is empty.',
+  AssetAlreadyRegistered: 'This asset is already registered with the liquidator.',
+  AssetNotRegistered: 'This asset is not registered with the liquidator.',
   InvalidSlotIndex: 'Invalid swap slot index.',
   NoPendingCollateral: 'No pending collateral to liquidate.',
   NoProceeds: 'No proceeds available to pull.',
+  OnlyCollateralManager: 'This action can only be called by the CollateralManager contract.',
   OnlyLoans: 'This action can only be called by the Loans contract.',
   SlotBusy: 'Swap slot is already in use.',
   TooSoon: 'Cannot create a new swap yet — please wait for the creation interval.',
 }
 
 /**
- * Map of 4-byte error selectors to error names.
- * Used when viem cannot decode the error because it's from a contract not in the call's ABI
- * (e.g. PriceDataFeed errors surfacing through Loans).
+ * Every custom error across all protocol contracts, sourced directly from the
+ * ABIs so selectors and argument shapes can never drift from what's deployed.
+ * Used to decode revert data when viem cannot (e.g. a PriceDataFeed error
+ * surfacing through a Loans call, or a raw eth_call with no ABI attached).
  */
-const ERROR_SELECTOR_MAP: Record<string, string> = {
-  '0xf71e7ad5': 'PriceStale',
-  '0x06439c6b': 'TokenNotSupported',
-  '0x2a1a8a3d': 'InsufficientHistoryData',
-  '0xea70e3dd': 'InvalidHistoricalData',
-  '0xda24832a': 'InvalidPriceData',
-  '0x8e047e66': 'PriceDeviationTooHigh',
-  '0xd159c917': 'SeedingPeriodEnded',
-  '0x147e7c67': 'UpdateTooFrequent',
-  // Loans errors surfacing through LiquidityPool contract calls
-  '0xb7c1140d': 'ArrayMismatch',
-  '0xef3ff4ae': 'BadIndex',
-  '0xfd1ee349': 'BadPrice',
-  '0xa64c4b6d': 'ConfigExists',
-  '0x94537346': 'ConfigNotFound',
-  '0xa3095eff': 'DecimalsTooHigh',
-  '0x521299a9': 'EmptyArray',
-  '0x3c6690e6': 'ExcessivePayment',
-  '0x2a869bc2': 'FirstPaymentTooLarge',
-  '0xf4d678b8': 'InsufficientBalance',
-  '0x3a23d825': 'InsufficientCollateral',
-  '0xf3f77567': 'InvalidAPR',
-  '0xc52a9bd3': 'InvalidConfiguration',
-  '0xd25598a0': 'InvalidDecimals',
-  '0x76166401': 'InvalidDuration',
-  '0x5e544952': 'InvalidLTV',
-  '0x4ad34ed1': 'InvalidMarketValue',
-  '0x561ce9bb': 'InvalidRange',
-  '0x43d9fbcd': 'LoanAlreadyWithdrawn',
-  '0x272e04e6': 'LoanAmountExceedsMax',
-  '0xf04e38bc': 'LoanLocked',
-  '0x082f7846': 'LoanNotActive',
-  '0x0e7e621d': 'LoanNotFound',
-  '0xa710449c': 'NoFeePrice',
-  '0x5ed1c7e5': 'NotDivisible',
-  '0x2ec0d7b3': 'OriginationDelegateNotAuthorized',
-  '0xee1aff09': 'RangeOverlap',
-  '0x367558c3': 'SameAddress',
-  '0x218e0a07': 'TooLarge',
-  '0x90b8ec18': 'TransferFailed',
-  '0x02a43f8b': 'UnauthorizedUser',
-  '0xb00b9d4c': 'ZeroCycles',
-  // LiquidityPool errors surfacing through Loans contract calls
-  '0x5bbe8622': 'BelowMinimumDeposit',
-  '0x8af3e600': 'AccountEmpty',
-  '0xb4b1eeef': 'AccountNotEmpty',
-  '0x9fabe1c1': 'AddressZero',
-  '0x981a2a2b': 'AssetNotSupported',
-  '0x5872f81f': 'EarningsTooEarly',
-  '0x9c92bdfb': 'InsufficientNativeFee',
-  '0x9a127468': 'InsufficientUnlocked',
-  '0x2c5211c6': 'InvalidAmount',
-  '0x7a12c6d2': 'InvalidTierDuration',
-  '0x255b3821': 'InvalidTierIndex',
-  '0x2cbdee5f': 'InvalidTierMultiplier',
-  '0x8b340986': 'LockDurationNotAvailable',
-  '0x83da747e': 'LockTierDisabled',
-  '0xb6db9972': 'NativeFeeTransferFailed',
-  '0x996d783e': 'NoEarningsAvailable',
-  '0x517907dd': 'NotRequestOwner',
-  '0x82b42900': 'Unauthorized',
-  '0xb222c964': 'UtilizationBelowThreshold',
-  '0x2f29b3db': 'WithdrawalAlreadyClaimed',
-  '0xb9b49203': 'WithdrawalNotFullyFunded',
-  '0x514447b5': 'WithdrawalRequestNotFound',
+const ALL_CONTRACT_ERRORS: AbiErrorItem[] = [
+  loansAbi,
+  liquidityPoolAbi,
+  priceDataFeedAbi,
+  priceHelperAbi,
+  collateralManagerAbi,
+  defaultLiquidatorAbiJson as Abi
+].flatMap((abi) =>
+  (abi as Abi).filter((item): item is AbiErrorItem => item.type === 'error')
+)
+
+/**
+ * 4-byte selector → error name, computed from the ABIs at module load.
+ * Covers the case where only the selector (no argument data) is available.
+ */
+const ERROR_SELECTOR_MAP: Record<string, string> = Object.fromEntries(
+  ALL_CONTRACT_ERRORS.map((err) => [
+    toFunctionSelector(
+      `${err.name}(${(err.inputs || []).map((i) => i.type).join(',')})`
+    ).toLowerCase(),
+    err.name
+  ])
+)
+
+/**
+ * Decode raw revert data (selector + encoded args) against the combined ABI.
+ * Falls back to a selector-only lookup for parameterized errors whose argument
+ * data is missing or malformed. Returns null when nothing matches.
+ */
+function decodeRevertData(
+  data: string
+): { errorName: string; args?: readonly unknown[] } | null {
+  if (!/^0x[0-9a-fA-F]{8,}$/.test(data)) return null
+  try {
+    const decoded = decodeErrorResult({
+      abi: ALL_CONTRACT_ERRORS,
+      data: data as `0x${string}`
+    })
+    return { errorName: decoded.errorName, args: decoded.args }
+  } catch {
+    const name = ERROR_SELECTOR_MAP[data.slice(0, 10).toLowerCase()]
+    return name ? { errorName: name } : null
+  }
+}
+
+/**
+ * Walk an error's cause chain collecting anything that looks like raw revert
+ * data. Viem surfaces it in different places depending on the call path:
+ * `data` as a hex string (raw RPC errors), `data.data` (nested provider
+ * shapes), or embedded in message text.
+ */
+function findRevertDataCandidates(err: unknown, depth = 0, out: string[] = []): string[] {
+  if (!err || depth > 10 || typeof err !== 'object') return out
+  const e = err as Record<string, unknown>
+  if (typeof e['data'] === 'string' && e['data'].startsWith('0x')) {
+    out.push(e['data'])
+  } else if (e['data'] && typeof e['data'] === 'object') {
+    const nested = (e['data'] as Record<string, unknown>)['data']
+    if (typeof nested === 'string' && nested.startsWith('0x')) out.push(nested)
+  }
+  if (e['cause']) findRevertDataCandidates(e['cause'], depth + 1, out)
+  return out
 }
 
 /**
@@ -187,14 +209,26 @@ function findRevertedError(
 }
 
 /**
- * Check if an error is a user rejection (cancelled transaction)
+ * Check if an error is a user rejection (cancelled transaction).
+ * Wallets vary widely here: MetaMask says "User rejected"/"User denied",
+ * WalletConnect wallets emit "User canceled" or "Transaction declined", and
+ * some providers nest the EIP-1193 code 4001 (or viem's
+ * UserRejectedRequestError) inside the cause chain rather than at top level.
  */
 export const isUserRejection = (error: ContractError): boolean => {
-  return (
-    error?.message?.includes('User rejected') ||
-    error?.message?.includes('User denied') ||
-    error?.code === 4001
-  )
+  const rejectionText =
+    /user (rejected|denied|cancell?ed)|rejected the request|transaction (was )?declined|request rejected/i
+
+  let current: unknown = error
+  for (let depth = 0; current && typeof current === 'object' && depth <= 10; depth++) {
+    const e = current as Record<string, unknown>
+    if (e['code'] === 4001) return true
+    if (e['name'] === 'UserRejectedRequestError') return true
+    if (typeof e['message'] === 'string' && rejectionText.test(e['message'])) return true
+    if (typeof e['shortMessage'] === 'string' && rejectionText.test(e['shortMessage'])) return true
+    current = e['cause']
+  }
+  return false
 }
 
 /**
@@ -280,29 +314,50 @@ function translateTokenRevert(reason: string): string | null {
 }
 
 /**
+ * Turn a decoded custom error (name + args) into a user-facing message.
+ * Handles the Solidity built-ins `Error(string)` and `Panic(uint256)`.
+ */
+function messageForDecodedError(
+  errorName: string,
+  args?: readonly unknown[]
+): string {
+  // Standard Solidity `Error(string)` revert — the human-readable reason
+  // lives in args[0]. Without this branch we'd render "Contract error: Error".
+  if (errorName === 'Error') {
+    const reason = args?.[0]
+    if (typeof reason === 'string' && reason.length > 0) {
+      return translateTokenRevert(reason) ?? reason
+    }
+  }
+  // Standard Solidity `Panic(uint256)` — internal compiler-emitted reverts.
+  if (errorName === 'Panic') {
+    return 'The contract hit an internal error (Solidity panic).'
+  }
+  const friendly = CONTRACT_ERROR_MESSAGES[errorName]
+  return friendly ?? `Contract error: ${errorName}`
+}
+
+/**
  * Extract meaningful error message from contract error
  */
 export const extractErrorMessage = (error: ContractError): string => {
   // 1. Walk the viem cause chain for a decoded revert (cleanest path)
   const revertError = findRevertedError(error)
   if (revertError) {
-    // Standard Solidity `Error(string)` revert — the human-readable reason
-    // lives in args[0]. Without this branch we'd render "Contract error: Error".
-    if (revertError.errorName === 'Error') {
-      const reason = revertError.args?.[0]
-      if (typeof reason === 'string' && reason.length > 0) {
-        return translateTokenRevert(reason) ?? reason
-      }
-    }
-    // Standard Solidity `Panic(uint256)` — internal compiler-emitted reverts.
-    if (revertError.errorName === 'Panic') {
-      return 'The contract hit an internal error (Solidity panic).'
-    }
-    const friendly = CONTRACT_ERROR_MESSAGES[revertError.errorName]
-    return friendly ?? `Contract error: ${revertError.errorName}`
+    return messageForDecodedError(revertError.errorName, revertError.args)
   }
 
-  // 2. Collect all text from the full error / cause chain and scan for known names.
+  // 2. Raw revert data anywhere in the cause chain — covers raw eth_call
+  //    errors (no ABI attached, viem reports "Execution reverted for an
+  //    unknown reason") and sub-contract errors absent from the call's ABI.
+  for (const candidate of findRevertDataCandidates(error)) {
+    const decoded = decodeRevertData(candidate)
+    if (decoded) {
+      return messageForDecodedError(decoded.errorName, decoded.args)
+    }
+  }
+
+  // 3. Collect all text from the full error / cause chain and scan for known names.
   //    Handles cases where the RPC doesn't return decoded revert data, but viem still
   //    includes the error name as a string somewhere (e.g. "Error: InsufficientNativeFee()").
   const allText = collectErrorText(error)
@@ -311,19 +366,19 @@ export const extractErrorMessage = (error: ContractError): string => {
     return CONTRACT_ERROR_MESSAGES[errorNameInText]!
   }
 
-  // 3. Unknown selector — viem couldn't decode because the error is from a sub-contract
-  //    not in the call's ABI (e.g. PriceDataFeed errors bubbling through Loans).
-  const selectorMatch = allText.match(/reverted with the following signature:\s*(0x[0-9a-fA-F]{8})/)
-  if (selectorMatch) {
-    const selector = selectorMatch[1].toLowerCase()
-    const errorName = ERROR_SELECTOR_MAP[selector]
-    if (errorName) {
-      const friendly = CONTRACT_ERROR_MESSAGES[errorName]
-      return friendly ?? `Contract error: ${errorName}`
+  // 4. Revert data that only appears inside message text. Matches both viem's
+  //    "reverted with the following signature: 0x…" phrasing and bare hex
+  //    revert payloads (selector, or selector + 32-byte-aligned args).
+  for (const match of allText.matchAll(/0x[0-9a-fA-F]{8,}/g)) {
+    const hex = match[0]
+    if ((hex.length - 10) % 64 !== 0) continue // not selector(+args)-shaped
+    const decoded = decodeRevertData(hex)
+    if (decoded) {
+      return messageForDecodedError(decoded.errorName, decoded.args)
     }
   }
 
-  // 4. Gas estimation / simulation errors — try to extract a revert reason string
+  // 5. Gas estimation / simulation errors — try to extract a revert reason string
   if (isGasEstimationError(error)) {
     const revertMatch = allText.match(/reverted with the following reason:\s*(.+?)(?:\n|$)/)
     if (revertMatch && !isGasCapMessage(revertMatch[1].trim())) {

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -421,7 +421,7 @@ export const handleContractError = (
     description: string
     variant?: 'destructive'
   }) => void,
-  successTitle: string = 'Operation Failed'
+  errorTitle: string = 'Operation Failed'
 ): void => {
   // Don't show error toast for user rejections - user knows they cancelled
   if (isUserRejection(error)) {
@@ -439,7 +439,7 @@ export const handleContractError = (
   const errorMessage = extractErrorMessage(error)
 
   showToast({
-    title: successTitle,
+    title: errorTitle,
     description: errorMessage,
     variant: 'destructive'
   })

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -72,6 +72,7 @@ const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   LoanNotFound: 'Loan not found.',
   NoFeePrice: 'No fee price is configured.',
   NotDivisible: 'Amount must be evenly divisible by the payment cycle.',
+  OriginationDelegateNotAuthorized: "That wallet hasn't authorized you to pay its fees.",
   PaymentTooLow: 'Payment amount is too low.',
   RangeOverlap: 'Configuration ranges must not overlap.',
   SameAddress: 'Source and destination addresses must be different.',
@@ -133,6 +134,7 @@ const ERROR_SELECTOR_MAP: Record<string, string> = {
   '0x0e7e621d': 'LoanNotFound',
   '0xa710449c': 'NoFeePrice',
   '0x5ed1c7e5': 'NotDivisible',
+  '0x2ec0d7b3': 'OriginationDelegateNotAuthorized',
   '0xee1aff09': 'RangeOverlap',
   '0x367558c3': 'SameAddress',
   '0x218e0a07': 'TooLarge',
@@ -249,12 +251,53 @@ function findErrorNameInText(text: string): string | null {
 }
 
 /**
+ * Translate awkward token-contract revert strings into plain English.
+ * Catches both standard OpenZeppelin patterns and the WLEMX-style "amount <
+ * balance" wording. Returns null when nothing matches.
+ */
+function translateTokenRevert(reason: string): string | null {
+  // Most ERC20 reverts prefix the symbol (e.g. "WLEMX: ...", "ERC20: ...").
+  const prefixMatch = reason.match(/^([A-Za-z0-9]+):\s*(.+)$/)
+  const symbol = prefixMatch ? prefixMatch[1] : null
+  const rest = prefixMatch ? prefixMatch[2] : reason
+  const tokenLabel = symbol && symbol !== 'ERC20' ? symbol : 'tokens'
+
+  // Insufficient balance — covers "amount < balance" (LMLN/WLEMX phrasing),
+  // "exceeds balance" (OpenZeppelin), and similar variants.
+  if (
+    /amount\s*<\s*balance|exceeds\s+balance|insufficient\s+balance|transfer\s+amount\s+exceeds\s+balance/i.test(
+      rest
+    )
+  ) {
+    return `Not enough ${tokenLabel} in your wallet for this transaction.`
+  }
+  // Insufficient allowance — covers OpenZeppelin's "insufficient allowance"
+  // and custom variants like "amount > allowance".
+  if (/insufficient\s+allowance|amount\s*>\s*allowance|exceeds\s+allowance/i.test(rest)) {
+    return `Your ${tokenLabel} approval isn't large enough for this transaction.`
+  }
+  return null
+}
+
+/**
  * Extract meaningful error message from contract error
  */
 export const extractErrorMessage = (error: ContractError): string => {
-  // 1. Walk the viem cause chain for a decoded custom error (cleanest path)
+  // 1. Walk the viem cause chain for a decoded revert (cleanest path)
   const revertError = findRevertedError(error)
   if (revertError) {
+    // Standard Solidity `Error(string)` revert — the human-readable reason
+    // lives in args[0]. Without this branch we'd render "Contract error: Error".
+    if (revertError.errorName === 'Error') {
+      const reason = revertError.args?.[0]
+      if (typeof reason === 'string' && reason.length > 0) {
+        return translateTokenRevert(reason) ?? reason
+      }
+    }
+    // Standard Solidity `Panic(uint256)` — internal compiler-emitted reverts.
+    if (revertError.errorName === 'Panic') {
+      return 'The contract hit an internal error (Solidity panic).'
+    }
     const friendly = CONTRACT_ERROR_MESSAGES[revertError.errorName]
     return friendly ?? `Contract error: ${revertError.errorName}`
   }
@@ -328,6 +371,14 @@ export const handleContractError = (
   // Don't show error toast for user rejections - user knows they cancelled
   if (isUserRejection(error)) {
     return
+  }
+
+  // Surface the full error shape in dev so we can see exactly what the RPC
+  // returned (selector, decoded errorName, cause chain). Production builds
+  // strip this out via NODE_ENV checks bundled by Next.
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.error('[contract error]', error)
   }
 
   const errorMessage = extractErrorMessage(error)

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -1,0 +1,18 @@
+/**
+ * Protocol fee math shared by the payment flow (hook + dialog display).
+ * Kept pure so the exact amounts users are charged are unit-testable.
+ */
+
+/**
+ * Gross amount the Loans contract pulls on makeLoanPayment: the payment
+ * plus the protocol fee (FEE_BPS), with the fee rounded UP so approvals
+ * and balance checks always cover the on-chain transfer.
+ */
+export function grossPaymentAmount(
+  amount: bigint,
+  feeBps: bigint,
+  bpsDenominator: bigint
+): bigint {
+  if (bpsDenominator === 0n) return amount
+  return amount + (amount * feeBps + bpsDenominator - 1n) / bpsDenominator
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -7,6 +7,17 @@ export const formatAmount = (amount: bigint, decimals = 18): string => {
   return formatTokenAmount(amount, decimals)
 }
 
+/**
+ * Floor a value to N decimal places for display. Balances and receivable
+ * amounts must round DOWN — half-up rounding shows users money they don't
+ * quite have (99.996 renders as "100.00", and typing that back in then fails
+ * the exact-amount balance check).
+ */
+export const floorToDecimals = (value: number, decimals: number): number => {
+  const factor = 10 ** decimals
+  return Math.floor(value * factor) / factor
+}
+
 export const formatAmountWithSymbol = (
   amount: bigint,
   symbol: string,

--- a/src/utils/loanStatus.ts
+++ b/src/utils/loanStatus.ts
@@ -1,0 +1,42 @@
+/**
+ * Effective loan default timing, shared by useLoans (status override) and
+ * the ActiveLoans countdown. Kept pure so the exact moment the UI flips a
+ * loan to Defaulted is unit-testable.
+ */
+
+/**
+ * The grace window that applies to a specific loan: its creation-time
+ * snapshot when present, otherwise the global config value. Loans created
+ * before the contract upgrade that added the snapshot read 0 there.
+ */
+export function resolveGraceDuration(
+  balloonGraceSnapshot: bigint,
+  globalGrace: bigint
+): bigint {
+  return balloonGraceSnapshot > 0n ? balloonGraceSnapshot : globalGrace
+}
+
+/** Absolute timestamp (seconds) at which a loan defaults. */
+export function loanDefaultTimestamp(
+  createdAt: bigint,
+  duration: bigint,
+  grace: bigint
+): bigint {
+  return createdAt + duration + grace
+}
+
+/**
+ * True when an ACTIVE-per-contract loan has actually passed its default
+ * moment. The contract's stored status only changes when a state-writing
+ * function runs, so the UI must compute this itself.
+ */
+export function isPastDefault(
+  createdAt: bigint,
+  duration: bigint,
+  balloonGraceSnapshot: bigint,
+  globalGrace: bigint,
+  nowSec: bigint
+): boolean {
+  const grace = resolveGraceDuration(balloonGraceSnapshot, globalGrace)
+  return nowSec >= loanDefaultTimestamp(createdAt, duration, grace)
+}


### PR DESCRIPTION
## Release scope

16 commits, ~45 files. The full production-readiness effort: four-dimension audit → P0/P1/P2 fixes (PRs #28, #29, #31) → 219-test QA suite → modal-consistency pass → high-effort release audit with all confirmed findings fixed.

### Highlights
- **Transaction truthfulness**: every write checks `receipt.status`; reverted txs can never show a success toast
- **ABI-driven error decoding**: revert reasons decode from all six contract ABIs wherever they appear; 9 wrong selectors eliminated; every contract error has a human-readable message (enforced by CI-failing tests)
- **Fee transparency**: protocol fee (FEE_BPS from chain), origination fee, and native network fee disclosed in every confirm modal before signing; native-balance guards
- **Config-change safety**: per-loan `balloonGraceSnapshot`, exact LTV tier values on-chain, chain-scoped caches, contract-read utilization
- **Consistent modal contract**: all 13 transaction dialogs stay open with spinner during the tx, block dismissal mid-flight, close on success
- **QA**: 219 tests incl. ABI drift guards (a contract regen that reorders tuples or adds unmapped errors fails the build)
- **Release audit (final commit)**: 8 confirmed bugs found by an 8-angle adversarial review of this very diff, all fixed — incl. a delegate approve-loop, chain-switch cache staleness, and pagination truncation

### Pre-merge checklist
- [x] Final smoke test on develop preview (payment fee breakdown, LP deposit/claim via new claim modal, loan creation steps display, delegation flow)
- [x] ~~Delegation mapping order verified on testnet~~ **Verified 2026-07-17**: delegation set from payer wallet → Delegation Manager and borrower-side payer field both immediately reflect the authorized state — `originationDelegations[payer][borrower]` order confirmed
- [x] ~~Mainnet config per docs/mainnet-setup.md~~ **Verified on-chain 2026-07-17** against the BSC production contract (`0x2E03…921D`, chain 56): upgraded to new ABI (14-field struct, delegation present), unpaused, price feed live, fee tiers confirmed whole-USD ($100 tier charges 865,651 LMLN ≈ $91.74 at spot)
- [x] Cloudflare **production** env: `NEXT_PUBLIC_SUPPORTED_CHAINS=56` and `NEXT_PUBLIC_BSC_LOANS_ADDRESS=0x2E03E03f346b034F2FaE3212B89cA246e4D0921D` (baked in at build time; the LemonChain 1006 address is a dead placeholder — fine as long as 1006 isn't in prod's supported chains)

### Verification
- `vitest` 219/219 · `tsc --noEmit` clean · `next lint` 0 errors · production build passes (6GB heap baked into build script after the Cloudflare OOM)

### Known accepted risk
`FEE_BPS ?? 25n` fallback during an unresolved read narrows the old blanket 1% approval margin — fail-closed (pre-simulation catches it), impossible at current on-chain values; revisit if governance changes FEE_BPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

