### PR TITLE
fix: keep toasts up long enough to read

### DIFF
--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useToast } from '@/src/hooks/use-toast'
 import {
   Toast,
@@ -10,11 +11,61 @@ import {
   ToastViewport
 } from '@/src/components/ui/toast'
 
+/**
+ * Floor on how long a toast stays up. Deposit results carry a couple of
+ * sentences — the referral commission outcome among them — and Radix's 5s
+ * default was closing them mid-read.
+ */
+const MIN_VISIBLE_MS = 5000
+
 export function Toaster() {
-  const { toasts } = useToast()
+  const { toasts, dismiss } = useToast()
+
+  // Identity of the currently-open set, so the effect restarts when a new toast
+  // replaces an old one (TOAST_LIMIT is 1, so that is the normal case).
+  const openIds = toasts
+    .filter((t) => t.open !== false)
+    .map((t) => t.id)
+    .join(',')
+
+  useEffect(() => {
+    if (!openIds) return
+
+    // Dismiss at max(shown + 5s, first click) — a click before the floor still
+    // waits it out, a click after it closes immediately, and with no click at
+    // all the toast stays put rather than vanishing unread.
+    const shownAt = Date.now()
+    let dismissTimer: number | undefined
+
+    const onPointerDown = () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      const remaining = MIN_VISIBLE_MS - (Date.now() - shownAt)
+      dismissTimer = window.setTimeout(
+        () => dismiss(),
+        remaining > 0 ? remaining : 0
+      )
+    }
+
+    // Attached on the next tick: the click that produced this toast (Confirm
+    // Deposit, say) is still propagating, and would otherwise dismiss it
+    // instantly.
+    const attachTimer = window.setTimeout(
+      () => document.addEventListener('pointerdown', onPointerDown, true),
+      0
+    )
+
+    return () => {
+      window.clearTimeout(attachTimer)
+      if (dismissTimer !== undefined) window.clearTimeout(dismissTimer)
+      document.removeEventListener('pointerdown', onPointerDown, true)
+    }
+  }, [openIds, dismiss])
 
   return (
-    <ToastProvider>
+    // Infinity is a documented Radix escape hatch (`duration || duration ===
+    // Infinity`) that disables its auto-close, handing dismissal to the effect
+    // above. The X button and swipe still work as before.
+    <ToastProvider duration={Infinity}>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
           <Toast key={id} {...props}>


### PR DESCRIPTION
Toasts were closing mid-read. Radix auto-closed each one after its default **5s measured from when it appeared**, not from when the reader got to it — and deposit results run to a couple of sentences, the referral commission outcome among them.

Dismissal is now **max(5s, first click anywhere)**:

- click **before** 5s → still waits the floor out
- click **after** 5s → closes immediately
- **no click** → stays put rather than vanishing unread

Radix's auto-close is disabled with `duration={Infinity}`, its documented escape hatch (`duration || duration === Infinity`), handing the decision to an effect in `Toaster`. The X button and swipe-to-dismiss are untouched.

Two details worth knowing:

- The click listener attaches on the **next tick**. The click that raised the toast — the Confirm Deposit press — is still propagating and would otherwise dismiss it instantly.
- `TOAST_LIMIT` is 1, so a toast that is never clicked **cannot stack**; the next one replaces it.

### Measured in a browser against a real toast

| case | result |
|---|---|
| no click | still visible at 8.0s |
| click at 1.0s | visible at 3.0s, gone by 6.5s |
| click at 6.5s | gone within 800ms |

`npm run build`, `npm run pages:build` and `tsc` clean; 358 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)