### PR TITLE
copy: reframe the returns table as illustrative scenarios

### DIFF
--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -120,7 +120,7 @@ const COLUMNS = [
   { label: 'Time Period', sub: null },
   { label: 'Weight', sub: '(Multiplier)' },
   { label: 'Lock Duration', sub: '(Years)' },
-  { label: 'Estimated Total', sub: 'Return (%)' }
+  { label: 'Illustrative Total', sub: 'Returns*' }
 ] as const
 
 const HEAD_CELL =
@@ -191,10 +191,10 @@ export function DisconnectedLiquidity() {
           />
           <div className='text-left'>
             <h3 className='text-xl font-extrabold tracking-tight text-gray-900 sm:text-2xl dark:text-gray-100'>
-              ESTIMATED RETURNS
+              ILLUSTRATIVE RETURN SCENARIOS
             </h3>
             <p className='text-sm font-medium italic text-gray-500 dark:text-gray-400'>
-              (Current Model Assumptions)
+              Model Outputs Based on Stated Protocol-Activity Assumptions
             </p>
           </div>
         </div>


### PR DESCRIPTION
Copy-only, one file.

| was | now |
|---|---|
| ESTIMATED RETURNS | **ILLUSTRATIVE RETURN SCENARIOS** |
| (Current Model Assumptions) | **Model Outputs Based on Stated Protocol-Activity Assumptions** |
| Estimated Total / Return (%) | **Illustrative Total / Returns\*** |

Two judgement calls worth a glance:

- The subtitle **drops its parentheses**. It is now a full descriptive line rather than a parenthetical aside, and the supplied wording carries none.
- The column header **regains the asterisk**, which now has something to point at — the disclaimer directly beneath the table opens *"Illustrative outcomes are model-generated and are not promised or guaranteed"*, so the marker and the footnote share the same language.

Verified at 430px and 1280px: all four strings render, no old copy survives, and the four-column table still fits with no clipping and no sideways page scroll despite the longer header wrapping to three lines on mobile.

`npm run build`, `npm run pages:build` and `tsc` clean; 357 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)