### PR TITLE
Deposit dialog alignment, toast timing, and Earnings Fee stat removal

### DIFF
--- a/src/components/liquidity/AddLiquidityCard.tsx
+++ b/src/components/liquidity/AddLiquidityCard.tsx
@@ -715,7 +715,7 @@ export function AddLiquidityCard({
                       ? `~${depositFeeTokens} ${symbol}`
                       : 'Applies'
                   }
-                  sub='Taken on top of the deposit amount'
+                  note='Taken on top of the deposit amount'
                 />
               )}
               {depositNativeFee !== undefined && depositNativeFee > 0n && (

--- a/src/components/liquidity/LiquidityPerformance.tsx
+++ b/src/components/liquidity/LiquidityPerformance.tsx
@@ -7,7 +7,7 @@ import {
   CardContent,
   CardDescription,
   CardHeader,
-  CardTitle,
+  CardTitle
 } from '@/src/components/ui/card'
 import { Button } from '@/src/components/ui/button'
 import { Badge } from '@/src/components/ui/badge'
@@ -18,7 +18,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
+  DialogFooter
 } from '@/src/components/ui/dialog'
 import { useToast } from '@/src/hooks/use-toast'
 import { formatTokenAmount } from '@/src/utils/decimals'
@@ -35,36 +35,59 @@ import {
   Coins,
   Send,
   Wallet,
-  Repeat2,
+  Repeat2
 } from 'lucide-react'
 import {
   handleContractError,
-  type ContractError,
+  type ContractError
 } from '@/src/utils/errorHandling'
 import type { UseLiquidityPoolReturn } from '@/src/hooks/liquidity/useLiquidityPool'
 interface LiquidityPerformanceProps {
   liquidityPool: UseLiquidityPoolReturn
 }
 
-function StatItem({ label, value, warning }: { label: string; value: string; warning?: boolean }) {
+function StatItem({
+  label,
+  value,
+  warning
+}: {
+  label: string
+  value: string
+  warning?: boolean
+}) {
   return (
     <div className='space-y-1'>
       <p className='text-xs text-muted-foreground'>{label}</p>
-      <p className={`text-sm font-medium ${warning ? 'text-destructive' : ''}`}>{value}</p>
+      <p className={`text-sm font-medium ${warning ? 'text-destructive' : ''}`}>
+        {value}
+      </p>
     </div>
   )
 }
 
-function formatCurrency(value: bigint, decimals: number, symbol: string): string {
+function formatCurrency(
+  value: bigint,
+  decimals: number,
+  symbol: string
+): string {
   // Floor, never round up — these are balances/claimable amounts, and a
   // rounded-up display overstates what the user can actually withdraw.
-  const formatted = floorToDecimals(parseFloat(formatTokenAmount(value, decimals)), 4)
+  const formatted = floorToDecimals(
+    parseFloat(formatTokenAmount(value, decimals)),
+    4
+  )
   return `${formatted.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 })} ${symbol}`
 }
 
 function formatShares(value: bigint, decimals: number): string {
-  const formatted = floorToDecimals(parseFloat(formatTokenAmount(value, decimals)), 4)
-  return formatted.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+  const formatted = floorToDecimals(
+    parseFloat(formatTokenAmount(value, decimals)),
+    4
+  )
+  return formatted.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4
+  })
 }
 
 function formatPct(value: number): string {
@@ -97,7 +120,7 @@ function formatDate(timestamp: bigint): string {
   return new Date(ts * 1000).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
-    day: 'numeric',
+    day: 'numeric'
   })
 }
 
@@ -124,19 +147,43 @@ interface TransferAccountModal {
   confirmed: boolean
 }
 
-const emptyAccountModal: TransferAccountModal = { open: false, address: '', confirmed: false }
+const emptyAccountModal: TransferAccountModal = {
+  open: false,
+  address: '',
+  confirmed: false
+}
 
 function isValidAddress(addr: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(addr)
 }
 
-export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProps) {
+export function LiquidityPerformance({
+  liquidityPool
+}: LiquidityPerformanceProps) {
   const { toast } = useToast()
   const { address: connectedAddress } = useAccount()
   const [isProcessing, setIsProcessing] = useState<string | null>(null)
-  const [transferAccountModal, setTransferAccountModal] = useState<TransferAccountModal>(emptyAccountModal)
-  const [compoundModal, setCompoundModal] = useState<{ open: boolean; selectedTierIndex: number | null }>({ open: false, selectedTierIndex: null })
-  const [confirmModal, setConfirmModal] = useState<{ open: boolean; title: string; description: string; actionName: string; action: () => Promise<unknown>; successMsg: string }>({ open: false, title: '', description: '', actionName: '', action: async () => {}, successMsg: '' })
+  const [transferAccountModal, setTransferAccountModal] =
+    useState<TransferAccountModal>(emptyAccountModal)
+  const [compoundModal, setCompoundModal] = useState<{
+    open: boolean
+    selectedTierIndex: number | null
+  }>({ open: false, selectedTierIndex: null })
+  const [confirmModal, setConfirmModal] = useState<{
+    open: boolean
+    title: string
+    description: string
+    actionName: string
+    action: () => Promise<unknown>
+    successMsg: string
+  }>({
+    open: false,
+    title: '',
+    description: '',
+    actionName: '',
+    action: async () => {},
+    successMsg: ''
+  })
 
   const {
     userStatus,
@@ -158,7 +205,7 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     compoundEarnings,
     pullEarnings,
     transferAccount,
-    refetch,
+    refetch
   } = liquidityPool
 
   const decimals = stableTokenDecimals ?? 18
@@ -170,26 +217,47 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
     abi: liquidityPoolAbi as unknown as any[],
     functionName: 'getAssetLockTiers',
     args: stableTokenAddress ? [stableTokenAddress] : undefined,
-    query: { enabled: !!stableTokenAddress && !!liquidityPoolContractAddress },
+    query: { enabled: !!stableTokenAddress && !!liquidityPoolContractAddress }
   })
 
   const stableLockTiers = useMemo(() => {
     if (!stableLockTiersRaw) return []
-    return (stableLockTiersRaw as readonly { duration: bigint; interestMultiplier: bigint; isEnabled: boolean }[])
+    return (
+      stableLockTiersRaw as readonly {
+        duration: bigint
+        interestMultiplier: bigint
+        isEnabled: boolean
+      }[]
+    )
       .filter((t) => t.isEnabled)
-      .map((t) => ({ duration: t.duration, interestMultiplier: t.interestMultiplier }))
-      .sort((a, b) => (a.duration < b.duration ? -1 : a.duration > b.duration ? 1 : 0))
+      .map((t) => ({
+        duration: t.duration,
+        interestMultiplier: t.interestMultiplier
+      }))
+      .sort((a, b) =>
+        a.duration < b.duration ? -1 : a.duration > b.duration ? 1 : 0
+      )
   }, [stableLockTiersRaw])
 
   // Computed values
   const poolOwnership = useMemo(() => {
-    if (!userStatus || !poolStatus || poolStatus.totalLiquidityShares === 0n) return 0
-    return (Number(userStatus.liquidityShares) / Number(poolStatus.totalLiquidityShares)) * 100
+    if (!userStatus || !poolStatus || poolStatus.totalLiquidityShares === 0n)
+      return 0
+    return (
+      (Number(userStatus.liquidityShares) /
+        Number(poolStatus.totalLiquidityShares)) *
+      100
+    )
   }, [userStatus, poolStatus])
 
   const interestShareOwnership = useMemo(() => {
-    if (!userStatus || !poolStatus || poolStatus.totalInterestShares === 0n) return 0
-    return (Number(userStatus.interestShares) / Number(poolStatus.totalInterestShares)) * 100
+    if (!userStatus || !poolStatus || poolStatus.totalInterestShares === 0n)
+      return 0
+    return (
+      (Number(userStatus.interestShares) /
+        Number(poolStatus.totalInterestShares)) *
+      100
+    )
   }, [userStatus, poolStatus])
 
   const lifetimeEarnings = useMemo(() => {
@@ -230,7 +298,9 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
   }, [poolStatus])
 
   const sortedDepositEntries = useMemo(() => {
-    return [...depositEntries].sort((a, b) => Number(a.lockDuration - b.lockDuration))
+    return [...depositEntries].sort((a, b) =>
+      Number(a.lockDuration - b.lockDuration)
+    )
   }, [depositEntries])
 
   // Action handlers. Returns true on success so confirm modals \u2014 which stay
@@ -277,11 +347,27 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
         >
           <StatItem
             label='Total Liquidity Available'
-            value={liquidityStatus ? formatCurrency(liquidityStatus.principalAvailable, decimals, symbol) : 'Loading...'}
+            value={
+              liquidityStatus
+                ? formatCurrency(
+                    liquidityStatus.principalAvailable,
+                    decimals,
+                    symbol
+                  )
+                : 'Loading...'
+            }
           />
           <StatItem
             label='Principal in Active Loans'
-            value={liquidityStatus ? formatCurrency(liquidityStatus.principalInLoans, decimals, symbol) : 'Loading...'}
+            value={
+              liquidityStatus
+                ? formatCurrency(
+                    liquidityStatus.principalInLoans,
+                    decimals,
+                    symbol
+                  )
+                : 'Loading...'
+            }
           />
           <StatItem
             label='Pool Utilization'
@@ -296,15 +382,27 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           )}
           <StatItem
             label='Total Pool Shares'
-            value={poolStatus ? formatShares(poolStatus.totalLiquidityShares, decimals) : 'Loading...'}
+            value={
+              poolStatus
+                ? formatShares(poolStatus.totalLiquidityShares, decimals)
+                : 'Loading...'
+            }
           />
           <StatItem
             label='Total Interest Shares'
-            value={poolStatus ? formatShares(poolStatus.totalInterestShares, decimals) : 'Loading...'}
+            value={
+              poolStatus
+                ? formatShares(poolStatus.totalInterestShares, decimals)
+                : 'Loading...'
+            }
           />
           <StatItem
             label='Total Loans Issued'
-            value={totalLoansIssued !== undefined ? Number(totalLoansIssued).toLocaleString() : 'Loading...'}
+            value={
+              totalLoansIssued !== undefined
+                ? Number(totalLoansIssued).toLocaleString()
+                : 'Loading...'
+            }
           />
         </div>
       </div>
@@ -320,15 +418,31 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
       <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
         <StatItem
           label='Total Interest Generated'
-          value={liquidityStatus ? formatCurrency(liquidityStatus.interestEarned, decimals, symbol) : 'Loading...'}
+          value={
+            liquidityStatus
+              ? formatCurrency(liquidityStatus.interestEarned, decimals, symbol)
+              : 'Loading...'
+          }
         />
         <StatItem
           label='Uncollected Pool Earnings'
-          value={poolStatus ? formatCurrency(poolStatus.availableEarningsInLoans, decimals, symbol) : 'Loading...'}
+          value={
+            poolStatus
+              ? formatCurrency(
+                  poolStatus.availableEarningsInLoans,
+                  decimals,
+                  symbol
+                )
+              : 'Loading...'
+          }
         />
         <StatItem
           label='Last Distribution'
-          value={poolStatus ? formatRelativeTime(poolStatus.lastEarningsWithdrawal) : 'Loading...'}
+          value={
+            poolStatus
+              ? formatRelativeTime(poolStatus.lastEarningsWithdrawal)
+              : 'Loading...'
+          }
         />
         <StatItem
           label='Next Distribution Available'
@@ -344,18 +458,24 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
               setConfirmModal({
                 open: true,
                 title: 'Distribute Earnings',
-                description: 'This will pull earned interest from the Loans contract into the liquidity pool, making it available for all depositors to claim. Anyone can trigger this action.',
+                description:
+                  'This will pull earned interest from the Loans contract into the liquidity pool, making it available for all depositors to claim. Anyone can trigger this action.',
                 actionName: 'Distribute',
                 action: () => pullEarnings(),
-                successMsg: 'Earnings distributed to the pool.',
+                successMsg: 'Earnings distributed to the pool.'
               })
             }
             disabled={isProcessing !== null}
           >
             {isProcessing === 'Distribute' ? (
-              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Distributing...</>
+              <>
+                <Loader2 className='h-4 w-4 mr-2 animate-spin' />{' '}
+                Distributing...
+              </>
             ) : (
-              <><ArrowDownToLine className='h-4 w-4 mr-2' /> Distribute Earnings</>
+              <>
+                <ArrowDownToLine className='h-4 w-4 mr-2' /> Distribute Earnings
+              </>
             )}
           </Button>
         </div>
@@ -381,7 +501,8 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
           </div>
           <div className='border-t pt-4 text-center'>
             <p className='text-sm text-muted-foreground'>
-              Deposit liquidity to start earning from borrower interest payments.
+              Deposit liquidity to start earning from borrower interest
+              payments.
             </p>
           </div>
         </CardContent>
@@ -392,379 +513,500 @@ export function LiquidityPerformance({ liquidityPool }: LiquidityPerformanceProp
   // Full position view
   return (
     <>
-    <Card>
-      <CardHeader>
-        <CardTitle className='flex items-center gap-2'>
-          <TrendingUp className='h-5 w-5' />
-          Liquidity Performance
-        </CardTitle>
-        <CardDescription>Your position and pool performance</CardDescription>
-      </CardHeader>
-      <CardContent className='space-y-6'>
-        {/* 1. Your Position */}
-        <div className='space-y-3'>
-          <h3 className='text-sm font-semibold flex items-center gap-2'>
-            <Coins className='h-4 w-4' /> Your Position
-          </h3>
-          <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
-            <StatItem
-              label='Total Deposited'
-              value={userStatus ? formatCurrency(userStatus.totalPrincipal, decimals, symbol) : 'Loading...'}
-            />
-            <StatItem
-              label='Locked'
-              value={userStatus ? formatCurrency(userStatus.lockedPrincipal, decimals, symbol) : 'Loading...'}
-            />
-            <StatItem
-              label='Unlocked'
-              value={userStatus ? formatCurrency(userStatus.unlockedPrincipal, decimals, symbol) : 'Loading...'}
-            />
-            <StatItem
-              label='Pool Ownership'
-              value={formatPct(poolOwnership)}
-            />
-            <StatItem
-              label='Liquidity Shares'
-              value={userStatus ? formatShares(userStatus.liquidityShares, decimals) : '0'}
-            />
-            <StatItem
-              label='Interest Shares'
-              value={userStatus ? formatShares(userStatus.interestShares, decimals) : '0'}
-            />
-            <StatItem
-              label='Interest Share %'
-              value={formatPct(interestShareOwnership)}
-            />
-          </div>
-          {userStatus && userStatus.liquidityShares > 0n && (
-            <div className='pt-2'>
-              <Button
-                size='sm'
-                variant='outline'
-                onClick={() => setTransferAccountModal({ open: true, address: '', confirmed: false })}
-                disabled={isProcessing !== null}
-              >
-                <Send className='h-4 w-4 mr-2' />
-                Transfer Account
-              </Button>
-            </div>
-          )}
-        </div>
-
-        <div className='border-t' />
-
-        {/* 2. Your Earnings */}
-        <div className='space-y-3'>
-          <h3 className='text-sm font-semibold flex items-center gap-2'>
-            <TrendingUp className='h-4 w-4' /> Your Earnings
-          </h3>
-          <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
-            <StatItem
-              label='Pending Earnings'
-              value={userStatus ? formatCurrency(userStatus.pendingEarnings, decimals, symbol) : 'Loading...'}
-            />
-            <StatItem
-              label='Total Claimed'
-              value={userStatus ? formatCurrency(userStatus.totalClaimed, decimals, symbol) : 'Loading...'}
-            />
-            <StatItem
-              label='Lifetime Earnings'
-              value={formatCurrency(lifetimeEarnings, decimals, symbol)}
-            />
-            {earningsFeePct && (
-              <StatItem label='Earnings Fee' value={formatPct(earningsFeePct)} />
-            )}
-          </div>
-          {userStatus && userStatus.pendingEarnings > 0n && (
-            <div className='flex gap-2 pt-2'>
-              <Button
-                size='sm'
-                variant='outline'
-                onClick={() =>
-                  setConfirmModal({
-                    open: true,
-                    title: 'Claim Earnings',
-                    description: `Your pending earnings of ${formatCurrency(userStatus.pendingEarnings, decimals, symbol)} will be transferred directly to your wallet.${earningsFeePct ? ` A ${earningsFeePct}% fee will be deducted.` : ''}`,
-                    actionName: 'Claim',
-                    action: () => claimEarnings(),
-                    successMsg: `${formatCurrency(userStatus.pendingEarnings, decimals, symbol)} claimed successfully.`,
-                  })
+      <Card>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2'>
+            <TrendingUp className='h-5 w-5' />
+            Liquidity Performance
+          </CardTitle>
+          <CardDescription>Your position and pool performance</CardDescription>
+        </CardHeader>
+        <CardContent className='space-y-6'>
+          {/* 1. Your Position */}
+          <div className='space-y-3'>
+            <h3 className='text-sm font-semibold flex items-center gap-2'>
+              <Coins className='h-4 w-4' /> Your Position
+            </h3>
+            <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
+              <StatItem
+                label='Total Deposited'
+                value={
+                  userStatus
+                    ? formatCurrency(
+                        userStatus.totalPrincipal,
+                        decimals,
+                        symbol
+                      )
+                    : 'Loading...'
                 }
-                disabled={isProcessing !== null}
-              >
-                {isProcessing === 'Claim' ? (
-                  <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Claiming...</>
-                ) : (
-                  <><Wallet className='h-4 w-4 mr-2' /> Claim</>
-                )}
-              </Button>
-              <Button
-                size='sm'
-                variant='outline'
-                onClick={() => setCompoundModal({ open: true, selectedTierIndex: null })}
-                disabled={isProcessing !== null}
-              >
-                {isProcessing === 'Compound' ? (
-                  <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Compounding...</>
-                ) : (
-                  <><Repeat2 className='h-4 w-4 mr-2' /> Compound</>
-                )}
-              </Button>
+              />
+              <StatItem
+                label='Locked'
+                value={
+                  userStatus
+                    ? formatCurrency(
+                        userStatus.lockedPrincipal,
+                        decimals,
+                        symbol
+                      )
+                    : 'Loading...'
+                }
+              />
+              <StatItem
+                label='Unlocked'
+                value={
+                  userStatus
+                    ? formatCurrency(
+                        userStatus.unlockedPrincipal,
+                        decimals,
+                        symbol
+                      )
+                    : 'Loading...'
+                }
+              />
+              <StatItem
+                label='Pool Ownership'
+                value={formatPct(poolOwnership)}
+              />
+              <StatItem
+                label='Liquidity Shares'
+                value={
+                  userStatus
+                    ? formatShares(userStatus.liquidityShares, decimals)
+                    : '0'
+                }
+              />
+              <StatItem
+                label='Interest Shares'
+                value={
+                  userStatus
+                    ? formatShares(userStatus.interestShares, decimals)
+                    : '0'
+                }
+              />
+              <StatItem
+                label='Interest Share %'
+                value={formatPct(interestShareOwnership)}
+              />
             </div>
-          )}
-        </div>
-
-        <div className='border-t' />
-
-        {/* 3. Pool Overview */}
-        <PoolOverview />
-
-        <div className='border-t' />
-
-        {/* 4. Earnings Distribution */}
-        <EarningsDistribution />
-
-        <div className='border-t' />
-
-        {/* 5. Deposit History */}
-        <div className='space-y-3'>
-          <h3 className='text-sm font-semibold flex items-center gap-2'>
-            <Clock className='h-4 w-4' /> Deposit History
-          </h3>
-          {sortedDepositEntries.length > 0 ? (
-            <div className='space-y-2'>
-              <div className='grid grid-cols-5 text-xs font-medium text-muted-foreground pb-1 border-b'>
-                <span>Deposit Amount</span>
-                <span>Token Amount</span>
-                <span>Lock Duration</span>
-                <span>Unlock Date</span>
-                <span>Status</span>
-              </div>
-              {sortedDepositEntries.map((entry, index) => {
-                const now = BigInt(Math.floor(Date.now() / 1000))
-                const isUnlocked = entry.unlockTime <= now
-                const originalKey = `${entry.token.toLowerCase()}:${entry.unlockTime}:${entry.lockDuration}`
-                const originalValue = originalDepositValues.get(originalKey) ?? entry.stableTokenValue
-                const meta = tokenMetadata.get(entry.token.toLowerCase())
-                const tokenAmountFormatted = meta
-                  ? formatCurrency(entry.tokenAmount, meta.decimals, meta.symbol)
-                  : '—'
-
-                return (
-                  <div key={index} className='grid grid-cols-5 items-center text-sm py-2 border-b border-border/50'>
-                    <span>{formatCurrency(originalValue, decimals, symbol)}</span>
-                    <span>{tokenAmountFormatted}</span>
-                    <span>{formatDuration(entry.lockDuration)}</span>
-                    <span>{formatDate(entry.unlockTime)}</span>
-                    <div>
-                      {isUnlocked ? (
-                        <Badge variant='green' className='text-xs'>
-                          <Unlock className='h-3 w-3 mr-1' /> Unlocked
-                        </Badge>
-                      ) : (
-                        <Badge variant='secondary' className='text-xs'>
-                          <Lock className='h-3 w-3 mr-1' /> Locked
-                        </Badge>
-                      )}
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          ) : (
-            <p className='text-sm text-muted-foreground'>No deposit entries found.</p>
-          )}
-
-        </div>
-      </CardContent>
-    </Card>
-
-    {/* Compound Earnings Modal */}
-    <Dialog
-      open={compoundModal.open}
-      onOpenChange={(open) => { if (!open && isProcessing !== null) return; if (!open) setCompoundModal({ open: false, selectedTierIndex: null }) }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Compound Earnings</DialogTitle>
-        </DialogHeader>
-        <div className='space-y-4 py-2'>
-          {userStatus && (
-            <p className='text-sm text-muted-foreground'>
-              Your pending earnings of {formatCurrency(userStatus.pendingEarnings, decimals, symbol)} will be deposited back into the pool as new shares. Select a lock duration below.
-            </p>
-          )}
-          {stableLockTiers.length === 0 ? (
-            <p className='text-sm text-muted-foreground'>No lock tiers available.</p>
-          ) : (
-            <div className='space-y-2'>
-              {stableLockTiers.map((tier, i) => (
-                <button
-                  key={i}
-                  type='button'
-                  onClick={() => setCompoundModal((m) => ({ ...m, selectedTierIndex: i }))}
-                  className={`w-full text-left rounded-md border px-4 py-3 text-sm transition-colors ${
-                    compoundModal.selectedTierIndex === i
-                      ? 'border-primary bg-primary/10'
-                      : 'border-border hover:border-primary/50'
-                  }`}
+            {userStatus && userStatus.liquidityShares > 0n && (
+              <div className='pt-2'>
+                <Button
+                  size='sm'
+                  variant='outline'
+                  onClick={() =>
+                    setTransferAccountModal({
+                      open: true,
+                      address: '',
+                      confirmed: false
+                    })
+                  }
+                  disabled={isProcessing !== null}
                 >
-                  <span className='font-medium'>{formatDuration(tier.duration)} lock</span>
-                  <span className='text-muted-foreground ml-2'>
-                    — {(Number(tier.interestMultiplier) / 100).toFixed(2)}× interest multiplier
-                  </span>
-                </button>
-              ))}
+                  <Send className='h-4 w-4 mr-2' />
+                  Transfer Account
+                </Button>
+              </div>
+            )}
+          </div>
+
+          <div className='border-t' />
+
+          {/* 2. Your Earnings */}
+          <div className='space-y-3'>
+            <h3 className='text-sm font-semibold flex items-center gap-2'>
+              <TrendingUp className='h-4 w-4' /> Your Earnings
+            </h3>
+            <div className='grid grid-cols-2 md:grid-cols-4 gap-4'>
+              <StatItem
+                label='Pending Earnings'
+                value={
+                  userStatus
+                    ? formatCurrency(
+                        userStatus.pendingEarnings,
+                        decimals,
+                        symbol
+                      )
+                    : 'Loading...'
+                }
+              />
+              <StatItem
+                label='Total Claimed'
+                value={
+                  userStatus
+                    ? formatCurrency(userStatus.totalClaimed, decimals, symbol)
+                    : 'Loading...'
+                }
+              />
+              <StatItem
+                label='Lifetime Earnings'
+                value={formatCurrency(lifetimeEarnings, decimals, symbol)}
+              />
             </div>
-          )}
-        </div>
-        <DialogFooter>
-          <Button
-            variant='outline'
-            onClick={() => setCompoundModal({ open: false, selectedTierIndex: null })}
-            disabled={isProcessing !== null}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={compoundModal.selectedTierIndex === null || isProcessing !== null}
-            onClick={async () => {
-              const tier = stableLockTiers[compoundModal.selectedTierIndex!]
-              const ok = await handleAction(
-                'Compound',
-                () => compoundEarnings(tier.duration),
-                'Earnings compounded into new shares.'
-              )
-              if (ok) setCompoundModal({ open: false, selectedTierIndex: null })
-            }}
-          >
-            {isProcessing === 'Compound' ? (
-              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Compounding…</>
-            ) : (
-              'Confirm'
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-
-    {/* Transfer Account Modal */}
-    <Dialog
-      open={transferAccountModal.open}
-      onOpenChange={(open) => { if (!open && isProcessing !== null) return; if (!open) setTransferAccountModal(emptyAccountModal) }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Transfer Account</DialogTitle>
-        </DialogHeader>
-        <div className='space-y-4 py-2'>
-          <p className='text-sm text-muted-foreground'>
-            All of your liquidity will be transferred to the entered wallet, including all deposits, shares, and any pending earnings. This action cannot be undone.
-          </p>
-          <div className='space-y-1.5'>
-            <label className='text-sm font-medium'>Recipient Wallet Address</label>
-            <Input
-              placeholder='0x...'
-              value={transferAccountModal.address}
-              onChange={(e) =>
-                setTransferAccountModal((m) => ({ ...m, address: e.target.value }))
-              }
-            />
-            {isValidAddress(transferAccountModal.address) &&
-              connectedAddress &&
-              transferAccountModal.address.toLowerCase() === connectedAddress.toLowerCase() && (
-              <p className='text-sm text-destructive'>You cannot transfer your account to yourself.</p>
+            {userStatus && userStatus.pendingEarnings > 0n && (
+              <div className='flex gap-2 pt-2'>
+                <Button
+                  size='sm'
+                  variant='outline'
+                  onClick={() =>
+                    setConfirmModal({
+                      open: true,
+                      title: 'Claim Earnings',
+                      description: `Your pending earnings of ${formatCurrency(userStatus.pendingEarnings, decimals, symbol)} will be transferred directly to your wallet.${earningsFeePct ? ` A ${earningsFeePct}% fee will be deducted.` : ''}`,
+                      actionName: 'Claim',
+                      action: () => claimEarnings(),
+                      successMsg: `${formatCurrency(userStatus.pendingEarnings, decimals, symbol)} claimed successfully.`
+                    })
+                  }
+                  disabled={isProcessing !== null}
+                >
+                  {isProcessing === 'Claim' ? (
+                    <>
+                      <Loader2 className='h-4 w-4 mr-2 animate-spin' />{' '}
+                      Claiming...
+                    </>
+                  ) : (
+                    <>
+                      <Wallet className='h-4 w-4 mr-2' /> Claim
+                    </>
+                  )}
+                </Button>
+                <Button
+                  size='sm'
+                  variant='outline'
+                  onClick={() =>
+                    setCompoundModal({ open: true, selectedTierIndex: null })
+                  }
+                  disabled={isProcessing !== null}
+                >
+                  {isProcessing === 'Compound' ? (
+                    <>
+                      <Loader2 className='h-4 w-4 mr-2 animate-spin' />{' '}
+                      Compounding...
+                    </>
+                  ) : (
+                    <>
+                      <Repeat2 className='h-4 w-4 mr-2' /> Compound
+                    </>
+                  )}
+                </Button>
+              </div>
             )}
           </div>
-          <div className='flex items-start gap-3 pt-1'>
-            <Checkbox
-              id='transfer-account-confirm'
-              checked={transferAccountModal.confirmed}
-              onCheckedChange={(checked) =>
-                setTransferAccountModal((m) => ({ ...m, confirmed: checked === true }))
+
+          <div className='border-t' />
+
+          {/* 3. Pool Overview */}
+          <PoolOverview />
+
+          <div className='border-t' />
+
+          {/* 4. Earnings Distribution */}
+          <EarningsDistribution />
+
+          <div className='border-t' />
+
+          {/* 5. Deposit History */}
+          <div className='space-y-3'>
+            <h3 className='text-sm font-semibold flex items-center gap-2'>
+              <Clock className='h-4 w-4' /> Deposit History
+            </h3>
+            {sortedDepositEntries.length > 0 ? (
+              <div className='space-y-2'>
+                <div className='grid grid-cols-5 text-xs font-medium text-muted-foreground pb-1 border-b'>
+                  <span>Deposit Amount</span>
+                  <span>Token Amount</span>
+                  <span>Lock Duration</span>
+                  <span>Unlock Date</span>
+                  <span>Status</span>
+                </div>
+                {sortedDepositEntries.map((entry, index) => {
+                  const now = BigInt(Math.floor(Date.now() / 1000))
+                  const isUnlocked = entry.unlockTime <= now
+                  const originalKey = `${entry.token.toLowerCase()}:${entry.unlockTime}:${entry.lockDuration}`
+                  const originalValue =
+                    originalDepositValues.get(originalKey) ??
+                    entry.stableTokenValue
+                  const meta = tokenMetadata.get(entry.token.toLowerCase())
+                  const tokenAmountFormatted = meta
+                    ? formatCurrency(
+                        entry.tokenAmount,
+                        meta.decimals,
+                        meta.symbol
+                      )
+                    : '—'
+
+                  return (
+                    <div
+                      key={index}
+                      className='grid grid-cols-5 items-center text-sm py-2 border-b border-border/50'
+                    >
+                      <span>
+                        {formatCurrency(originalValue, decimals, symbol)}
+                      </span>
+                      <span>{tokenAmountFormatted}</span>
+                      <span>{formatDuration(entry.lockDuration)}</span>
+                      <span>{formatDate(entry.unlockTime)}</span>
+                      <div>
+                        {isUnlocked ? (
+                          <Badge variant='green' className='text-xs'>
+                            <Unlock className='h-3 w-3 mr-1' /> Unlocked
+                          </Badge>
+                        ) : (
+                          <Badge variant='secondary' className='text-xs'>
+                            <Lock className='h-3 w-3 mr-1' /> Locked
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className='text-sm text-muted-foreground'>
+                No deposit entries found.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Compound Earnings Modal */}
+      <Dialog
+        open={compoundModal.open}
+        onOpenChange={(open) => {
+          if (!open && isProcessing !== null) return
+          if (!open) setCompoundModal({ open: false, selectedTierIndex: null })
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Compound Earnings</DialogTitle>
+          </DialogHeader>
+          <div className='space-y-4 py-2'>
+            {userStatus && (
+              <p className='text-sm text-muted-foreground'>
+                Your pending earnings of{' '}
+                {formatCurrency(userStatus.pendingEarnings, decimals, symbol)}{' '}
+                will be deposited back into the pool as new shares. Select a
+                lock duration below.
+              </p>
+            )}
+            {stableLockTiers.length === 0 ? (
+              <p className='text-sm text-muted-foreground'>
+                No lock tiers available.
+              </p>
+            ) : (
+              <div className='space-y-2'>
+                {stableLockTiers.map((tier, i) => (
+                  <button
+                    key={i}
+                    type='button'
+                    onClick={() =>
+                      setCompoundModal((m) => ({ ...m, selectedTierIndex: i }))
+                    }
+                    className={`w-full text-left rounded-md border px-4 py-3 text-sm transition-colors ${
+                      compoundModal.selectedTierIndex === i
+                        ? 'border-primary bg-primary/10'
+                        : 'border-border hover:border-primary/50'
+                    }`}
+                  >
+                    <span className='font-medium'>
+                      {formatDuration(tier.duration)} lock
+                    </span>
+                    <span className='text-muted-foreground ml-2'>
+                      — {(Number(tier.interestMultiplier) / 100).toFixed(2)}×
+                      interest multiplier
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant='outline'
+              onClick={() =>
+                setCompoundModal({ open: false, selectedTierIndex: null })
               }
-            />
-            <label
-              htmlFor='transfer-account-confirm'
-              className='text-sm leading-snug cursor-pointer'
+              disabled={isProcessing !== null}
             >
-              I understand that all liquidity, shares, and pending earnings will be transferred to the entered wallet and this cannot be reversed.
-            </label>
+              Cancel
+            </Button>
+            <Button
+              disabled={
+                compoundModal.selectedTierIndex === null ||
+                isProcessing !== null
+              }
+              onClick={async () => {
+                const tier = stableLockTiers[compoundModal.selectedTierIndex!]
+                const ok = await handleAction(
+                  'Compound',
+                  () => compoundEarnings(tier.duration),
+                  'Earnings compounded into new shares.'
+                )
+                if (ok)
+                  setCompoundModal({ open: false, selectedTierIndex: null })
+              }}
+            >
+              {isProcessing === 'Compound' ? (
+                <>
+                  <Loader2 className='h-4 w-4 mr-2 animate-spin' /> Compounding…
+                </>
+              ) : (
+                'Confirm'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Transfer Account Modal */}
+      <Dialog
+        open={transferAccountModal.open}
+        onOpenChange={(open) => {
+          if (!open && isProcessing !== null) return
+          if (!open) setTransferAccountModal(emptyAccountModal)
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Transfer Account</DialogTitle>
+          </DialogHeader>
+          <div className='space-y-4 py-2'>
+            <p className='text-sm text-muted-foreground'>
+              All of your liquidity will be transferred to the entered wallet,
+              including all deposits, shares, and any pending earnings. This
+              action cannot be undone.
+            </p>
+            <div className='space-y-1.5'>
+              <label className='text-sm font-medium'>
+                Recipient Wallet Address
+              </label>
+              <Input
+                placeholder='0x...'
+                value={transferAccountModal.address}
+                onChange={(e) =>
+                  setTransferAccountModal((m) => ({
+                    ...m,
+                    address: e.target.value
+                  }))
+                }
+              />
+              {isValidAddress(transferAccountModal.address) &&
+                connectedAddress &&
+                transferAccountModal.address.toLowerCase() ===
+                  connectedAddress.toLowerCase() && (
+                  <p className='text-sm text-destructive'>
+                    You cannot transfer your account to yourself.
+                  </p>
+                )}
+            </div>
+            <div className='flex items-start gap-3 pt-1'>
+              <Checkbox
+                id='transfer-account-confirm'
+                checked={transferAccountModal.confirmed}
+                onCheckedChange={(checked) =>
+                  setTransferAccountModal((m) => ({
+                    ...m,
+                    confirmed: checked === true
+                  }))
+                }
+              />
+              <label
+                htmlFor='transfer-account-confirm'
+                className='text-sm leading-snug cursor-pointer'
+              >
+                I understand that all liquidity, shares, and pending earnings
+                will be transferred to the entered wallet and this cannot be
+                reversed.
+              </label>
+            </div>
           </div>
-        </div>
-        <DialogFooter>
-          <Button
-            variant='outline'
-            onClick={() => setTransferAccountModal(emptyAccountModal)}
-            disabled={isProcessing !== null}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={
-              !isValidAddress(transferAccountModal.address) ||
-              !transferAccountModal.confirmed ||
-              isProcessing !== null ||
-              (!!connectedAddress && transferAccountModal.address.toLowerCase() === connectedAddress.toLowerCase())
-            }
-            onClick={async () => {
-              const to = transferAccountModal.address as `0x${string}`
-              const ok = await handleAction(
-                'TransferAccount',
-                () => transferAccount(to),
-                'Account transferred successfully.'
-              )
-              if (ok) setTransferAccountModal(emptyAccountModal)
-            }}
-          >
-            {isProcessing === 'TransferAccount' ? (
-              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Transferring…</>
-            ) : (
-              'Confirm Transfer'
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          <DialogFooter>
+            <Button
+              variant='outline'
+              onClick={() => setTransferAccountModal(emptyAccountModal)}
+              disabled={isProcessing !== null}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={
+                !isValidAddress(transferAccountModal.address) ||
+                !transferAccountModal.confirmed ||
+                isProcessing !== null ||
+                (!!connectedAddress &&
+                  transferAccountModal.address.toLowerCase() ===
+                    connectedAddress.toLowerCase())
+              }
+              onClick={async () => {
+                const to = transferAccountModal.address as `0x${string}`
+                const ok = await handleAction(
+                  'TransferAccount',
+                  () => transferAccount(to),
+                  'Account transferred successfully.'
+                )
+                if (ok) setTransferAccountModal(emptyAccountModal)
+              }}
+            >
+              {isProcessing === 'TransferAccount' ? (
+                <>
+                  <Loader2 className='h-4 w-4 mr-2 animate-spin' />{' '}
+                  Transferring…
+                </>
+              ) : (
+                'Confirm Transfer'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-    {/* Confirmation Modal */}
-    <Dialog
-      open={confirmModal.open}
-      onOpenChange={(open) => { if (!open && isProcessing !== null) return; if (!open) setConfirmModal((m) => ({ ...m, open: false })) }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{confirmModal.title}</DialogTitle>
-        </DialogHeader>
-        <div className='py-2'>
-          <p className='text-sm text-muted-foreground'>{confirmModal.description}</p>
-        </div>
-        <DialogFooter>
-          <Button
-            variant='outline'
-            onClick={() => setConfirmModal((m) => ({ ...m, open: false }))}
-            disabled={isProcessing !== null}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={isProcessing !== null}
-            onClick={async () => {
-              const { actionName, action, successMsg } = confirmModal
-              const ok = await handleAction(actionName, action, successMsg)
-              if (ok) setConfirmModal((m) => ({ ...m, open: false }))
-            }}
-          >
-            {isProcessing === confirmModal.actionName ? (
-              <><Loader2 className='h-4 w-4 mr-2 animate-spin' /> Processing…</>
-            ) : (
-              'Confirm'
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-
-  </>
+      {/* Confirmation Modal */}
+      <Dialog
+        open={confirmModal.open}
+        onOpenChange={(open) => {
+          if (!open && isProcessing !== null) return
+          if (!open) setConfirmModal((m) => ({ ...m, open: false }))
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{confirmModal.title}</DialogTitle>
+          </DialogHeader>
+          <div className='py-2'>
+            <p className='text-sm text-muted-foreground'>
+              {confirmModal.description}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              variant='outline'
+              onClick={() => setConfirmModal((m) => ({ ...m, open: false }))}
+              disabled={isProcessing !== null}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={isProcessing !== null}
+              onClick={async () => {
+                const { actionName, action, successMsg } = confirmModal
+                const ok = await handleAction(actionName, action, successMsg)
+                if (ok) setConfirmModal((m) => ({ ...m, open: false }))
+              }}
+            >
+              {isProcessing === confirmModal.actionName ? (
+                <>
+                  <Loader2 className='h-4 w-4 mr-2 animate-spin' /> Processing…
+                </>
+              ) : (
+                'Confirm'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useToast } from '@/src/hooks/use-toast'
 import {
   Toast,
@@ -10,11 +11,61 @@ import {
   ToastViewport
 } from '@/src/components/ui/toast'
 
+/**
+ * Floor on how long a toast stays up. Deposit results carry a couple of
+ * sentences — the referral commission outcome among them — and Radix's 5s
+ * default was closing them mid-read.
+ */
+const MIN_VISIBLE_MS = 5000
+
 export function Toaster() {
-  const { toasts } = useToast()
+  const { toasts, dismiss } = useToast()
+
+  // Identity of the currently-open set, so the effect restarts when a new toast
+  // replaces an old one (TOAST_LIMIT is 1, so that is the normal case).
+  const openIds = toasts
+    .filter((t) => t.open !== false)
+    .map((t) => t.id)
+    .join(',')
+
+  useEffect(() => {
+    if (!openIds) return
+
+    // Dismiss at max(shown + 5s, first click) — a click before the floor still
+    // waits it out, a click after it closes immediately, and with no click at
+    // all the toast stays put rather than vanishing unread.
+    const shownAt = Date.now()
+    let dismissTimer: number | undefined
+
+    const onPointerDown = () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      const remaining = MIN_VISIBLE_MS - (Date.now() - shownAt)
+      dismissTimer = window.setTimeout(
+        () => dismiss(),
+        remaining > 0 ? remaining : 0
+      )
+    }
+
+    // Attached on the next tick: the click that produced this toast (Confirm
+    // Deposit, say) is still propagating, and would otherwise dismiss it
+    // instantly.
+    const attachTimer = window.setTimeout(
+      () => document.addEventListener('pointerdown', onPointerDown, true),
+      0
+    )
+
+    return () => {
+      window.clearTimeout(attachTimer)
+      if (dismissTimer !== undefined) window.clearTimeout(dismissTimer)
+      document.removeEventListener('pointerdown', onPointerDown, true)
+    }
+  }, [openIds, dismiss])
 
   return (
-    <ToastProvider>
+    // Infinity is a documented Radix escape hatch (`duration || duration ===
+    // Infinity`) that disables its auto-close, handing dismissal to the effect
+    // above. The X button and swipe still work as before.
+    <ToastProvider duration={Infinity}>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
           <Toast key={id} {...props}>


### PR DESCRIPTION
Three UI fixes merged to `develop` (#49, #50, #51), verified together rather than only individually.

## Changes

**Toasts stay readable** (#49) — `src/components/ui/toaster.tsx`
Toasts were dismissing before the text could be read. They now stay for 5 seconds or until a click anywhere, whichever is longer. Uses Radix's documented `duration={Infinity}` escape hatch with our own timer, so the auto-dismiss can't race the read.

**Earnings Fee stat dropped** (#50) — `src/components/liquidity/LiquidityPerformance.tsx`
The fee is already stated in the Claim Earnings confirmation, at the moment it applies. Showing it permanently in Your Earnings gave a cost equal billing with the three figures that belong there (pending, claimed, lifetime). `earningsFeePct` still backs the claim confirmation.

**Deposit fee note left-aligned** (#51) — `src/components/liquidity/AddLiquidityCard.tsx`
"Taken on top of the deposit amount" was passed as `sub`, rendering inside the right-aligned `<dd>`, while the referral note used `note` (full-width, left-aligned). Two explanatory sentences in one dialog were justified to opposite edges. One-word fix — `DetailRow` already had the slot. "You deposit" keeps its `sub` (`~500.00 LUSD`), which qualifies the value above it.

## Reviewer note on the diff size

`LiquidityPerformance.tsx` shows **1032 changed lines for a 6-line change.** The file was also brought into compliance with the project's Prettier config (trailing commas removed, 80-col wrapping applied); it grew 770 → 1012 lines as a result.

Verified this is formatting-only: normalizing both the `main` and `develop` versions through Prettier and diffing leaves exactly one hunk — the 6-line `StatItem` removal. Under the project's own `.prettierrc`, the `main` version fails the check and the `develop` version passes. Reviewing with `-w` cuts it to 328 insertions; the semantic change is just those 6 lines.

## Verification

Run against merged `develop`, all three changes together:

- `npm run build` — pass
- `npm run pages:build` — pass (Cloudflare target)
- `tsc --noEmit` — pass (needs `--max-old-space-size=8192`; standalone tsc OOMs on the 545KB `generated.ts`, a known issue in this repo unrelated to these changes)
- 358 tests across 10 files — pass

Scope is limited to three presentational files. No hook, contract, ABI, or deposit-path logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)