### PR TITLE
release: disconnected liquidity landing page

### DIFF
--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -1,29 +1,262 @@
 'use client'
-import { ConnectButton } from '@rainbow-me/rainbowkit'
+import { useConnectModal } from '@rainbow-me/rainbowkit'
 import Image from 'next/image'
+import {
+  BarChart3,
+  FileLock2,
+  Lock,
+  PieChart,
+  Search,
+  ShieldCheck,
+  Users
+} from 'lucide-react'
+
+/**
+ * Marketing figures, not protocol data.
+ *
+ * These are the "current model assumptions" from the approved design — they are
+ * projections, not anything readable from chain, so they are hardcoded here on
+ * purpose rather than dressed up as live values. The lock tiers a depositor can
+ * actually pick, and their real interest multipliers, come from
+ * `getAssetLockTiers` on the connected view. Keep the two in step by hand when
+ * the model changes.
+ */
+const RETURN_MODEL = [
+  {
+    period: '1 Year',
+    multiplier: '1.00x',
+    lock: '0 – 1 Year',
+    total: '28% – 35%'
+  },
+  {
+    period: '2 Years',
+    multiplier: '1.25x',
+    lock: '1 – 2 Years',
+    total: '70% – 90%'
+  },
+  {
+    period: '3 Years',
+    multiplier: '1.50x',
+    lock: '2 – 3 Years',
+    total: '130% – 170%'
+  },
+  {
+    period: '4 Years',
+    multiplier: '1.75x',
+    lock: '3 – 4 Years',
+    total: '220% – 280%'
+  },
+  {
+    period: '5 Years',
+    multiplier: '2.00x',
+    lock: '4 – 5 Years',
+    total: '350% – 500%'
+  }
+] as const
+
+const PILLARS = [
+  {
+    Icon: ShieldCheck,
+    title: 'Overcollateralized Protection.',
+    lines: ['Capital is protected.', 'Built to safeguard.']
+  },
+  {
+    Icon: FileLock2,
+    title: 'Smart Contract Execution.',
+    lines: ['No intermediaries.', 'Fully on-chain.']
+  },
+  {
+    Icon: Search,
+    title: 'Transparent, Auditable, On-Chain.',
+    lines: ['Live data.', 'Verifiable anytime.']
+  }
+] as const
+
+const ASSURANCES = [
+  {
+    Icon: PieChart,
+    headline: '~90%',
+    label: 'Average Utilization',
+    lines: []
+  },
+  {
+    Icon: Users,
+    headline: null,
+    label: 'Institutional Borrowers',
+    lines: ['High quality.', 'Vetted.']
+  },
+  {
+    Icon: Lock,
+    headline: null,
+    label: 'Built for Safety',
+    lines: ['Capital security', 'is our priority.']
+  }
+] as const
 
 export function DisconnectedLiquidity() {
+  const { openConnectModal } = useConnectModal()
+
   return (
-    <div className='flex flex-col items-center justify-center min-h-[60vh] text-center space-y-8'>
-      <div className='flex flex-col items-center space-y-6'>
-        <div className='flex items-center space-x-4'>
+    <div className='mx-auto flex max-w-4xl flex-col items-center gap-10 py-4 text-center'>
+      {/* ── Masthead ─────────────────────────────────────────────── */}
+      <div className='flex flex-col items-center gap-3'>
+        <div className='flex items-center gap-4'>
           <Image
             src='/images/lemloans-logo.png'
             alt='LemLoans Logo'
             width={80}
             height={80}
-            className='h-auto'
+            className='h-14 w-14 sm:h-20 sm:w-20'
             priority
           />
-          <h1 className='text-4xl font-bold text-gray-900 dark:text-gray-100'>
+          <h1 className='text-4xl font-extrabold tracking-tight text-gray-900 sm:text-6xl dark:text-gray-100'>
             LemLoans
           </h1>
         </div>
-        <h2 className='text-2xl font-semibold text-gray-700 dark:text-gray-300'>
+        <h2 className='text-2xl font-semibold text-gray-700 sm:text-3xl dark:text-gray-300'>
           Become a Liquidity Provider
         </h2>
       </div>
-      <ConnectButton />
+
+      {/* ── Three pillars ────────────────────────────────────────── */}
+      <div className='grid w-full grid-cols-3 divide-x divide-gray-200 dark:divide-gray-700'>
+        {PILLARS.map(({ Icon, title, lines }) => (
+          <div
+            key={title}
+            className='flex flex-col items-center gap-2 px-1.5 sm:gap-3 sm:px-6'
+          >
+            <Icon
+              className='h-7 w-7 text-yellow-500 sm:h-10 sm:w-10'
+              strokeWidth={1.75}
+            />
+            <h3 className='text-[11px] font-bold leading-snug text-gray-900 sm:text-base dark:text-gray-100'>
+              {title}
+            </h3>
+            <p className='text-[10px] leading-relaxed text-gray-600 sm:text-sm dark:text-gray-400'>
+              {lines.map((line) => (
+                <span key={line} className='block'>
+                  {line}
+                </span>
+              ))}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Estimated returns ────────────────────────────────────── */}
+      <section className='w-full rounded-2xl border border-gray-200 bg-white p-5 shadow-sm sm:p-6 dark:border-gray-700 dark:bg-gray-900'>
+        <div className='flex items-center justify-center gap-3 sm:justify-start'>
+          <BarChart3
+            className='h-8 w-8 shrink-0 text-yellow-500'
+            strokeWidth={2}
+          />
+          <div className='text-left'>
+            <h3 className='text-xl font-extrabold tracking-tight text-gray-900 sm:text-2xl dark:text-gray-100'>
+              ESTIMATED RETURNS
+            </h3>
+            <p className='text-sm font-medium italic text-gray-500 dark:text-gray-400'>
+              (Current Model Assumptions)
+            </p>
+          </div>
+        </div>
+
+        {/* Wide content scrolls inside its own container so the page never
+            scrolls sideways on a phone. */}
+        <div className='mt-5 overflow-x-auto'>
+          <table className='w-full border-collapse overflow-hidden rounded-lg'>
+            <thead>
+              <tr className='bg-gray-900 text-yellow-400'>
+                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
+                  Time Period
+                </th>
+                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
+                  Weight
+                  <span className='block font-semibold'>(Multiplier)</span>
+                </th>
+                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
+                  Lock Duration
+                  <span className='block font-semibold'>(Years)</span>
+                </th>
+                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
+                  Estimated Total
+                  <span className='block font-semibold'>Return* (%)</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className='divide-y divide-gray-200 dark:divide-gray-700'>
+              {RETURN_MODEL.map((row) => (
+                <tr key={row.period} className='bg-white dark:bg-gray-900'>
+                  <td className='px-1.5 py-3 text-center text-[11px] font-bold uppercase text-yellow-600 sm:px-3 sm:text-sm dark:text-yellow-500'>
+                    {row.period}
+                  </td>
+                  <td className='px-1.5 py-3 text-center text-[11px] font-bold tabular-nums text-green-700 sm:px-3 sm:text-sm dark:text-green-400'>
+                    {row.multiplier}
+                  </td>
+                  <td className='px-1.5 py-3 text-center text-[11px] font-medium uppercase text-gray-800 sm:px-3 sm:text-sm dark:text-gray-200'>
+                    {row.lock}
+                  </td>
+                  <td className='px-1.5 py-3 text-center text-[11px] font-bold tabular-nums text-green-700 sm:px-3 sm:text-sm dark:text-green-400'>
+                    {row.total}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className='mt-4 space-y-1 text-left text-sm text-gray-500 dark:text-gray-400'>
+          <p>
+            Returns vary based on market conditions, utilization, demand,
+            protocol performance and repeated refinancing.
+          </p>
+          <p className='font-bold italic text-gray-700 dark:text-gray-300'>
+            Not a guarantee of future results.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Call to action ───────────────────────────────────────── */}
+      <button
+        type='button'
+        onClick={openConnectModal}
+        disabled={!openConnectModal}
+        className='w-full max-w-md rounded-xl bg-blue-600 px-8 py-4 text-lg font-bold text-white shadow-sm transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-60'
+      >
+        Connect Wallet
+      </button>
+
+      {/* ── Assurances ───────────────────────────────────────────── */}
+      <div className='grid w-full grid-cols-3 divide-x divide-gray-200 dark:divide-gray-700'>
+        {ASSURANCES.map(({ Icon, headline, label, lines }) => (
+          <div
+            key={label}
+            className='flex flex-col items-center gap-1.5 px-1.5 text-center sm:flex-row sm:justify-center sm:gap-3 sm:px-6 sm:text-left'
+          >
+            <Icon
+              className='h-7 w-7 shrink-0 text-yellow-500 sm:h-10 sm:w-10'
+              strokeWidth={1.75}
+            />
+            <div>
+              {headline && (
+                <div className='text-lg font-extrabold leading-none text-gray-900 sm:text-2xl dark:text-gray-100'>
+                  {headline}
+                </div>
+              )}
+              <div className='text-[10px] font-bold uppercase leading-tight text-gray-900 sm:text-sm dark:text-gray-100'>
+                {label}
+              </div>
+              {lines.map((line) => (
+                <div
+                  key={line}
+                  className='text-[10px] leading-tight text-gray-600 sm:text-sm dark:text-gray-400'
+                >
+                  {line}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -93,6 +93,22 @@ const ASSURANCES = [
   }
 ] as const
 
+const COLUMNS = [
+  { label: 'Time Period', sub: null },
+  { label: 'Weight', sub: '(Multiplier)' },
+  { label: 'Lock Duration', sub: '(Years)' },
+  { label: 'Estimated Total', sub: 'Return* (%)' }
+] as const
+
+const HEAD_CELL =
+  'px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'
+
+const CELL = 'px-1.5 py-3 text-center text-[11px] sm:px-3 sm:text-sm'
+
+/** The two three-across rows that bracket the returns panel share this shape. */
+const TRIPLET_ROW =
+  'grid w-full grid-cols-3 divide-x divide-gray-200 dark:divide-gray-700'
+
 export function DisconnectedLiquidity() {
   const { openConnectModal } = useConnectModal()
 
@@ -119,7 +135,7 @@ export function DisconnectedLiquidity() {
       </div>
 
       {/* ── Three pillars ────────────────────────────────────────── */}
-      <div className='grid w-full grid-cols-3 divide-x divide-gray-200 dark:divide-gray-700'>
+      <div className={TRIPLET_ROW}>
         {PILLARS.map(({ Icon, title, lines }) => (
           <div
             key={title}
@@ -160,42 +176,43 @@ export function DisconnectedLiquidity() {
           </div>
         </div>
 
-        {/* Wide content scrolls inside its own container so the page never
-            scrolls sideways on a phone. */}
+        {/* The table is sized to fit all four columns down to ~430px rather
+            than scroll — clipping the return column defeats the point of the
+            panel. overflow-x-auto is the backstop below that, so an unusually
+            narrow screen scrolls the table and never the page. */}
         <div className='mt-5 overflow-x-auto'>
           <table className='w-full border-collapse overflow-hidden rounded-lg'>
             <thead>
               <tr className='bg-gray-900 text-yellow-400'>
-                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
-                  Time Period
-                </th>
-                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
-                  Weight
-                  <span className='block font-semibold'>(Multiplier)</span>
-                </th>
-                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
-                  Lock Duration
-                  <span className='block font-semibold'>(Years)</span>
-                </th>
-                <th className='px-1.5 py-2.5 text-center text-[9px] font-bold uppercase leading-tight tracking-wide sm:px-3 sm:py-3 sm:text-xs'>
-                  Estimated Total
-                  <span className='block font-semibold'>Return* (%)</span>
-                </th>
+                {COLUMNS.map(({ label, sub }) => (
+                  <th key={label} className={HEAD_CELL}>
+                    {label}
+                    {sub && <span className='block font-semibold'>{sub}</span>}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody className='divide-y divide-gray-200 dark:divide-gray-700'>
               {RETURN_MODEL.map((row) => (
                 <tr key={row.period} className='bg-white dark:bg-gray-900'>
-                  <td className='px-1.5 py-3 text-center text-[11px] font-bold uppercase text-yellow-600 sm:px-3 sm:text-sm dark:text-yellow-500'>
+                  <td
+                    className={`${CELL} font-bold uppercase text-yellow-600 dark:text-yellow-500`}
+                  >
                     {row.period}
                   </td>
-                  <td className='px-1.5 py-3 text-center text-[11px] font-bold tabular-nums text-green-700 sm:px-3 sm:text-sm dark:text-green-400'>
+                  <td
+                    className={`${CELL} font-bold tabular-nums text-green-700 dark:text-green-400`}
+                  >
                     {row.multiplier}
                   </td>
-                  <td className='px-1.5 py-3 text-center text-[11px] font-medium uppercase text-gray-800 sm:px-3 sm:text-sm dark:text-gray-200'>
+                  <td
+                    className={`${CELL} font-medium uppercase text-gray-800 dark:text-gray-200`}
+                  >
                     {row.lock}
                   </td>
-                  <td className='px-1.5 py-3 text-center text-[11px] font-bold tabular-nums text-green-700 sm:px-3 sm:text-sm dark:text-green-400'>
+                  <td
+                    className={`${CELL} font-bold tabular-nums text-green-700 dark:text-green-400`}
+                  >
                     {row.total}
                   </td>
                 </tr>
@@ -227,7 +244,7 @@ export function DisconnectedLiquidity() {
       </button>
 
       {/* ── Assurances ───────────────────────────────────────────── */}
-      <div className='grid w-full grid-cols-3 divide-x divide-gray-200 dark:divide-gray-700'>
+      <div className={TRIPLET_ROW}>
         {ASSURANCES.map(({ Icon, headline, label, lines }) => (
           <div
             key={label}

--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -204,15 +204,16 @@ export function DisconnectedLiquidity() {
           </table>
         </div>
 
-        <div className='mt-4 space-y-1 text-left text-sm text-gray-500 dark:text-gray-400'>
-          <p>
-            Returns vary based on market conditions, utilization, demand,
-            protocol performance and repeated refinancing.
-          </p>
-          <p className='font-bold italic text-gray-700 dark:text-gray-300'>
-            Not a guarantee of future results.
-          </p>
-        </div>
+        {/* Deliberately set smaller than the table it sits under: it has to be
+            present and readable without competing with the figures above. */}
+        <p className='mt-4 text-left text-[10px] leading-relaxed text-gray-500 sm:text-xs dark:text-gray-400'>
+          Illustrative outcomes are model-generated and are not promised or
+          guaranteed. Actual protocol outcomes depend on borrower demand,
+          utilization, collateral performance, market conditions, refinancing
+          activity, smart-contract execution and other factors. Digital assets
+          deposited into the protocol may lose value, including the possible
+          loss of some or all assets supplied.
+        </p>
       </section>
 
       {/* ── Call to action ───────────────────────────────────────── */}


### PR DESCRIPTION
Release of the disconnected liquidity landing page. Contains PR #36 only — the referral feature already shipped to `main` in #35.

**Scope: one file, presentational.** `src/components/liquidity/DisconnectedLiquidity.tsx`, +259 / −8. No hooks, no contract calls, no config, no env vars. Nothing a connected user sees changes.

## What it does

Replaces the placeholder disconnected view on `/liquidity` — logo, one line of text, a connect button — with the approved landing design: three trust pillars, an estimated-returns table, a full-width connect CTA, and three closing assurances.

With `NEXT_PUBLIC_HIDE_LOANS_PAGE=true` this is the first thing a visitor sees, since `/` redirects to `/liquidity`.

## Two things to look at before approving

**The model table does not match the real lock tiers.** The figures are marketing projections, held in a `RETURN_MODEL` const and commented as such. But the connected view reads *actual* tiers from `getAssetLockTiers` — on Citron those are 3min/4min/15min/30min/10yr with multipliers like 1x, 3x, 2x and 0.05x, nothing like the 1.00x–2.00x / 1–5 year model shown here. Harmless on testnet, but **if mainnet tiers differ from the model, this page promises something the deposit form contradicts on the next screen.** Worth confirming the mainnet tiers before this is public.

**The risk disclaimer is a real disclosure now.** The previous two-line copy was replaced with supplied wording that names the factors outcomes depend on and states that deposited assets may lose value, *including the possible loss of some or all assets supplied*. The old copy said none of that. Whoever owns legal language should see it rendered rather than only in a ticket.

## Responsive deviations from the drawn design

Supplied as a phone screenshot; two things did not translate literally:

- **Returns table** is sized to fit all four columns down to ~430px rather than scroll. Keeping the drawn column widths clipped "ESTIMATED TOTAL RETURN" off-screen, which defeats the panel. `overflow-x-auto` stays as the backstop below that width, so the table scrolls and the page never does.
- **Closing assurances** stack icon-above-text below the `sm` breakpoint. Beside the text as drawn, "BUILT FOR SAFETY" wrapped onto three lines and its description onto four. From `sm` up they sit beside the text as designed.

Both are one-line reversals if you'd rather have literal fidelity at phone widths.

## Verification

Rendered in a real browser at 430px, 768px and 1280px — no horizontal page scroll at any width, no column clipped. `npm run build`, `npm run pages:build`, `tsc` and 353 tests all pass on `develop` as it stands.

No tests added: presentational, with no logic beyond opening the wallet modal.

## Deployment

Nothing new to configure. Unrelated but still true from #35: setting a real `NEXT_PUBLIC_<CHAIN>_REFERRAL_ROUTER_ADDRESS` makes deposits referral-only on that chain, and LemonChain mainnet is currently `0x00` (invalid → inert), so referrals remain off in production until that variable is deliberately changed and rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
