### PR TITLE
feat: accept only ?affiliate= for the referral link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A referral link carries **two** halves, and both are required:
 https://<app>/liquidity?affiliate=0xAFFILIATE&commissions=0xCOMMISSIONS
 ```
 
-- `?affiliate=` (or `?ref=`) — the affiliate's wallet, credited with the commission.
+- `?affiliate=` — the affiliate's wallet, credited with the commission.
 - `?commissions=` — the **per-company** commissions contract, which must appear in the
   router's `allowedCommissionsList()`. This is why it travels in the link rather than in
   build config: one build serves every partner.

--- a/src/__tests__/referral-logic.test.ts
+++ b/src/__tests__/referral-logic.test.ts
@@ -28,37 +28,38 @@ const REFERRER = getAddress(REFERRER_LOWER)
 const OTHER = getAddress('0xc6e1cc44bbc9e047b5c25966dffe7ea673e913e0')
 
 describe('referral param parsing', () => {
-  it('accepts ?ref=', () => {
-    expect(parseReferrerFromSearch(`?ref=${REFERRER}`)).toBe(REFERRER)
+  it('ignores the legacy ?ref= key', () => {
+    // Dropped in favour of ?affiliate=, which is what the affiliate dapp emits.
+    expect(parseReferrerFromSearch(`?ref=${REFERRER}`)).toBeNull()
   })
 
   it('accepts ?affiliate= — the sibling affiliate dapp generates these links', () => {
     expect(parseReferrerFromSearch(`?affiliate=${REFERRER}`)).toBe(REFERRER)
   })
 
-  it('prefers ref over affiliate when both are present', () => {
-    expect(parseReferrerFromSearch(`?affiliate=${OTHER}&ref=${REFERRER}`)).toBe(
+  it('reads affiliate even when a legacy ref is also present', () => {
+    expect(parseReferrerFromSearch(`?ref=${OTHER}&affiliate=${REFERRER}`)).toBe(
       REFERRER
     )
   })
 
   it('checksums a lowercase address', () => {
-    const parsed = parseReferrerFromSearch(`?ref=${REFERRER_LOWER}`)
+    const parsed = parseReferrerFromSearch(`?affiliate=${REFERRER_LOWER}`)
     expect(parsed).toBe(REFERRER)
     expect(parsed).not.toBe(REFERRER_LOWER)
   })
 
   it('accepts a URLSearchParams instance as well as a raw string', () => {
-    const params = new URLSearchParams({ ref: REFERRER })
+    const params = new URLSearchParams({ affiliate: REFERRER })
     expect(parseReferrerFromSearch(params)).toBe(REFERRER)
   })
 
   it('returns null for malformed values — the gate turns that into a block', () => {
-    expect(parseReferrerFromSearch('?ref=0x123')).toBeNull()
-    expect(parseReferrerFromSearch('?ref=not-an-address')).toBeNull()
-    expect(parseReferrerFromSearch('?ref=')).toBeNull()
+    expect(parseReferrerFromSearch('?affiliate=0x123')).toBeNull()
+    expect(parseReferrerFromSearch('?affiliate=not-an-address')).toBeNull()
+    expect(parseReferrerFromSearch('?affiliate=')).toBeNull()
     // Right length, invalid characters
-    expect(parseReferrerFromSearch(`?ref=0x${'z'.repeat(40)}`)).toBeNull()
+    expect(parseReferrerFromSearch(`?affiliate=0x${'z'.repeat(40)}`)).toBeNull()
   })
 
   it('returns null when the param is missing entirely', () => {
@@ -242,9 +243,15 @@ describe('commissions param parsing', () => {
 
 describe('hasReferralParams', () => {
   it('is true whenever a referral key is present, even if the value is junk', () => {
-    expect(hasReferralParams('?ref=nonsense')).toBe(true)
+    expect(hasReferralParams('?affiliate=nonsense')).toBe(true)
     expect(hasReferralParams('?affiliate=')).toBe(true)
     expect(hasReferralParams('?commissions=0x123')).toBe(true)
+  })
+
+  it('treats a legacy ?ref= only link as no link at all', () => {
+    // It no longer counts as a referral key, so the visitor is told a link is
+    // required rather than that their link is broken.
+    expect(hasReferralParams(`?ref=${REFERRER}`)).toBe(false)
   })
 
   it('is false for an unrelated or empty query string', () => {

--- a/src/hooks/referral/useReferralParam.ts
+++ b/src/hooks/referral/useReferralParam.ts
@@ -51,7 +51,7 @@ function writeStored(pair: StoredPair | null) {
 /**
  * Captures the referral link and remembers it for the visit.
  *
- * A link carries two halves — the affiliate (`?ref=` or `?affiliate=`) and the
+ * A link carries two halves — the affiliate (`?affiliate=`) and the
  * per-company commissions contract (`?commissions=`) — and they are treated as
  * a PAIR throughout:
  *

--- a/src/utils/referral.ts
+++ b/src/utils/referral.ts
@@ -8,8 +8,8 @@ import { getAddress, isAddress, decodeEventLog } from 'viem'
 import type { Abi, Log } from 'viem'
 import referralDepositRouterAbiJson from '@/src/abis/ReferralDepositRouter.json'
 
-/** Query-string keys that may carry a referrer, in priority order. */
-export const REFERRAL_PARAM_KEYS = ['ref', 'affiliate'] as const
+/** Query-string key carrying the affiliate. Matches what the affiliate dapp emits. */
+export const REFERRAL_PARAM_KEYS = ['affiliate'] as const
 
 /**
  * Query-string keys carrying the commissions contract. This is per-company, so
@@ -58,10 +58,9 @@ function firstValue(
 }
 
 /**
- * Pull a referrer out of a query string, accepting both `?ref=` (this dapp) and
- * `?affiliate=` (the links royal-citadel-affiliate-dapp generates). `ref` wins
- * when both are present. Returns null for a missing OR malformed value — the
- * caller distinguishes the two via `hasReferralParams`.
+ * Pull the affiliate out of a query string (`?affiliate=`, the parameter
+ * royal-citadel-affiliate-dapp generates). Returns null for a missing OR
+ * malformed value — the caller distinguishes the two via `hasReferralParams`.
  */
 export function parseReferrerFromSearch(
   search: string | URLSearchParams | null | undefined


### PR DESCRIPTION
`?ref=` was a synonym this dapp invented and **nothing ever produced** — `royal-citadel-affiliate-dapp` builds every link with `?affiliate=`, at all three of its generation sites. Dropping it leaves one parameter with one name.

```
/liquidity?affiliate=0xAFFILIATE&commissions=0xCOMMISSIONS
```

`ref` appeared only in the priority array, two doc comments and the README. No UI copy referenced it, so no user-facing wording changes.

### Behaviour change worth noting

A `?ref=`-only link now reads as **no link at all** rather than a broken one, because `ref` is no longer a referral key. The visitor is told a link is required rather than that theirs is malformed — the more accurate of the two.

### Verified

In a browser on citron:

| link | result |
|---|---|
| `?affiliate=0x6D8c…&commissions=0x3330…` | **Referred by 0x6D8c…2488** |
| `?ref=0x6D8c…&commissions=0x3330…` | *This referral link is incomplete — missing a valid affiliate address* |

358 tests pass (+1 covering the legacy-link case). `npm run build`, `npm run pages:build` and `tsc` clean.

### ⚠ Existing `?ref=` links stop working

Any test or staging link using `?ref=` — including the ones used in this project's own testing — needs updating to `?affiliate=`. No production links are affected, since the affiliate dapp has only ever emitted `?affiliate=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)