### PR TITLE
release: wrong-network detection fix and returns-table copy

### DIFF
--- a/src/components/common/Calculator.tsx
+++ b/src/components/common/Calculator.tsx
@@ -6,10 +6,7 @@ import type { UseLoansReturn } from '../../hooks/types'
 import { formatUnits, parseUnits } from 'viem'
 import { useContractTokenConfiguration } from '../../hooks/useContractTokenConfiguration'
 import { useToast } from '../../hooks/use-toast'
-import {
-  formatPercentage,
-  formatTokenAmount
-} from '../../utils/decimals'
+import { formatPercentage, formatTokenAmount } from '../../utils/decimals'
 import { formatDuration } from '../../utils/format'
 import { LoanParameters } from '../calculator/LoanParameters'
 import { LoanSummary } from '../calculator/LoanSummary'
@@ -19,6 +16,7 @@ import {
   isUserRejection,
   type ContractError
 } from '../../utils/errorHandling'
+import { useIsWrongNetwork } from '../../hooks/useIsWrongNetwork'
 import { useCollateralManager } from '../../hooks/useCollateralManager'
 import { useLoanConfig } from '../../hooks/loans/useLoanConfig'
 import { useDelegateValidation } from '../../hooks/loans/useDelegateValidation'
@@ -226,7 +224,13 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
       duration: selectedDuration,
       ltv: selectedLtvOption.ltv
     }
-  }, [selectedCollateral, loanAmount, selectedDuration, selectedLtvOption, tokenConfig])
+  }, [
+    selectedCollateral,
+    loanAmount,
+    selectedDuration,
+    selectedLtvOption,
+    tokenConfig
+  ])
 
   // Validate the typed payer address (format + on-chain delegation). Balance
   // and allowance shortfalls are surfaced by LoanSummary's existing
@@ -238,9 +242,13 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
   // even before the delegation check completes — so balance/allowance reads
   // start firing against the right wallet immediately.
   const effectiveOriginationPayer =
-    !isPayerLocked && payerValidation.normalizedAddress && !payerValidation.isSelf
+    !isPayerLocked &&
+    payerValidation.normalizedAddress &&
+    !payerValidation.isSelf
       ? payerValidation.normalizedAddress
       : undefined
+
+  const isWrongNetwork = useIsWrongNetwork()
 
   const loanOperations = useLoans({
     loanRequest,
@@ -262,7 +270,10 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     operationError &&
     loanRequest &&
     !loanOperations.calculationData &&
-    !loanOperations.isSimulating
+    !loanOperations.isSimulating &&
+    // On the wrong network every simulation fails; that is not a loan problem
+    // and the network banner already carries the fix.
+    !isWrongNetwork
       ? extractErrorMessage(operationError as unknown as ContractError)
       : undefined
 
@@ -298,7 +309,11 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     // contract config is still loading or the user hasn't picked a collateral.
     // Either way, render a neutral em-dash to match the "no calc yet" branch
     // below; the form surfaces actionable validation elsewhere.
-    if (!tokenConfig || !selectedCollateral || perAssetConfig.interestAprConfigs.length === 0) {
+    if (
+      !tokenConfig ||
+      !selectedCollateral ||
+      perAssetConfig.interestAprConfigs.length === 0
+    ) {
       return {
         ...baseWithDials,
         priceError: '—'
@@ -334,9 +349,12 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
     }
 
     // Calculate loan cycles
-    const loanCycles = formatted.loanCycleDuration && formatted.loanCycleDuration > 0n
-      ? Math.ceil(Number(selectedDuration) / Number(formatted.loanCycleDuration))
-      : 0
+    const loanCycles =
+      formatted.loanCycleDuration && formatted.loanCycleDuration > 0n
+        ? Math.ceil(
+            Number(selectedDuration) / Number(formatted.loanCycleDuration)
+          )
+        : 0
 
     // Build the final calculation with all values
     const isValid =
@@ -347,15 +365,17 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
       !loanOperations.hasInsufficientLiquidity &&
       payerValidation.isValid
 
-    const priceError = buildPriceError(
-      loanOperations.isSimulating,
-      loanOperations.hasInsufficientLmln,
-      formatted.originationFeeLmln,
-      loanOperations.userLmlnBalance,
-      tokenConfig
-    ) || (loanOperations.hasInsufficientLiquidity
-      ? 'Insufficient pool liquidity for this loan amount'
-      : undefined)
+    const priceError =
+      buildPriceError(
+        loanOperations.isSimulating,
+        loanOperations.hasInsufficientLmln,
+        formatted.originationFeeLmln,
+        loanOperations.userLmlnBalance,
+        tokenConfig
+      ) ||
+      (loanOperations.hasInsufficientLiquidity
+        ? 'Insufficient pool liquidity for this loan amount'
+        : undefined)
 
     return {
       ...baseWithDials,
@@ -418,7 +438,11 @@ const CalculatorSection = ({ isDashboard = false }: CalculatorSectionProps) => {
 
   // Handle collateral ERC20 approval (WLEMX → CollateralManager)
   const handleApproveCollateral = async () => {
-    if (!selectedCollateral || !loanOperations.calculationData?.collateralAmount) return
+    if (
+      !selectedCollateral ||
+      !loanOperations.calculationData?.collateralAmount
+    )
+      return
     setIsApprovingCollateral(true)
     try {
       await loanOperations.approveCollateral(

--- a/src/components/common/ProtocolStatusBanner.tsx
+++ b/src/components/common/ProtocolStatusBanner.tsx
@@ -7,6 +7,10 @@ import {
   loansAddress
 } from '@/src/generated'
 import { useProtocolAddresses } from '@/src/hooks/useProtocolAddresses'
+import {
+  useIsWrongNetwork,
+  hasLoansAddress
+} from '@/src/hooks/useIsWrongNetwork'
 import { usePricing } from '@/src/hooks/usePricing'
 import {
   extractErrorMessage,
@@ -15,13 +19,42 @@ import {
 import { AlertTriangle, PauseCircle, Network } from 'lucide-react'
 
 /**
+ * Display names for chains a wallet is commonly parked on but that this build
+ * does not configure. `useAccount().chain` resolves only against the configured
+ * list, so without this the banner can only say "another network" — naming the
+ * chain the user is actually on is most of what makes the message land.
+ * Display only: nothing is ever read from these chains.
+ */
+const COMMON_CHAIN_NAMES: Record<number, string> = {
+  1: 'Ethereum',
+  10: 'OP Mainnet',
+  56: 'BNB Smart Chain',
+  97: 'BNB Smart Chain Testnet',
+  137: 'Polygon',
+  8453: 'Base',
+  42161: 'Arbitrum One',
+  43114: 'Avalanche',
+  11155111: 'Sepolia'
+}
+
+/**
  * Global protocol health banner. Every fee-bearing write depends on the
  * contracts being unpaused and the price feed being fresh — without this
  * banner those states only surface as opaque per-transaction failures deep
  * in a flow (approve succeeds, then the real tx reverts).
  */
 export function ProtocolStatusBanner() {
-  const { isConnected } = useAccount()
+  // `chain` is the WALLET's chain, resolved against the configured list —
+  // undefined when the wallet is on a chain this build doesn't support.
+  // `useChainId()` cannot be used for this: it returns config.state.chainId,
+  // which wagmi clamps to a configured chain, so it reports a supported chain
+  // even while the wallet sits on an unsupported one. Detecting with it left
+  // the banner silent and the failure surfaced as a raw price-feed error.
+  const {
+    isConnected,
+    chain: walletChain,
+    chainId: walletChainId
+  } = useAccount()
   const chainId = useChainId()
   const { switchChain, chains } = useSwitchChain()
 
@@ -30,13 +63,16 @@ export function ProtocolStatusBanner() {
   // pill. Detect it here and offer a one-click switch. Widen to string —
   // the generated literal types make a zero-address comparison a TS error,
   // but at runtime an unconfigured env var really does yield the zero addr.
-  const hasLoansAddress = (id: number): boolean => {
-    const addr = loansAddress[id as keyof typeof loansAddress] as
-      | string
-      | undefined
-    return !!addr && addr !== '0x0000000000000000000000000000000000000000'
-  }
-  const isUnsupportedNetwork = isConnected && !hasLoansAddress(chainId)
+  // Two ways to be on the wrong network: the wallet's chain isn't in the
+  // configured set at all (walletChain undefined), or it is configured but has
+  // no Loans address for this deployment.
+  const isUnsupportedNetwork = useIsWrongNetwork()
+
+  // Prefer the configured chain's own name, fall back to the lookup above,
+  // and only then to a generic phrase.
+  const walletChainName =
+    walletChain?.name ??
+    (walletChainId ? COMMON_CHAIN_NAMES[walletChainId] : undefined)
   const fallbackChain = chains.find((c) => hasLoansAddress(c.id))
 
   // @ts-ignore - wagmi deep type instantiation
@@ -59,12 +95,17 @@ export function ProtocolStatusBanner() {
   const priceMessage = pricingError
     ? extractErrorMessage(pricingError as unknown as ContractError)
     : undefined
-  const showPriceWarning =
-    !!priceMessage && /price|stale/i.test(priceMessage)
+  const showPriceWarning = !!priceMessage && /price|stale/i.test(priceMessage)
 
   const isPaused = Boolean(loansPaused) || Boolean(lpPaused)
 
-  if (!isPaused && !showPriceWarning && !isUnsupportedNetwork) return null
+  // On the wrong network every read returns "0x", so the paused and
+  // price-feed warnings are symptoms of that, not independent problems.
+  // Showing all three at once buries the one thing the user can act on.
+  const showPaused = isPaused && !isUnsupportedNetwork
+  const showPrice = showPriceWarning && !isUnsupportedNetwork
+
+  if (!showPaused && !showPrice && !isUnsupportedNetwork) return null
 
   return (
     <div className='space-y-2'>
@@ -73,11 +114,12 @@ export function ProtocolStatusBanner() {
           <Network className='h-5 w-5 shrink-0 text-orange-600 dark:text-orange-400 mt-0.5' />
           <div className='flex-1'>
             <p className='text-sm font-semibold text-orange-800 dark:text-orange-300'>
-              Unsupported network
+              Switch to {fallbackChain?.name ?? 'a supported network'}
             </p>
             <p className='text-sm text-orange-700 dark:text-orange-400'>
-              Your wallet is connected to a network this app doesn&apos;t
-              support, so no data can load.
+              Your wallet is on {walletChainName ?? 'another network'}. LemLoans
+              runs on {fallbackChain?.name ?? 'a different network'} — switch to
+              see your position.
             </p>
           </div>
           {fallbackChain && (
@@ -85,12 +127,12 @@ export function ProtocolStatusBanner() {
               onClick={() => switchChain({ chainId: fallbackChain.id })}
               className='shrink-0 rounded-md bg-orange-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-orange-700 transition-colors'
             >
-              Switch to {fallbackChain.name}
+              Switch network
             </button>
           )}
         </div>
       )}
-      {isPaused && (
+      {showPaused && (
         <div className='flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950/40 p-4'>
           <PauseCircle className='h-5 w-5 shrink-0 text-red-600 dark:text-red-400 mt-0.5' />
           <div>
@@ -109,7 +151,7 @@ export function ProtocolStatusBanner() {
           </div>
         </div>
       )}
-      {showPriceWarning && (
+      {showPrice && (
         <div className='flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950/40 p-4'>
           <AlertTriangle className='h-5 w-5 shrink-0 text-yellow-600 dark:text-yellow-400 mt-0.5' />
           <div>
@@ -117,8 +159,8 @@ export function ProtocolStatusBanner() {
               Price feed issue
             </p>
             <p className='text-sm text-yellow-700 dark:text-yellow-400'>
-              {priceMessage} Operations that depend on pricing (loans,
-              deposits, claims) may fail until the feed updates.
+              {priceMessage} Operations that depend on pricing (loans, deposits,
+              claims) may fail until the feed updates.
             </p>
           </div>
         </div>

--- a/src/components/dashboard/PriceDataBanner.tsx
+++ b/src/components/dashboard/PriceDataBanner.tsx
@@ -3,6 +3,7 @@
 import { usePricing } from '@/src/hooks/usePricing'
 import { Card, CardContent } from '@/src/components/ui/card'
 import { BarChart } from 'lucide-react'
+import { useIsWrongNetwork } from '@/src/hooks/useIsWrongNetwork'
 
 function PriceDataBannerSkeleton() {
   return (
@@ -55,6 +56,10 @@ function PriceDataBannerError({ error }: { error: Error }) {
 }
 
 export function PriceDataBanner() {
+  // On the wrong network every read fails, so "Price Data Unavailable" would be
+  // a symptom competing with the one banner that can actually be acted on.
+  const isWrongNetwork = useIsWrongNetwork()
+
   const {
     spotPrice,
     monthlyAverage,
@@ -65,6 +70,9 @@ export function PriceDataBanner() {
     error
   } = usePricing()
 
+  // Suppressed entirely on the wrong network: the failure is the network, and
+  // ProtocolStatusBanner is already saying so with the switch CTA.
+  if (isWrongNetwork) return null
   if (isLoading) return <PriceDataBannerSkeleton />
   if (error) return <PriceDataBannerError error={error} />
 

--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -120,7 +120,7 @@ const COLUMNS = [
   { label: 'Time Period', sub: null },
   { label: 'Weight', sub: '(Multiplier)' },
   { label: 'Lock Duration', sub: '(Years)' },
-  { label: 'Estimated Total', sub: 'Return (%)' }
+  { label: 'Illustrative Total', sub: 'Returns*' }
 ] as const
 
 const HEAD_CELL =
@@ -191,10 +191,10 @@ export function DisconnectedLiquidity() {
           />
           <div className='text-left'>
             <h3 className='text-xl font-extrabold tracking-tight text-gray-900 sm:text-2xl dark:text-gray-100'>
-              ESTIMATED RETURNS
+              ILLUSTRATIVE RETURN SCENARIOS
             </h3>
             <p className='text-sm font-medium italic text-gray-500 dark:text-gray-400'>
-              (Current Model Assumptions)
+              Model Outputs Based on Stated Protocol-Activity Assumptions
             </p>
           </div>
         </div>

--- a/src/components/liquidity/DisconnectedLiquidity.tsx
+++ b/src/components/liquidity/DisconnectedLiquidity.tsx
@@ -247,7 +247,7 @@ export function DisconnectedLiquidity() {
         {/* Deliberately set smaller than the table it sits under: it has to be
             present and readable without competing with the figures above. */}
         <p className='mt-4 text-left text-[10px] leading-relaxed text-gray-500 sm:text-xs dark:text-gray-400'>
-          Illustrative outcomes are model-generated and are not promised or
+          *Illustrative outcomes are model-generated and are not promised or
           guaranteed. Actual protocol outcomes depend on borrower demand,
           utilization, collateral performance, market conditions, refinancing
           activity, smart-contract execution and other factors. Digital assets

--- a/src/hooks/useIsWrongNetwork.ts
+++ b/src/hooks/useIsWrongNetwork.ts
@@ -1,0 +1,34 @@
+'use client'
+import { useAccount } from 'wagmi'
+import { loansAddress } from '@/src/generated'
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+/** True when this build has a real Loans address for the chain. */
+export function hasLoansAddress(id: number): boolean {
+  // Widened to string on purpose: the generated literal types make a
+  // zero-address comparison a type error, but at runtime an unconfigured env
+  // var really does yield the zero address.
+  const addr = loansAddress[id as keyof typeof loansAddress] as
+    | string
+    | undefined
+  return !!addr && addr !== ZERO_ADDRESS
+}
+
+/**
+ * Whether the connected wallet is on a chain this build cannot serve.
+ *
+ * Deliberately reads `useAccount().chain` and NOT `useChainId()`. The latter
+ * returns `config.state.chainId`, which wagmi clamps to a configured chain — so
+ * it reports a supported chain even while the wallet sits on an unsupported
+ * one. Detecting with it left the wrong-network banner silent and the failure
+ * surfaced instead as a raw "priceDataFeed returned no data (0x)" error.
+ *
+ * Every read fails on the wrong network, so anything downstream that would show
+ * an error is a symptom of this. Those surfaces consult this hook and stay
+ * quiet, leaving one banner with one actionable CTA.
+ */
+export function useIsWrongNetwork(): boolean {
+  const { isConnected, chain } = useAccount()
+  return isConnected && (!chain || !hasLoansAddress(chain.id))
+}


### PR DESCRIPTION
Two changes since the last release: a real bug fix reported from production, and copy on the liquidity landing page. 5 files.

## Fix — the wrong-network banner never fired (#43)

Reported from `lending.lemloans.io/liquidity`: a wallet on the wrong network showed no values and this instead —

> **Price feed issue** — The contract function "priceDataFeed" returned no data ("0x").

— while RainbowKit's own pill correctly read *Wrong network*.

Detection tested `useChainId()`, which returns `config.state.chainId`. **wagmi clamps that to a configured chain**, so a wallet on Ethereum read as a supported chain, the guard passed, and the banner stayed silent — while the reads went to the wallet's actual chain, returned `0x`, and surfaced as a raw contract error.

It now uses `useAccount().chain`, resolved as `config.chains.find(c => c.id === connection.chainId)` and therefore `undefined` when the wallet's chain isn't configured. That is the same signal RainbowKit uses, which is why its pill was right and ours was wrong.

**One banner owns the message.** Extracted `useIsWrongNetwork()` so every surface shares one predicate. On the wrong network every read fails, so anything downstream is a symptom — the paused warning, the price-feed warning, `PriceDataBanner`'s "Price Data Unavailable" card and `Calculator`'s inline simulation error now stay quiet and defer to the single actionable banner. **On the right network they behave exactly as before.**

New copy, naming both chains:

```
Switch to BNB Smart Chain
Your wallet is on Ethereum. LemLoans runs on BNB Smart Chain — switch to see your position.
[ Switch network ]
```

`useAccount().chain` is undefined for unconfigured chains, so `COMMON_CHAIN_NAMES` maps the ids a wallet is realistically parked on (Ethereum, Polygon, Base, Arbitrum, OP, Avalanche, BSC + testnets) **for display only** — nothing is ever read from them, and unknown ids fall back to "another network".

## Copy — returns table (#44, #45)

| was | now |
|---|---|
| ESTIMATED RETURNS | **ILLUSTRATIVE RETURN SCENARIOS** |
| (Current Model Assumptions) | **Model Outputs Based on Stated Protocol-Activity Assumptions** |
| Estimated Total / Return (%) | **Illustrative Total / Returns\*** |

The footnote beneath the table now opens with the matching `*`, so the marker and the disclaimer are tied together.

## Verification

Driven in a real browser, both `/` and `/liquidity`:

| scenario | result |
|---|---|
| wallet on Ethereum / Polygon | banner shown, correct chain named, switch button wired |
| wrong network | price-feed, "Price Data Unavailable", paused and raw `0x` errors all suppressed |
| **right network + broken price feed** | **price warning still shows** — suppression is conditional, not permanent |
| right network, healthy | no banners, normal dashboard |
| returns table at 430px / 1280px | all strings render, no clipping, no sideways scroll |

`npm run build`, `npm run pages:build` and `tsc` clean from a cold tree; 357 tests pass; working tree clean and `public/` assets intact.

## Not included

On the wrong network the banner still renders *above* the dashboard rather than replacing it, so empty cards remain visible beneath it. That was the original complaint's remaining rough edge, but it is a layout change rather than a fix and is deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)