### PR TITLE
release: landing page copy edits and always-on deposit minimum

### DIFF
--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -576,9 +576,18 @@ export function AddLiquidityCard({
         )}
 
         <div className='flex-1 space-y-1'>
-          {isBelowMinimum && minimumForDisplay && (
-            <p className='text-sm text-destructive'>
-              Minimum deposit is ${minimumForDisplay} USD.
+          {/* Always shown so the threshold is known before typing, not only
+              after tripping it. Still read from minimumDepositValue on the
+              pool — it turns red once the entered amount is under it. */}
+          {minimumForDisplay && (
+            <p
+              className={
+                isBelowMinimum
+                  ? 'text-sm text-destructive'
+                  : 'text-sm text-muted-foreground'
+              }
+            >
+              Minimum deposit is ${minimumForDisplay} USD equivalent.
             </p>
           )}
           {insufficientBalance && (

--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -59,8 +59,8 @@ const RETURN_MODEL = [
 const PILLARS = [
   {
     Icon: ShieldCheck,
-    title: 'Overcollateralized Protection.',
-    lines: ['Capital is protected.', 'Built to safeguard.']
+    title: 'Overcollateralized Lending.',
+    lines: ['Risk controlled on chain.', 'Every loan is backed by collateral.']
   },
   {
     Icon: FileLock2,
@@ -84,14 +84,14 @@ const ASSURANCES = [
   {
     Icon: Users,
     headline: null,
-    label: 'Institutional Borrowers',
-    lines: ['High quality.', 'Vetted.']
+    label: 'Collateralized Borrowers',
+    lines: ['Built for broad participation.', 'Requirements enforced on-chain.']
   },
   {
     Icon: Lock,
     headline: null,
-    label: 'Built for Safety',
-    lines: ['Capital security', 'is our priority.']
+    label: 'Decentralized by design',
+    lines: ['Protocol risk controls.']
   }
 ] as const
 
@@ -291,9 +291,15 @@ export function DisconnectedLiquidity() {
           ))}
         </ul>
 
-        <p className='mt-5 text-center text-[10px] text-gray-500 sm:text-xs dark:text-gray-400'>
-          All assets are accepted as BEP-20 tokens on BNB Smart Chain.
-        </p>
+        <div className='mt-5 space-y-2 text-center text-[10px] text-gray-500 sm:text-xs dark:text-gray-400'>
+          <p>All assets are accepted as BEP-20 tokens on BNB Smart Chain.</p>
+          <p>
+            Where an underlying asset is not native to BSC, its approved wrapped
+            or pegged BEP-20 representation may be used. Eligible collateral is
+            enabled according to protocol-defined risk, liquidity, and
+            collateral parameters.
+          </p>
+        </div>
       </section>
 
       {/* ── Call to action ───────────────────────────────────────── */}


### PR DESCRIPTION
Copy-only release. One commit ahead of `main`, two files, no logic or contract-interaction changes.

## Landing page wording

| was | now |
|---|---|
| Overcollateralized Protection. | **Overcollateralized Lending.** |
| Capital is protected. / Built to safeguard. | **Risk controlled on chain. / Every loan is backed by collateral.** |
| Institutional Borrowers | **Collateralized Borrowers** |
| High quality. / Vetted. | **Built for broad participation. / Requirements enforced on-chain.** |
| Built for Safety | **Decentralized by design** |
| Capital security is our priority. | **Protocol risk controls.** |

## Supported assets

A second line under the existing BEP-20 note:

> Where an underlying asset is not native to BSC, its approved wrapped or pegged BEP-20 representation may be used. Eligible collateral is enabled according to protocol-defined risk, liquidity, and collateral parameters.

## Add Liquidity minimum

The minimum-deposit line is now **always visible** rather than appearing only once the entered amount trips it, so the threshold is known before typing. It stays read from the pool's `minimumDepositValue()` — not hardcoded — and turns red only when the amount is actually below it, muted otherwise.

Note this currently renders **$500**, not $100: that is what `minimumDepositValue()` returns on the citron pool today. The page states whatever the contract says, so it is worth confirming the intended value per network before this goes out.

## Verification

Rendered in a browser: every new string appears and none of the replaced copy survives. The minimum line was checked in four states — before an asset is picked, with no amount entered, below the threshold, and above it — confirming it is always present and only changes colour when below.

`npm run build`, `npm run pages:build` and `tsc` clean; 357 tests pass. Working tree clean, `public/` assets intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)