### PR TITLE
fix: credit the wallet's existing sponsor when the referral link disagrees

### DIFF
--- a/src/__tests__/referral-logic.test.ts
+++ b/src/__tests__/referral-logic.test.ts
@@ -11,6 +11,7 @@ import {
   parseCommissionsFromSearch,
   parseReferralLink,
   parseReferrerFromSearch,
+  resolveEffectiveReferrer,
   type ReferralBlockReason,
   type ReferralGateInput
 } from '../utils/referral'
@@ -408,5 +409,93 @@ describe('referral gate', () => {
       expect(detail.length).toBeGreaterThan(0)
     }
     expect(REFERRAL_BLOCK_REMEDY).toMatch(/referred you/i)
+  })
+})
+
+describe('effective referrer — chain sponsor beats the link', () => {
+  const ZERO = '0x0000000000000000000000000000000000000000'
+
+  it('keeps the link affiliate when the wallet has no sponsor yet', () => {
+    for (const sponsor of [
+      undefined,
+      null,
+      ZERO,
+      ZERO.toUpperCase().replace('0X', '0x')
+    ]) {
+      expect(
+        resolveEffectiveReferrer({
+          linkReferrer: REFERRER,
+          existingSponsor: sponsor
+        })
+      ).toEqual({ referrer: REFERRER, wasOverridden: false })
+    }
+  })
+
+  it('keeps the link affiliate when it already matches the sponsor, ignoring case', () => {
+    expect(
+      resolveEffectiveReferrer({
+        linkReferrer: REFERRER,
+        existingSponsor: REFERRER.toLowerCase()
+      })
+    ).toEqual({ referrer: REFERRER, wasOverridden: false })
+  })
+
+  it('overrides with the existing sponsor when they differ', () => {
+    // Attribution is permanent: the contract reverts with
+    // CustomerAffiliateMismatch() rather than re-attribute, so the sponsor wins.
+    expect(
+      resolveEffectiveReferrer({
+        linkReferrer: REFERRER,
+        existingSponsor: OTHER
+      })
+    ).toEqual({ referrer: OTHER, wasOverridden: true })
+  })
+
+  it('adopts the sponsor even when the link had no valid affiliate at all', () => {
+    expect(
+      resolveEffectiveReferrer({ linkReferrer: null, existingSponsor: OTHER })
+    ).toEqual({ referrer: OTHER, wasOverridden: true })
+  })
+
+  it('leaves a broken link broken when there is no sponsor to fall back on', () => {
+    expect(
+      resolveEffectiveReferrer({ linkReferrer: null, existingSponsor: ZERO })
+    ).toEqual({ referrer: null, wasOverridden: false })
+  })
+})
+
+describe('gate holds while the sponsor is still being read', () => {
+  const base = {
+    enabled: true,
+    referrer: REFERRER,
+    commissions: OTHER,
+    hasLink: true,
+    account: getAddress('0xad1c4acbb1d3b13bc0e06bc9cbeae0103bcc878b'),
+    allowedCommissions: [OTHER],
+    isRegistered: true,
+    isPaused: false,
+    hasPoolMismatch: false
+  }
+
+  it('is checking while resolving, then ready once resolved', () => {
+    // The credited affiliate can still change, so no verdict may be issued yet.
+    expect(evaluateReferralGate({ ...base, isResolvingSponsor: true })).toEqual(
+      {
+        status: 'checking'
+      }
+    )
+    expect(
+      evaluateReferralGate({ ...base, isResolvingSponsor: false }).status
+    ).toBe('ready')
+  })
+
+  it('still reports a missing link before waiting on the sponsor read', () => {
+    expect(
+      evaluateReferralGate({
+        ...base,
+        hasLink: false,
+        isResolvingSponsor: true
+      })
+    ).toEqual({ status: 'blocked', reason: 'no-link' })
   })
 })

--- a/src/__tests__/referral-messages.test.ts
+++ b/src/__tests__/referral-messages.test.ts
@@ -4,6 +4,7 @@ import { extractErrorMessage, type ContractError } from '../utils/errorHandling'
 import referralDepositRouterAbi from '../abis/ReferralDepositRouter.json'
 import {
   REFERRAL_BLOCK_REMEDY,
+  REFERRAL_OVERRIDE_NOTICE,
   REFERRAL_PREFLIGHT_MESSAGES,
   describeReferralBlock,
   describeSkipReason,
@@ -202,5 +203,13 @@ describe('pre-flight re-check messages', () => {
     for (const msg of Object.values(REFERRAL_PREFLIGHT_MESSAGES)) {
       expect(msg).toContain('No transaction was sent')
     }
+  })
+})
+
+describe('referrer-corrected notice', () => {
+  it('reads exactly as reviewed', () => {
+    expect(REFERRAL_OVERRIDE_NOTICE).toBe(
+      'Your referral link had a different wallet address as the referrer, but we have updated it to show the correct wallet address.'
+    )
   })
 })

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -12,7 +12,12 @@ export default function Header() {
     <div className='sticky top-0 z-50 flex items-center justify-center w-full border-b border-border/40 bg-background'>
       <header className='flex items-center justify-between gap-3 p-3 sm:p-4 min-w-full max-w-screen-xl'>
         <div className='flex items-center min-w-0 gap-2 sm:gap-3'>
-          <Link href='/' className='flex items-center gap-2 sm:gap-3 shrink-0'>
+          {/* `/` redirects to /liquidity when loans are hidden — link straight
+              there so the logo doesn't bounce through a redirect. */}
+          <Link
+            href={isLoansPageHidden ? '/liquidity' : '/'}
+            className='flex items-center gap-2 sm:gap-3 shrink-0'
+          >
             <Image
               src='/images/lemloans-logo.png'
               alt='LemLoans Logo'
@@ -26,8 +31,12 @@ export default function Header() {
               LemLoans
             </h1>
           </Link>
-          <nav className='flex items-center gap-3 sm:gap-4 sm:ml-6 shrink-0'>
-            {!isLoansPageHidden && (
+          {/* With loans hidden there is only one page left, so the whole nav
+              goes — a lone tab that always points at the page you are already
+              on is just clutter. Rendered from a build-time constant, so this
+              is identical for connected and disconnected visitors. */}
+          {!isLoansPageHidden && (
+            <nav className='flex items-center gap-3 sm:gap-4 sm:ml-6 shrink-0'>
               <Link
                 href='/'
                 className={`text-sm font-medium transition-colors ${
@@ -38,18 +47,18 @@ export default function Header() {
               >
                 Loans
               </Link>
-            )}
-            <Link
-              href='/liquidity'
-              className={`text-sm font-medium transition-colors ${
-                pathname === '/liquidity'
-                  ? 'text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Liquidity
-            </Link>
-          </nav>
+              <Link
+                href='/liquidity'
+                className={`text-sm font-medium transition-colors ${
+                  pathname === '/liquidity'
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                Liquidity
+              </Link>
+            </nav>
+          )}
         </div>
         {/* Compact RainbowKit button on small screens — drop balance, use a shorter label
             and the icon-only chain status so the wallet pill doesn't blow out the header. */}

--- a/src/components/referral/ReferralBanner.tsx
+++ b/src/components/referral/ReferralBanner.tsx
@@ -2,6 +2,7 @@
 import { useAccount } from 'wagmi'
 import {
   REFERRAL_BLOCK_REMEDY,
+  REFERRAL_OVERRIDE_NOTICE,
   describeReferralBlock
 } from '@/src/utils/referral'
 import { truncateAddress } from '@/src/utils/format'
@@ -22,7 +23,7 @@ interface ReferralBannerProps {
  */
 export function ReferralBanner({ referral }: ReferralBannerProps) {
   const { chain } = useAccount()
-  const { referrer, gate } = referral
+  const { referrer: linkReferrer, gate } = referral
 
   // No router on this chain: the referral system does not apply and the plain
   // deposit flow is in charge. Render nothing at all.
@@ -57,10 +58,10 @@ export function ReferralBanner({ referral }: ReferralBannerProps) {
         <p className='text-sm font-medium'>{REFERRAL_BLOCK_REMEDY}</p>
         {/* Echo back whatever the link contained, so the referrer can be told
             exactly what their visitor received. */}
-        {referrer && (
+        {linkReferrer && (
           <p className='text-xs text-muted-foreground'>
             Affiliate in your link:{' '}
-            <span className='font-mono'>{truncateAddress(referrer)}</span>
+            <span className='font-mono'>{truncateAddress(linkReferrer)}</span>
           </p>
         )}
         {referral.commissions && (
@@ -77,10 +78,23 @@ export function ReferralBanner({ referral }: ReferralBannerProps) {
 
   // gate.status === 'ready' — confirm and stop talking. The banner is full
   // width, so the address fits in full without truncation.
+  //
+  // gate.referrer is the EFFECTIVE affiliate: if this wallet is already
+  // attributed to someone else on the commissions contract, that sponsor wins
+  // over the link, because the contract will not re-attribute. Showing the link's
+  // address here would promise a commission the chain would refuse to pay.
   const referrerUrl = explorerFor(gate.referrer)
+  const wasCorrected =
+    !!linkReferrer && linkReferrer.toLowerCase() !== gate.referrer.toLowerCase()
 
   return (
-    <div className='rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-4'>
+    <div className='rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-4 space-y-2'>
+      {wasCorrected && (
+        <p className='flex items-start gap-2 text-sm text-yellow-700 dark:text-yellow-500'>
+          <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0' />
+          {REFERRAL_OVERRIDE_NOTICE}
+        </p>
+      )}
       <div className='flex flex-wrap items-center gap-x-2 gap-y-1'>
         <CheckCircle2 className='h-4 w-4 shrink-0 text-emerald-600' />
         <span className='text-sm font-semibold'>Referred by</span>

--- a/src/hooks/referral/useReferralParam.ts
+++ b/src/hooks/referral/useReferralParam.ts
@@ -12,8 +12,6 @@ export interface UseReferralParamReturn {
   referrer: `0x${string}` | null
   /** Checksummed per-company commissions contract, or null. */
   commissions: `0x${string}` | null
-  /** Where the pair came from — null when there is nothing at all. */
-  source: 'url' | 'storage' | null
   /** True when the visitor arrived with a referral link, valid or not. */
   hasLink: boolean
 }
@@ -78,7 +76,6 @@ export function useReferralParam(): UseReferralParamReturn {
   const [captured, setCaptured] = useState<UseReferralParamReturn>({
     referrer: null,
     commissions: null,
-    source: null,
     hasLink: false
   })
 
@@ -90,7 +87,7 @@ export function useReferralParam(): UseReferralParamReturn {
     if (hasReferralParams(search)) {
       const { referrer, commissions } = parseReferralLink(search)
       writeStored(referrer && commissions ? { referrer, commissions } : null)
-      setCaptured({ referrer, commissions, source: 'url', hasLink: true })
+      setCaptured({ referrer, commissions, hasLink: true })
       return
     }
 
@@ -99,7 +96,6 @@ export function useReferralParam(): UseReferralParamReturn {
       setCaptured({
         referrer: null,
         commissions: null,
-        source: null,
         hasLink: false
       })
       return
@@ -108,7 +104,7 @@ export function useReferralParam(): UseReferralParamReturn {
     // Re-validate on the way out: storage is user-writable.
     const referrer = normalizeReferrer(stored.referrer)
     const commissions = normalizeReferrer(stored.commissions)
-    setCaptured({ referrer, commissions, source: 'storage', hasLink: true })
+    setCaptured({ referrer, commissions, hasLink: true })
   }, [])
 
   return captured

--- a/src/hooks/referral/useReferralRouter.ts
+++ b/src/hooks/referral/useReferralRouter.ts
@@ -37,8 +37,6 @@ export interface UseReferralRouterReturn {
    * the read is in flight — the gate must not judge a link before it arrives.
    */
   allowedCommissions: readonly `0x${string}`[] | undefined
-  /** LiquidityPool the router deposits into. */
-  routerPool: `0x${string}` | undefined
   /** True when router.pool() differs from the pool the UI is showing. */
   hasPoolMismatch: boolean
   isPaused: boolean
@@ -48,13 +46,10 @@ export interface UseReferralRouterReturn {
    * contract, in which case that sponsor wins.
    */
   effectiveReferrer: `0x${string}` | null
-  /** True when the chain's sponsor replaced the affiliate from the link. */
-  wasReferrerOverridden: boolean
   /** True while the sponsor lookup is still in flight. */
   isResolvingSponsor: boolean
   /** Whether the EFFECTIVE referrer is registered with the commissions contract. */
   isRegistered: boolean | undefined
-  isRegistrationLoading: boolean
   isLoading: boolean
 }
 
@@ -109,32 +104,31 @@ export function useReferralRouter({
     query: { enabled: enabled && !!commissionsAddress && !!account }
   })
 
-  const { referrer: effectiveReferrer, wasOverridden: wasReferrerOverridden } =
-    useMemo(
-      () =>
-        resolveEffectiveReferrer({
-          linkReferrer: referrer,
-          existingSponsor: sponsorRaw as string | undefined
-        }),
-      [referrer, sponsorRaw]
-    )
+  // The banner decides whether to warn by comparing the link's affiliate with
+  // this one, so the `wasOverridden` flag is not surfaced.
+  const { referrer: effectiveReferrer } = useMemo(
+    () =>
+      resolveEffectiveReferrer({
+        linkReferrer: referrer,
+        existingSponsor: sponsorRaw as string | undefined
+      }),
+    [referrer, sponsorRaw]
+  )
 
   const isResolvingSponsor =
     enabled && !!commissionsAddress && !!account && sponsorLoading
 
-  const {
-    data: isRegisteredRaw,
-    isLoading: isRegistrationLoading,
-    error: isRegistrationError
-  } = useReadContract({
-    address: commissionsAddress,
-    abi: commissionsAbi,
-    functionName: 'isRegistered',
-    args: effectiveReferrer ? [effectiveReferrer] : undefined,
-    query: {
-      enabled: enabled && !!commissionsAddress && !!effectiveReferrer
+  const { data: isRegisteredRaw, error: isRegistrationError } = useReadContract(
+    {
+      address: commissionsAddress,
+      abi: commissionsAbi,
+      functionName: 'isRegistered',
+      args: effectiveReferrer ? [effectiveReferrer] : undefined,
+      query: {
+        enabled: enabled && !!commissionsAddress && !!effectiveReferrer
+      }
     }
-  })
+  )
 
   // Fail closed on a read error rather than leaving the gate on 'checking'
   // forever. `commissions` is URL-supplied, so the call can revert simply
@@ -159,14 +153,11 @@ export function useReferralRouter({
     enabled,
     routerAddress,
     allowedCommissions,
-    routerPool,
     hasPoolMismatch,
     isPaused: (pausedRaw as boolean | undefined) ?? false,
     effectiveReferrer,
-    wasReferrerOverridden,
     isResolvingSponsor,
     isRegistered,
-    isRegistrationLoading,
     isLoading: enabled && (poolLoading || pausedLoading || allowedLoading)
   }
 }

--- a/src/hooks/referral/useReferralRouter.ts
+++ b/src/hooks/referral/useReferralRouter.ts
@@ -6,7 +6,7 @@ import {
   getReferralRouterAddress,
   isReferralEnabled
 } from '@/src/config/referral'
-import { commissionsAbi } from '@/src/utils/referral'
+import { commissionsAbi, resolveEffectiveReferrer } from '@/src/utils/referral'
 
 export interface UseReferralRouterParams {
   /** Captured referrer, or null when there is none. */
@@ -18,6 +18,8 @@ export interface UseReferralRouterParams {
    * below.
    */
   commissions: `0x${string}` | null
+  /** Connected wallet — its existing sponsor can override the link's affiliate. */
+  account?: `0x${string}`
   /**
    * The LiquidityPool the rest of the UI is reading from. Compared against
    * `router.pool()` — a mismatch means the referral path would deposit
@@ -40,7 +42,17 @@ export interface UseReferralRouterReturn {
   /** True when router.pool() differs from the pool the UI is showing. */
   hasPoolMismatch: boolean
   isPaused: boolean
-  /** Whether the referrer is registered with the commissions contract. */
+  /**
+   * The affiliate that will actually be credited: the link's affiliate, unless
+   * the wallet is already attributed to someone else on this commissions
+   * contract, in which case that sponsor wins.
+   */
+  effectiveReferrer: `0x${string}` | null
+  /** True when the chain's sponsor replaced the affiliate from the link. */
+  wasReferrerOverridden: boolean
+  /** True while the sponsor lookup is still in flight. */
+  isResolvingSponsor: boolean
+  /** Whether the EFFECTIVE referrer is registered with the commissions contract. */
   isRegistered: boolean | undefined
   isRegistrationLoading: boolean
   isLoading: boolean
@@ -56,6 +68,7 @@ export interface UseReferralRouterReturn {
 export function useReferralRouter({
   referrer,
   commissions,
+  account,
   expectedPool
 }: UseReferralRouterParams): UseReferralRouterReturn {
   const chainId = useChainId()
@@ -86,6 +99,29 @@ export function useReferralRouter({
   const { data: allowedRaw, isLoading: allowedLoading } = useReadContract(
     routerRead('allowedCommissionsList')
   )
+  // Who, if anyone, already owns this wallet on this commissions contract?
+  // Attribution is permanent, so this beats whatever the link says.
+  const { data: sponsorRaw, isLoading: sponsorLoading } = useReadContract({
+    address: commissionsAddress,
+    abi: commissionsAbi,
+    functionName: 'getSponsor',
+    args: account ? [account] : undefined,
+    query: { enabled: enabled && !!commissionsAddress && !!account }
+  })
+
+  const { referrer: effectiveReferrer, wasOverridden: wasReferrerOverridden } =
+    useMemo(
+      () =>
+        resolveEffectiveReferrer({
+          linkReferrer: referrer,
+          existingSponsor: sponsorRaw as string | undefined
+        }),
+      [referrer, sponsorRaw]
+    )
+
+  const isResolvingSponsor =
+    enabled && !!commissionsAddress && !!account && sponsorLoading
+
   const {
     data: isRegisteredRaw,
     isLoading: isRegistrationLoading,
@@ -94,8 +130,10 @@ export function useReferralRouter({
     address: commissionsAddress,
     abi: commissionsAbi,
     functionName: 'isRegistered',
-    args: referrer ? [referrer] : undefined,
-    query: { enabled: enabled && !!commissionsAddress && !!referrer }
+    args: effectiveReferrer ? [effectiveReferrer] : undefined,
+    query: {
+      enabled: enabled && !!commissionsAddress && !!effectiveReferrer
+    }
   })
 
   // Fail closed on a read error rather than leaving the gate on 'checking'
@@ -124,6 +162,9 @@ export function useReferralRouter({
     routerPool,
     hasPoolMismatch,
     isPaused: (pausedRaw as boolean | undefined) ?? false,
+    effectiveReferrer,
+    wasReferrerOverridden,
+    isResolvingSponsor,
     isRegistered,
     isRegistrationLoading,
     isLoading: enabled && (poolLoading || pausedLoading || allowedLoading)

--- a/src/hooks/referral/useReferralState.ts
+++ b/src/hooks/referral/useReferralState.ts
@@ -9,7 +9,11 @@ import {
 import { evaluateReferralGate, type ReferralGate } from '@/src/utils/referral'
 
 export interface ReferralState {
-  /** Affiliate address from the link, or null when missing/malformed. */
+  /**
+   * Affiliate address as it appeared in the LINK. May differ from the one that
+   * actually gets credited — see `gate.referrer`, which the UI and the deposit
+   * both use. The two are compared to decide whether to warn the visitor.
+   */
   referrer: `0x${string}` | null
   /** Per-company commissions contract from the link, or null. */
   commissions: `0x${string}` | null
@@ -42,28 +46,35 @@ export function useReferralState(expectedPool?: `0x${string}`): ReferralState {
   const { address } = useAccount()
   const { referrer, commissions, hasLink } = useReferralParam()
 
-  const router = useReferralRouter({ referrer, commissions, expectedPool })
+  const router = useReferralRouter({
+    referrer,
+    commissions,
+    account: address,
+    expectedPool
+  })
 
   const gate = useMemo(
     () =>
       evaluateReferralGate({
         enabled: router.enabled,
-        referrer,
+        referrer: router.effectiveReferrer,
         commissions,
         hasLink,
         account: address,
         allowedCommissions: router.allowedCommissions,
         isRegistered: router.isRegistered,
         isPaused: router.isPaused,
-        hasPoolMismatch: router.hasPoolMismatch
+        hasPoolMismatch: router.hasPoolMismatch,
+        isResolvingSponsor: router.isResolvingSponsor
       }),
     [
       router.enabled,
+      router.effectiveReferrer,
+      router.isResolvingSponsor,
       router.allowedCommissions,
       router.isRegistered,
       router.isPaused,
       router.hasPoolMismatch,
-      referrer,
       commissions,
       hasLink,
       address

--- a/src/utils/referral.ts
+++ b/src/utils/referral.ts
@@ -116,6 +116,37 @@ export function parseReferralLink(
   }
 }
 
+/**
+ * Attribution on a Commissions contract is first-affiliate-wins and permanent.
+ * Once a wallet has been credited to a sponsor, `_registerAffiliateIfNeeded`
+ * reverts with `CustomerAffiliateMismatch()` if a later deposit names anyone
+ * else — so a link pointing at a different affiliate cannot be honoured.
+ *
+ * Rather than fail that deposit, defer to the chain: whoever already owns the
+ * wallet is the real referrer, and the UI is corrected to match. The contract's
+ * own `getSponsor` falls back to the shared unified tree, so this single read
+ * sees exactly what the deposit will check.
+ */
+export function resolveEffectiveReferrer({
+  linkReferrer,
+  existingSponsor
+}: {
+  linkReferrer: `0x${string}` | null
+  existingSponsor?: string | null
+}): { referrer: `0x${string}` | null; wasOverridden: boolean } {
+  const sponsor =
+    existingSponsor && existingSponsor.toLowerCase() !== ZERO_ADDRESS_LOWER
+      ? (existingSponsor as `0x${string}`)
+      : null
+  if (!sponsor) return { referrer: linkReferrer, wasOverridden: false }
+  if (linkReferrer && sponsor.toLowerCase() === linkReferrer.toLowerCase()) {
+    return { referrer: linkReferrer, wasOverridden: false }
+  }
+  return { referrer: sponsor, wasOverridden: true }
+}
+
+const ZERO_ADDRESS_LOWER = '0x0000000000000000000000000000000000000000'
+
 export type ReferralBlockReason =
   | 'no-link'
   | 'invalid-referrer'
@@ -160,6 +191,12 @@ export interface ReferralGateInput {
   isRegistered?: boolean
   isPaused: boolean
   hasPoolMismatch: boolean
+  /**
+   * True while the connected wallet's existing sponsor is still being read.
+   * The verdict must wait: the referrer that ends up being credited can change
+   * once it resolves, and a link must not be judged against the wrong one.
+   */
+  isResolvingSponsor?: boolean
 }
 
 /**
@@ -187,6 +224,7 @@ export function evaluateReferralGate(input: ReferralGateInput): ReferralGate {
   if (!enabled) return { status: 'disabled' }
 
   if (!hasLink) return { status: 'blocked', reason: 'no-link' }
+  if (input.isResolvingSponsor) return { status: 'checking' }
   if (!referrer) return { status: 'blocked', reason: 'invalid-referrer' }
   if (!commissions) return { status: 'blocked', reason: 'invalid-commissions' }
   if (isSelfReferral(referrer, account)) {
@@ -281,6 +319,14 @@ export function describeReferralBlock(reason: ReferralBlockReason): {
   }
 }
 
+/**
+ * Shown above the affiliate address when the chain's sponsor replaced the one
+ * from the link. Attribution is permanent, so this is a correction, not an
+ * error — the deposit proceeds and credits the address on screen.
+ */
+export const REFERRAL_OVERRIDE_NOTICE =
+  'Your referral link had a different wallet address as the referrer, but we have updated it to show the correct wallet address.'
+
 /** The remedy shown under every block reason the visitor cannot self-fix. */
 export const REFERRAL_BLOCK_REMEDY =
   'Please contact the person who referred you for a working link.'
@@ -335,6 +381,13 @@ export const commissionsAbi = [
     stateMutability: 'view',
     inputs: [{ name: 'account', type: 'address' }],
     outputs: [{ name: '', type: 'bool' }]
+  },
+  {
+    type: 'function',
+    name: 'getSponsor',
+    stateMutability: 'view',
+    inputs: [{ name: 'affiliate', type: 'address' }],
+    outputs: [{ name: '', type: 'address' }]
   },
   {
     type: 'function',


### PR DESCRIPTION
Follow-up to #33. Fixes the failure hit in staging.

## The problem

Attribution on a `Commissions` contract is **first-affiliate-wins and permanent**. Once a wallet has been credited to a sponsor, `_registerAffiliateIfNeeded` reverts with `CustomerAffiliateMismatch()` if a later deposit names anyone else:

```solidity
if (_affiliates[affiliate].registered) {
    if (_affiliates[affiliate].sponsor != sponsor) revert CustomerAffiliateMismatch();
}
```

In staging, wallet `0xD966C7A9…5F5D` is already attributed to `0xAc61a8A1…b74B` on commissions `0xC6E1…13e0`, so the link's affiliate `0x6D8c3D44…2488` could never be paid. The pre-flight guard from #33 correctly stopped the deposit — but told the user to get a new link, when the link was not at fault and no link could have worked.

## The change

The connected wallet's existing sponsor is now read from the commissions contract, and when it differs from the link, it wins:

- the banner shows the **sponsor** instead of the link's affiliate, above a notice that the address was corrected
- the gate, the pre-flight settle simulation, the confirm dialog and the `depositWithReferral` call all use that same effective referrer — so the commission goes to the address **on screen**, not the one in the URL
- the gate holds on `checking` until the sponsor read resolves, since the credited affiliate can still change and a link must not be judged against the wrong one

One read covers it: the contract's own `getSponsor` falls back to the shared unified tree exactly as `_registerAffiliateIfNeeded` does, so what is displayed is what the deposit will check. With no existing sponsor, or one that already matches, nothing changes and no notice appears.

## New copy

> Your referral link had a different wallet address as the referrer, but we have updated it to show the correct wallet address.

## Verification

Against the real failing case on citron:

| `settleCommission(0xC6E1…13e0, referrer, 0xD966C7A9…5F5D, $99.99)` | |
|---|---|
| link affiliate `0x6D8c…2488` | reverts ❌ |
| effective sponsor `0xAc61…b74B` | **settles ✅** |

And in a real browser with that exact wallet and link: the notice renders, `0xAc61a8A1…b74B` is displayed, the confirm dialog credits `0xAc61...b74B`, and the deposit now passes pre-flight instead of being blocked.

353 tests pass (+8 covering the resolution rule, the `checking` hold and the new copy). `npm run build`, `npm run pages:build` and `tsc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
