### PR TITLE
fix: left-align the deposit-fee note with the referral note

### DIFF
--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -715,7 +715,7 @@ export function AddLiquidityCard({
                       ? `~${depositFeeTokens} ${symbol}`
                       : 'Applies'
                   }
-                  sub='Taken on top of the deposit amount'
+                  note='Taken on top of the deposit amount'
                 />
               )}
               {depositNativeFee !== undefined && depositNativeFee > 0n && (


### PR DESCRIPTION
"Taken on top of the deposit amount" was passed as `sub`, which renders inside the right-aligned `<dd>` under the value. The referral note uses `note`, a full-width left-aligned `<p>`. Two explanatory sentences in the same dialog were justified to opposite edges.

Moved to `note` — no CSS change, `DetailRow` already had the slot.

**"You deposit" keeps its `sub`** (`~500.00 LUSD`). That one qualifies the value it sits under, so right-aligned is correct there.

Measured in a browser: the fee note, the referral note and the row labels now share a left edge at **422px**.

`npm run build`, `npm run pages:build` and `tsc` clean; 358 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)