### PR TITLE
copy: mark the returns footnote with the asterisk it answers

### DIFF
--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -247,7 +247,7 @@ export function DisconnectedLiquidity() {
         {/* Deliberately set smaller than the table it sits under: it has to be
             present and readable without competing with the figures above. */}
         <p className='mt-4 text-left text-[10px] leading-relaxed text-gray-500 sm:text-xs dark:text-gray-400'>
-          Illustrative outcomes are model-generated and are not promised or
+          *Illustrative outcomes are model-generated and are not promised or
           guaranteed. Actual protocol outcomes depend on borrower demand,
           utilization, collateral performance, market conditions, refinancing
           activity, smart-contract execution and other factors. Digital assets


### PR DESCRIPTION
One character. The table header reads **Illustrative Total Returns\***, but the disclaimer beneath carried no matching marker, so the asterisk pointed at nothing in particular. It now opens the footnote:

> \*Illustrative outcomes are model-generated and are not promised or guaranteed. Actual protocol outcomes depend on borrower demand, utilization, collateral performance, market conditions, refinancing activity, smart-contract execution and other factors. Digital assets deposited into the protocol may lose value, including the possible loss of some or all assets supplied.

Verified rendering at 430px; builds and 357 tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)